### PR TITLE
Update MelonLoader attributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ any will be cleaned up enough to see the light of OSS.
 > Note: Only PCVR versions of games are currently supported.
 > E.g., playing on a Quest2 works, but only when linked to a PC.
 
-1. Install [MelonLoader](https://github.com/LavaGang/MelonLoader#how-to-use-the-installer).
+1. Install [MelonLoader](https://github.com/LavaGang/MelonLoader#how-to-use-the-installer)
+   (must be version `0.5.3` or later).
 2. Download the the mods that you would like to use from
    the [releases page](https://github.com/orendain/DemeoMods/releases).
 3. Place the mod DLL files in the `/Mods` folder (created by MelonLoader) in

--- a/RoomFinder/Properties/AssemblyInfo.cs
+++ b/RoomFinder/Properties/AssemblyInfo.cs
@@ -39,3 +39,5 @@ using RoomFinder;
 // Melon Loader.
 [assembly: MelonInfo(typeof(RoomFinderMod), "RoomFinder", "1.3.0", "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
+[assembly: MelonID("566788")]
+[assembly: VerifyLoaderVersion("0.5.3", true)]

--- a/Rules/Properties/AssemblyInfo.cs
+++ b/Rules/Properties/AssemblyInfo.cs
@@ -39,4 +39,6 @@ using Rules;
 // Melon Loader.
 [assembly: MelonInfo(typeof(RulesMod), "Rules", "0.1.0", "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
+[assembly: MelonID("")]
+[assembly: VerifyLoaderVersion("0.5.3", true)]
 [assembly: MelonAdditionalDependencies("RulesAPI")]

--- a/RulesAPI/Properties/AssemblyInfo.cs
+++ b/RulesAPI/Properties/AssemblyInfo.cs
@@ -39,3 +39,5 @@ using RulesAPI;
 // Melon Loader.
 [assembly: MelonInfo(typeof(RulesAPIMod), "RulesAPI", "0.1.0", "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
+[assembly: MelonID("")]
+[assembly: VerifyLoaderVersion("0.5.3", true)]

--- a/SkipIntro/Properties/AssemblyInfo.cs
+++ b/SkipIntro/Properties/AssemblyInfo.cs
@@ -39,3 +39,5 @@ using SkipIntro;
 // Melon Loader.
 [assembly: MelonInfo(typeof(SkipIntroMod), "SkipIntro", "1.2.0", "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
+[assembly: MelonID("566782")]
+[assembly: VerifyLoaderVersion("0.5.3", true)]


### PR DESCRIPTION
- Require MelonLoader 0.5.3 or greater.
- Set CurseForge project ID as MelonID.
- Added ML attributes to Rules and RulesAPI mods. 