### PR TITLE
A generic PiceConfig Adjuster Rule which can set any named integer field.

### DIFF
--- a/Rules/Rule/PieceConfigAdjustedRule.cs
+++ b/Rules/Rule/PieceConfigAdjustedRule.cs
@@ -1,0 +1,47 @@
+﻿namespace Rules.Rule
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Boardgame;
+    using HarmonyLib;
+    using UnityEngine;
+
+    public sealed class PieceConfigAdjustedRule : RulesAPI.Rule
+    {
+        public override string Description => "Start Health is adjusted";
+
+        private readonly List<List<string>> _adjustments;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PieceConfigAdjustedRule"/> class.
+        /// </summary>
+        /// <param name="adjustments">Key-value pairs mapping the name of an entity to the number of action points
+        /// added to their base. Negative numbers are allowed.</param>
+        public PieceConfigAdjustedRule(List<List<string>> adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        protected override void OnPostGameCreated()
+        {
+            var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            foreach (var item in _adjustments)
+            {
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item[0]}"));
+                var actionPoint = Traverse.Create(pieceConfig).Property<int>(item[1]);
+                actionPoint.Value += int.Parse(item[2]);
+            }
+        }
+
+        protected override void OnDeactivate()
+        {
+            var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            foreach (var item in _adjustments)
+            {
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item[0]}"));
+                var actionPoint = Traverse.Create(pieceConfig).Property<int>(item[1]);
+                actionPoint.Value -= int.Parse(item[2]);
+            }
+        }
+    }
+}

--- a/Rules/Rule/PieceConfigAdjustedRule.cs
+++ b/Rules/Rule/PieceConfigAdjustedRule.cs
@@ -15,7 +15,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="PieceConfigAdjustedRule"/> class.
         /// </summary>
-        /// <param name="adjustments">Key-value pairs mapping the name of an entity to the number of action points
+        /// <param name="adjustments">Lists of PieceNames, PropertyNames and Values
         /// added to their base. Negative numbers are allowed.</param>
         public PieceConfigAdjustedRule(List<List<string>> adjustments)
         {

--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -1,69 +1,71 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{8FC09405-8E06-4090-BB68-94882F0A52D8}</ProjectGuid>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Rules</RootNamespace>
-        <AssemblyName>Rules</AssemblyName>
-        <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-        <FileAlignment>512</FileAlignment>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="Properties\AssemblyInfo.cs" />
-        <Compile Include="RulesMod.cs" />
-        <Compile Include="Rule\AbilityDamageAdjustedRule.cs" />
-        <Compile Include="Rule\ActionPointsAdjustedRule.cs" />
-        <Compile Include="Rule\RatNestsSpawnGoldRule.cs" />
-        <Compile Include="Rule\SampleRule.cs" />
-        <Compile Include="Rule\ZapStartingInventoryAdjustedRule.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <Reference Include="Assembly-CSharp">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
-        </Reference>
-        <Reference Include="MelonLoader">
-            <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
-        </Reference>
-        <Reference Include="System" />
-        <Reference Include="UnityEngine.CoreModule">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-        </Reference>
-    </ItemGroup>
-    <ItemGroup>
-      <ProjectReference Include="..\RulesAPI\RulesAPI.csproj">
-        <Project>{b412463f-a4f7-46ce-ac4e-37448762b45b}</Project>
-        <Name>RulesAPI</Name>
-      </ProjectReference>
-    </ItemGroup>
-    <ItemGroup>
-      <Content Include="README.md" />
-    </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-    <Target Name="CopyToModsDir" AfterTargets="Build">
-        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(SteamDemeoDir)\Mods" />
-        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(OculusDemeoDir)\Mods" />
-    </Target>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8FC09405-8E06-4090-BB68-94882F0A52D8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Rules</RootNamespace>
+    <AssemblyName>Rules</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RulesMod.cs" />
+    <Compile Include="Rule\AbilityDamageAdjustedRule.cs" />
+    <Compile Include="Rule\ActionPointsAdjustedRule.cs" />
+    <Compile Include="Rule\RatNestsSpawnGoldRule.cs" />
+    <Compile Include="Rule\SampleRule.cs" />
+    <Compile Include="Rule\PieceConfigAdjustedRule.cs" />
+    <Compile Include="Rule\StartHealthAdjustedRule.cs" />
+    <Compile Include="Rule\ZapStartingInventoryAdjustedRule.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="MelonLoader">
+      <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RulesAPI\RulesAPI.csproj">
+      <Project>{b412463f-a4f7-46ce-ac4e-37448762b45b}</Project>
+      <Name>RulesAPI</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="README.md" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="CopyToModsDir" AfterTargets="Build">
+    <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(SteamDemeoDir)\Mods" />
+    <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(OculusDemeoDir)\Mods" />
+  </Target>
 </Project>

--- a/Rules/RulesMod.cs
+++ b/Rules/RulesMod.cs
@@ -19,6 +19,7 @@
             registrar.Register(typeof(Rule.SampleRule));
             registrar.Register(typeof(Rule.AbilityDamageAdjustedRule));
             registrar.Register(typeof(Rule.ActionPointsAdjustedRule));
+            registrar.Register(typeof(Rule.PieceConfigAdjustedRule));
             registrar.Register(typeof(Rule.RatNestsSpawnGoldRule));
             registrar.Register(typeof(Rule.StartHealthAdjustedRule));
             registrar.Register(typeof(Rule.ZapStartingInventoryAdjustedRule));


### PR DESCRIPTION
# What
We had nearly identical code for ActionPointsAdjusted, StartHealthAdjusted and MoveRangeAdjusted, The only difference between them was the name of the parameter which they were adjusting.

I thought I'd have a go at making a totally generic PiceConfigaAdjusted rule which take a lists of PieceName, ParameterName and the value to set it to.

Because I don't know C# and am learning as I go, I've used `List<List<string>>` as the datatype to pass aroud. This is not ideal as we want to set int values - I used `int.Parse()` within the rule to convert the numeric string value to int. There will certianly be room for improvement here.

Aside from the code quality issues, this appears to function correctly.
  
## Suggested Ruleset for Testing

```
var sorcererTestRules = new HashSet<RulesAPI.Rule> {
                                            new Rule.ZapStartingInventoryAdjustedRule(),
                                            new Rule.AbilityDamageAdjustedRule(new Dictionary<string, int>() { { "Zap", 8 } }),
                                            new Rule.PieceConfigAdjustedRule(new List<List<string>>() {new List<string>(){"HeroSorcerer","MoveRange", "10"}, 
                                                                                                       new List<string>(){"HeroSorcerer","ActionPoint","3"},
                                                                                                       new List<string>(){"HeroSorcerer","StartHealth", "20"}
                                                                                                        } ), 
                                          };
var sorcererTestRuleset = RulesAPI.Ruleset.NewInstance("SorcererTest", "Test set of rules which apply to the Sorcerer.", sorcererTestRules);
registrar.Register(sorcererTestRuleset);
```