### PR TITLE
Deactive ruleset at the end of a game or when the player disconnects.

### DIFF
--- a/RulesAPI/ModPatcher.cs
+++ b/RulesAPI/ModPatcher.cs
@@ -12,7 +12,6 @@
 
         internal static void Patch(Harmony harmony)
         {
-
             harmony.Patch(
                 original: AccessTools.Method(typeof(GameStartup), "InitializeGame"),
                 postfix: new HarmonyMethod(typeof(ModPatcher), nameof(GameStartup_InitializeGame_Postfix)));
@@ -24,8 +23,6 @@
             harmony.Patch(
                 original: AccessTools.Method(typeof(BoardGameActionStartNewGame), "StartNewGame"),
                 postfix: new HarmonyMethod(typeof(ModPatcher), nameof(BoardGameActionStartNewGame_StartNewGame_Postfix)));
-
-            // TODO(orendain): Hook into game ending events in order to deactivate activated rules.
 
             harmony.Patch(
                 original: AccessTools.Method(typeof(GameStateMachine), "EndGame"),

--- a/RulesAPI/ModPatcher.cs
+++ b/RulesAPI/ModPatcher.cs
@@ -30,6 +30,10 @@
             harmony.Patch(
                 original: AccessTools.Method(typeof(GameStateMachine), "EndGame"),
                 prefix: new HarmonyMethod(typeof(ModPatcher), nameof(GameStateMachine_EndGame_Prefix)));
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(SerializableEventQueue), "DisconnectLocalPlayer"),
+                prefix: new HarmonyMethod(typeof(ModPatcher), nameof(SerializableEventQueue_DisconnectLocalPlayer_Prefix)));
         }
 
         private static void GameStartup_InitializeGame_Postfix(GameStartup __instance)
@@ -67,6 +71,11 @@
         }
 
         private static void GameStateMachine_EndGame_Prefix()
+        {
+            RulesAPI.DeactivateSelectedRuleset();
+        }
+
+        private static void SerializableEventQueue_DisconnectLocalPlayer_Prefix()
         {
             RulesAPI.DeactivateSelectedRuleset();
         }

--- a/RulesAPI/ModPatcher.cs
+++ b/RulesAPI/ModPatcher.cs
@@ -26,6 +26,10 @@
                 postfix: new HarmonyMethod(typeof(ModPatcher), nameof(BoardGameActionStartNewGame_StartNewGame_Postfix)));
 
             // TODO(orendain): Hook into game ending events in order to deactivate activated rules.
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(GameStateMachine), "EndGame"),
+                prefix: new HarmonyMethod(typeof(ModPatcher), nameof(GameStateMachine_EndGame_Prefix)));
         }
 
         private static void GameStartup_InitializeGame_Postfix(GameStartup __instance)
@@ -60,6 +64,11 @@
         {
             RulesAPI.TriggerPostGameCreated();
             RulesAPI.ActivateSelectedRuleset();
+        }
+
+        private static void GameStateMachine_EndGame_Prefix()
+        {
+            RulesAPI.DeactivateSelectedRuleset();
         }
     }
 }

--- a/RulesAPI/RulesAPI.cs
+++ b/RulesAPI/RulesAPI.cs
@@ -10,6 +10,8 @@ namespace RulesAPI
 
         internal static Ruleset SelectedRuleset { get; private set; }
 
+        private static bool _isRulesetActive;
+
         public static void SelectRuleset(string ruleset)
         {
             try
@@ -27,16 +29,28 @@ namespace RulesAPI
 
         internal static void ActivateSelectedRuleset()
         {
+            if (_isRulesetActive)
+            {
+                Logger.Warning("Ruleset activation was triggered while ruleset was already activated. This should not happen. Please report this to RulesAPI developers.");
+                return;
+            }
+
             if (SelectedRuleset == null)
             {
                 return;
             }
 
+            _isRulesetActive = true;
             SelectedRuleset.Activate();
         }
 
         internal static void DeactivateSelectedRuleset()
         {
+            if (!_isRulesetActive)
+            {
+                return;
+            }
+
             SelectedRuleset.Deactivate();
         }
 
@@ -51,7 +65,7 @@ namespace RulesAPI
                 catch (Exception e)
                 {
                     // TODO(orendain): Rollback activation.
-                    RulesAPI.Logger.Warning($"Failed to successfully call PreGameCreated on rule [{rule.GetType()}]: {e}");
+                    Logger.Warning($"Failed to successfully call PreGameCreated on rule [{rule.GetType()}]: {e}");
                 }
             }
         }
@@ -67,7 +81,7 @@ namespace RulesAPI
                 catch (Exception e)
                 {
                     // TODO(orendain): Rollback activation.
-                    RulesAPI.Logger.Warning($"Failed to successfully call PostGameCreated on rule [{rule.GetType()}]: {e}");
+                    Logger.Warning($"Failed to successfully call PostGameCreated on rule [{rule.GetType()}]: {e}");
                 }
             }
         }


### PR DESCRIPTION
Resolves https://github.com/orendain/DemeoMods/issues/41.

- Hook into the indicators of the game ending, and trigger deactivation of the active ruleset.
- Hook into whenever the local player disconnects from a game, and trigger deactivation of the active ruleset.
- Only trigger rule activation when rules are active.

At first pass, it seems these two hooks cover all logical cases of a game ending.  Perhaps testing is required to be sure.