### PR TITLE
Add a rule for adjusting character's default MoveRange

### DIFF
--- a/Rules/README.md
+++ b/Rules/README.md
@@ -11,6 +11,7 @@ RulesAPI.
   of a RulesAPI rule.
 - **AbilityDamageAdjustedRule**: Ability damage is adjusted
 - **ActionPointsAdjustedRule**: Action points are adjusted
+- **MoveRangeAdjustedRule**: Movement Range(s) are adjusted
 - **RatNestsSpawnGoldRule**: Rat nests spawn gold
 - **StartHealthAdjustedRule**: Starting Health is adjusted
 - **ZapStartingInventoryAdjustedRule**: Zap starting inventory is adjusted

--- a/Rules/Rule/MoveRangeAdjustedRule.cs
+++ b/Rules/Rule/MoveRangeAdjustedRule.cs
@@ -1,0 +1,47 @@
+﻿namespace Rules.Rule
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Boardgame;
+    using HarmonyLib;
+    using UnityEngine;
+
+    public sealed class MoveRangeAdjustedRule : RulesAPI.Rule
+    {
+        public override string Description => "Start Health is adjusted";
+
+        private readonly Dictionary<string, int> _adjustments;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MoveRangehAdjustedRule"/> class.
+        /// </summary>
+        /// <param name="adjustments">Key-value pairs mapping the name of an entity to the number of action points
+        /// added to their base. Negative numbers are allowed.</param>
+        public MoveRangeAdjustedRule(Dictionary<string, int> adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        protected override void OnPostGameCreated()
+        {
+            var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            foreach (var item in _adjustments)
+            {
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var actionPoint = Traverse.Create(pieceConfig).Property<int>("MoveRange");
+                actionPoint.Value += item.Value;
+            }
+        }
+
+        protected override void OnDeactivate()
+        {
+            var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            foreach (var item in _adjustments)
+            {
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var actionPoint = Traverse.Create(pieceConfig).Property<int>("MoveRange");
+                actionPoint.Value -= item.Value;
+            }
+        }
+    }
+}

--- a/Rules/RulesMod.cs
+++ b/Rules/RulesMod.cs
@@ -19,6 +19,7 @@
             registrar.Register(typeof(Rule.SampleRule));
             registrar.Register(typeof(Rule.AbilityDamageAdjustedRule));
             registrar.Register(typeof(Rule.ActionPointsAdjustedRule));
+            registrar.Register(typeof(Rule.MoveRangeAdjustedRule));
             registrar.Register(typeof(Rule.RatNestsSpawnGoldRule));
             registrar.Register(typeof(Rule.StartHealthAdjustedRule));
             registrar.Register(typeof(Rule.ZapStartingInventoryAdjustedRule));


### PR DESCRIPTION
Another quick PR for adjusting the Movement Range of characters (same as the speed potion does).

Appears to all work OK.