### PR TITLE
Add rule for multiplying recycled card energy.

### DIFF
--- a/Rules/README.md
+++ b/Rules/README.md
@@ -12,6 +12,7 @@ RulesAPI.
 - **AbilityDamageAdjustedRule**: Ability damage is adjusted
 - **ActionPointsAdjustedRule**: Action points are adjusted
 - **CardEnergyFromAttackMultipliedRule**: Card energy from attack is multiplied
+- **CardEnergyFromRecyclingMultipliedRule**: Card energy from recycling is multiplied
 - **CardSellValueMultipliedRule**: Card sell values are multiplied
 - **EnemyRespawnDisabledRule**: Enemy respawns are disabled
 - **GoldPickedUpMultipliedRule**: Gold picked up is multiplied

--- a/Rules/Rule/CardEnergyFromAttackMultipliedRule.cs
+++ b/Rules/Rule/CardEnergyFromAttackMultipliedRule.cs
@@ -13,7 +13,7 @@
         public CardEnergyFromAttackMultipliedRule(float multiplier)
         {
             _multiplier = multiplier;
-            _originalValue = AIDirectorConfig.CardEnergy_EnergyToGetFromKill;
+            _originalValue = AIDirectorConfig.CardEnergy_EnergyToGetFromDealingDamage;
         }
 
         protected override void OnPostGameCreated()

--- a/Rules/Rule/CardEnergyFromRecyclingMultipliedRule.cs
+++ b/Rules/Rule/CardEnergyFromRecyclingMultipliedRule.cs
@@ -1,0 +1,49 @@
+﻿namespace Rules.Rule
+{
+    using Boardgame;
+    using Data.GameData;
+    using HarmonyLib;
+
+    public sealed class CardEnergyFromRecyclingMultipliedRule : RulesAPI.Rule
+    {
+        public override string Description => "Card energy from recycling is multiplied";
+
+        private static bool _isActivated;
+
+        private static float _multiplier;
+
+        public CardEnergyFromRecyclingMultipliedRule(float multiplier)
+        {
+            _multiplier = multiplier;
+        }
+
+        protected override void OnActivate() => _isActivated = true;
+
+        protected override void OnDeactivate() => _isActivated = false;
+
+        protected override void OnPostGameCreated()
+        {
+            Traverse.Create(typeof(AIDirectorConfig))
+                .Field<int>("CardEnergy_PowerRankRequiredToGiveEnergy").Value = 0;
+        }
+
+        private static void OnPatch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(CardPowder), "OnTrashedCard"),
+                prefix: new HarmonyMethod(
+                    typeof(CardEnergyFromRecyclingMultipliedRule),
+                    nameof(CardPowder_OnTrashedCard_Prefix)));
+        }
+
+        private static void CardPowder_OnTrashedCard_Prefix(ref float cardEnergy)
+        {
+            if (!_isActivated)
+            {
+                return;
+            }
+
+            cardEnergy *= _multiplier;
+        }
+    }
+}

--- a/Rules/Rule/CardEnergyFromRecyclingMultipliedRule.cs
+++ b/Rules/Rule/CardEnergyFromRecyclingMultipliedRule.cs
@@ -1,7 +1,6 @@
 ﻿namespace Rules.Rule
 {
     using Boardgame;
-    using Data.GameData;
     using HarmonyLib;
 
     public sealed class CardEnergyFromRecyclingMultipliedRule : RulesAPI.Rule
@@ -20,12 +19,6 @@
         protected override void OnActivate() => _isActivated = true;
 
         protected override void OnDeactivate() => _isActivated = false;
-
-        protected override void OnPostGameCreated()
-        {
-            Traverse.Create(typeof(AIDirectorConfig))
-                .Field<int>("CardEnergy_PowerRankRequiredToGiveEnergy").Value = 0;
-        }
 
         private static void OnPatch(Harmony harmony)
         {

--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -37,6 +37,7 @@
         <Compile Include="Rule\AbilityDamageAdjustedRule.cs" />
         <Compile Include="Rule\ActionPointsAdjustedRule.cs" />
         <Compile Include="Rule\CardEnergyFromAttackMultipliedRule.cs" />
+        <Compile Include="Rule\CardEnergyFromRecyclingMultipliedRule.cs" />
         <Compile Include="Rule\CardSellValueMultipliedRule.cs" />
         <Compile Include="Rule\EnemyRespawnDisabledRule.cs" />
         <Compile Include="Rule\GoldPickedUpMultipliedRule.cs" />

--- a/Rules/RulesMod.cs
+++ b/Rules/RulesMod.cs
@@ -20,6 +20,7 @@
             registrar.Register(typeof(Rule.AbilityDamageAdjustedRule));
             registrar.Register(typeof(Rule.ActionPointsAdjustedRule));
             registrar.Register(typeof(Rule.CardEnergyFromAttackMultipliedRule));
+            registrar.Register(typeof(Rule.CardEnergyFromRecyclingMultipliedRule));
             registrar.Register(typeof(Rule.CardSellValueMultipliedRule));
             registrar.Register(typeof(Rule.EnemyRespawnDisabledRule));
             registrar.Register(typeof(Rule.GoldPickedUpMultipliedRule));


### PR DESCRIPTION
Part of https://github.com/orendain/DemeoMods/issues/61.

In the process, also fixed `CardEnergyFromAttackMultipliedRule` using the wrong field.