### PR TITLE
Add rule disallowed enemies from opening doors.

### DIFF
--- a/Rules/README.md
+++ b/Rules/README.md
@@ -14,6 +14,7 @@ RulesAPI.
 - **CardEnergyFromAttackMultipliedRule**: Card energy from attack is multiplied
 - **CardEnergyFromRecyclingMultipliedRule**: Card energy from recycling is multiplied
 - **CardSellValueMultipliedRule**: Card sell values are multiplied
+- **EnemyDoorOpeningDisabledRule**: Enemy door opening ability disabled
 - **EnemyRespawnDisabledRule**: Enemy respawns are disabled
 - **GoldPickedUpMultipliedRule**: Gold picked up is multiplied
 - **PieceConfigAdjustedRule**: Piece configuration is adjusted

--- a/Rules/Rule/EnemyDoorOpeningDisabledRule.cs
+++ b/Rules/Rule/EnemyDoorOpeningDisabledRule.cs
@@ -5,7 +5,7 @@
 
     public sealed class EnemyDoorOpeningDisabledRule : RulesAPI.Rule
     {
-        public override string Description => "Enemy door opening ability disabled";
+        public override string Description => "Enemy door opening ability is disabled";
 
         private static bool _isActivated;
 

--- a/Rules/Rule/EnemyDoorOpeningDisabledRule.cs
+++ b/Rules/Rule/EnemyDoorOpeningDisabledRule.cs
@@ -1,0 +1,36 @@
+﻿namespace Rules.Rule
+{
+    using Boardgame;
+    using HarmonyLib;
+
+    public sealed class EnemyDoorOpeningDisabledRule : RulesAPI.Rule
+    {
+        public override string Description => "Enemy door opening ability disabled";
+
+        private static bool _isActivated;
+
+        protected override void OnActivate() => _isActivated = true;
+
+        protected override void OnDeactivate() => _isActivated = false;
+
+        private static void OnPatch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.PropertyGetter(typeof(PieceConfig), "CanOpenDoor"),
+                prefix: new HarmonyMethod(
+                    typeof(EnemyDoorOpeningDisabledRule),
+                    nameof(PieceConfig_CanOpenDoor_Prefix)));
+        }
+
+        private static bool PieceConfig_CanOpenDoor_Prefix(ref bool __result)
+        {
+            if (!_isActivated)
+            {
+                return true;
+            }
+
+            __result = false;
+            return false;
+        }
+    }
+}

--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -39,6 +39,7 @@
         <Compile Include="Rule\CardEnergyFromAttackMultipliedRule.cs" />
         <Compile Include="Rule\CardEnergyFromRecyclingMultipliedRule.cs" />
         <Compile Include="Rule\CardSellValueMultipliedRule.cs" />
+        <Compile Include="Rule\EnemyDoorOpeningDisabledRule.cs" />
         <Compile Include="Rule\EnemyRespawnDisabledRule.cs" />
         <Compile Include="Rule\GoldPickedUpMultipliedRule.cs" />
         <Compile Include="Rule\RatNestsSpawnGoldRule.cs" />

--- a/Rules/RulesMod.cs
+++ b/Rules/RulesMod.cs
@@ -22,6 +22,7 @@
             registrar.Register(typeof(Rule.CardEnergyFromAttackMultipliedRule));
             registrar.Register(typeof(Rule.CardEnergyFromRecyclingMultipliedRule));
             registrar.Register(typeof(Rule.CardSellValueMultipliedRule));
+            registrar.Register(typeof(Rule.EnemyDoorOpeningDisabledRule));
             registrar.Register(typeof(Rule.EnemyRespawnDisabledRule));
             registrar.Register(typeof(Rule.GoldPickedUpMultipliedRule));
             registrar.Register(typeof(Rule.PieceConfigAdjustedRule));


### PR DESCRIPTION
Full credit goes to @Pokachi, who discovered and wrote this logic for DifficultyMod.

Posted about borrowing the rule for RulesAPI here: https://github.com/Pokachi/DemeoMods/issues/8

> Note: This rule ignores any modifications to an enemy's `PieceConfig`'s `CanOpenDoor` field, by the nature of the patch applied, which seems reasonable/expected when using the rule.