### PR TITLE
Update documentation to outline how to specify a ruleset via configuration.

### DIFF
--- a/Rules/README.md
+++ b/Rules/README.md
@@ -17,5 +17,5 @@ RulesAPI.
 
 ## Rulesets
 
-- **SampleRuleset**: A [sample ruleset](Ruleset/SampleRuleset.cs) documenting
-  the anatomy of a RulesAPI ruleset.
+- **SampleRuleset**: A [sample ruleset](https://github.com/orendain/DemeoMods/blob/045aec568fdddb95b63a1ed34abcb64065e4ca99/Rules/RulesMod.cs#L27-L28)
+  for the purposes of documenting how to create a ruleset (and for testing during development).

--- a/RulesAPI/README.md
+++ b/RulesAPI/README.md
@@ -22,6 +22,29 @@ RulesAPI provides the framework for defining custom rules and rulesets, and the
 mechanisms by which they are patched into the game and activated/deactivated
 during gameplay.
 
+## Choosing a Ruleset
+
+If installation instructions were followed (i.e., MelonLoader was installed),
+the following file will appear in the Demeo game directory:
+`UserData/MelonPreferences.cfg`.
+
+After RulesAPI is installed and Demeo is run at least once, the following will
+appear somewhere in that configuration file:
+
+```toml
+[RulesAPI]
+ruleset = ""
+```
+
+Select the ruleset to use by typing its name within the quotes.  Alternatively,
+use empty quotes `""` to specify no ruleset should be used.
+
+For now, Demeo should not be running when the configuration file is modified.
+Else your changes may not be saved.
+
+A list of out-of-the-box ruleset names can be found in the
+[Rules readme](../Rules/README.md).
+
 ## Rules vs Mods
 
 A RulesAPI rule can be written with as few as a couple dozen lines of code,

--- a/RulesAPI/RulesAPI.cs
+++ b/RulesAPI/RulesAPI.cs
@@ -27,10 +27,8 @@ namespace RulesAPI
 
         internal static void ActivateSelectedRuleset()
         {
-            // TODO(orendain): Do not automatically load the first ruleset when a game is hosted. For dev only.
             if (SelectedRuleset == null)
             {
-                SelectRuleset(Registrar.Instance().Rulesets.ElementAt(0).Name);
                 return;
             }
 


### PR DESCRIPTION
Additionally, remove autoselecting a ruleset when loading game.
Resolves https://github.com/orendain/DemeoMods/issues/45.