### PR TITLE
Flatten rule callback calls.

### DIFF
--- a/RulesAPI/Rule.cs
+++ b/RulesAPI/Rule.cs
@@ -7,34 +7,12 @@
         /// </summary>
         public abstract string Description { get; }
 
-        internal void Activate()
-        {
-            RulesAPI.Logger.Msg($"Activating rule type: {GetType()}");
-            OnActivate();
-        }
-
-        internal void Deactivate()
-        {
-            RulesAPI.Logger.Msg($"Deactivating rule type: {GetType()}");
-            OnDeactivate();
-        }
-
-        internal void PreGameCreated()
-        {
-            RulesAPI.Logger.Msg($"Calling OnPreGameCreated for rule type: {GetType()}");
-            OnPreGameCreated();
-        }
-
-        internal void PostGameCreated()
-        {
-            RulesAPI.Logger.Msg($"Calling OnPostGameCreated for rule type: {GetType()}");
-            OnPostGameCreated();
-        }
-
         /// <summary>
         /// Called when the rule is activated.
         /// </summary>
-        protected abstract void OnActivate();
+        protected internal virtual void OnActivate()
+        {
+        }
 
         /// <summary>
         /// Called when the rule is deactivated.
@@ -42,12 +20,16 @@
         /// <remarks>
         /// This method should undo any persistant changes made during <see cref="OnActivate"/>.
         /// </remarks>
-        protected abstract void OnDeactivate();
+        protected internal virtual void OnDeactivate()
+        {
+        }
 
         /// <summary>
         /// Called before a game is created.
         /// </summary>
-        protected abstract void OnPreGameCreated();
+        protected internal virtual void PreGameCreated()
+        {
+        }
 
         /// <summary>
         /// Called after a game is created.
@@ -55,6 +37,8 @@
         /// <remarks>
         /// Note that even though the game is created, the level/POIs/enemies may not yet fully be loaded/spawned.
         /// </remarks>
-        protected abstract void OnPostGameCreated();
+        protected internal virtual void PostGameCreated()
+        {
+        }
     }
 }

--- a/RulesAPI/RulesAPI.cs
+++ b/RulesAPI/RulesAPI.cs
@@ -41,7 +41,21 @@ namespace RulesAPI
             }
 
             _isRulesetActive = true;
-            SelectedRuleset.Activate();
+
+            Logger.Msg($"Activating ruleset: {SelectedRuleset.Name} (with {SelectedRuleset.Rules.Count} rules)");
+            foreach (var rule in SelectedRuleset.Rules)
+            {
+                try
+                {
+                    Logger.Msg($"Activating rule type: {rule.GetType()}");
+                    rule.OnActivate();
+                }
+                catch (Exception e)
+                {
+                    // TODO(orendain): Rollback activation.
+                    Logger.Warning($"Failed to activate rule [{rule.GetType()}]: {e}");
+                }
+            }
         }
 
         internal static void DeactivateSelectedRuleset()
@@ -51,7 +65,19 @@ namespace RulesAPI
                 return;
             }
 
-            SelectedRuleset.Deactivate();
+            Logger.Msg($"Deactivating ruleset: {SelectedRuleset.Name} (with {SelectedRuleset.Rules.Count} rules)");
+            foreach (var rule in SelectedRuleset.Rules)
+            {
+                try
+                {
+                    Logger.Msg($"Deactivating rule type: {rule.GetType()}");
+                    rule.OnDeactivate();
+                }
+                catch (Exception e)
+                {
+                    Logger.Warning($"Failed to deactivate rule [{rule.GetType()}]: {e}");
+                }
+            }
         }
 
         internal static void TriggerPreGameCreated()
@@ -60,12 +86,13 @@ namespace RulesAPI
             {
                 try
                 {
+                    Logger.Msg($"Calling OnPreGameCreated for rule type: {rule.GetType()}");
                     rule.PreGameCreated();
                 }
                 catch (Exception e)
                 {
                     // TODO(orendain): Rollback activation.
-                    Logger.Warning($"Failed to successfully call PreGameCreated on rule [{rule.GetType()}]: {e}");
+                    Logger.Warning($"Failed to successfully call OnPreGameCreated on rule [{rule.GetType()}]: {e}");
                 }
             }
         }
@@ -76,12 +103,13 @@ namespace RulesAPI
             {
                 try
                 {
+                    Logger.Msg($"Calling OnPostGameCreated for rule type: {rule.GetType()}");
                     rule.PostGameCreated();
                 }
                 catch (Exception e)
                 {
                     // TODO(orendain): Rollback activation.
-                    Logger.Warning($"Failed to successfully call PostGameCreated on rule [{rule.GetType()}]: {e}");
+                    Logger.Warning($"Failed to successfully call OnPostGameCreated on rule [{rule.GetType()}]: {e}");
                 }
             }
         }

--- a/RulesAPI/Ruleset.cs
+++ b/RulesAPI/Ruleset.cs
@@ -1,6 +1,5 @@
 ﻿namespace RulesAPI
 {
-    using System;
     using System.Collections.Generic;
 
     public class Ruleset
@@ -30,40 +29,6 @@
             Name = name;
             Description = description;
             Rules = rules;
-        }
-
-        internal void Activate()
-        {
-            RulesAPI.Logger.Msg($"Activating ruleset: {Name} (with {Rules.Count} rules)");
-
-            foreach (var rule in Rules)
-            {
-                try
-                {
-                    rule.Activate();
-                }
-                catch (Exception e)
-                {
-                    // TODO(orendain): Rollback activation.
-                    RulesAPI.Logger.Warning($"Failed to activate rule [{Name}]: {e}");
-                }
-            }
-        }
-
-        internal void Deactivate()
-        {
-            RulesAPI.Logger.Msg($"Deactivating ruleset: {Name} (with {Rules.Count} rules)");
-            foreach (var rule in Rules)
-            {
-                try
-                {
-                    rule.Deactivate();
-                }
-                catch (Exception e)
-                {
-                    RulesAPI.Logger.Warning($"Failed to deactivate rule [{Name}]: {e}");
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
Instead of RulesAPI class calling `Activate()` on a Ruleset, which in turn would call `Activate()` on the Rule baseclass, which in turn would call the implemented `OnActivate()`, RulesAPI calls the callbacks itself.