### PR TITLE
AbilityActionCostRule - A rule for adjusting whether specific cards have a cost to cast or not.

### DIFF
--- a/Rules/README.md
+++ b/Rules/README.md
@@ -10,6 +10,7 @@ RulesAPI.
 - **SampleRule**: A [sample rule](Rule/SampleRule.cs) documenting the anatomy
   of a RulesAPI rule.
 - **AbilityDamageAdjustedRule**: Ability damage is adjusted
+- **AbilityActionCostAdjustedRule**: Ability Action Cost is adjusted
 - **ActionPointsAdjustedRule**: Action points are adjusted
 - **CardEnergyFromAttackMultipliedRule**: Card energy from attack is multiplied
 - **CardEnergyFromRecyclingMultipliedRule**: Card energy from recycling is multiplied

--- a/Rules/Rule/AbilityActionCostAdjustedRule.cs
+++ b/Rules/Rule/AbilityActionCostAdjustedRule.cs
@@ -1,0 +1,44 @@
+﻿namespace Rules.Rule
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Boardgame.BoardEntities.Abilities;
+    using UnityEngine;
+
+    public sealed class AbilityActionCostAdjustedRule : RulesAPI.Rule
+    {
+        public override string Description => "Ability AP costs are adjusted";
+
+        private readonly Dictionary<string, bool> _adjustments;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AbilityActionCostAdjustedRule"/> class.
+        /// </summary>
+        /// <param name="adjustments">Key-value pairs mapping the name of an entity to the number of action points
+        /// added to their base. Negative numbers are allowed.</param>
+        public AbilityActionCostAdjustedRule(Dictionary<string, bool> adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        protected override void OnPostGameCreated()
+        {
+            var abilities = Resources.FindObjectsOfTypeAll<Ability>();
+            foreach (var item in _adjustments)
+            {
+                var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
+                ability.costActionPoint= item.Value;
+            }
+        }
+
+        protected override void OnDeactivate()
+        {
+            var abilities = Resources.FindObjectsOfTypeAll<Ability>();
+            foreach (var item in _adjustments)
+            {
+                var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
+                ability.costActionPoint = ! item.Value;
+            }
+        }
+    }
+}

--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -1,79 +1,80 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{8FC09405-8E06-4090-BB68-94882F0A52D8}</ProjectGuid>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>Rules</RootNamespace>
-        <AssemblyName>Rules</AssemblyName>
-        <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
-        <FileAlignment>512</FileAlignment>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="Properties\AssemblyInfo.cs" />
-        <Compile Include="RulesMod.cs" />
-        <Compile Include="Rule\AbilityDamageAdjustedRule.cs" />
-        <Compile Include="Rule\ActionPointsAdjustedRule.cs" />
-        <Compile Include="Rule\CardEnergyFromAttackMultipliedRule.cs" />
-        <Compile Include="Rule\CardEnergyFromRecyclingMultipliedRule.cs" />
-        <Compile Include="Rule\CardSellValueMultipliedRule.cs" />
-        <Compile Include="Rule\EnemyAttackScaledRule.cs" />
-        <Compile Include="Rule\EnemyDoorOpeningDisabledRule.cs" />
-        <Compile Include="Rule\EnemyHealthScaledRule.cs" />
-        <Compile Include="Rule\EnemyRespawnDisabledRule.cs" />
-        <Compile Include="Rule\GoldPickedUpMultipliedRule.cs" />
-        <Compile Include="Rule\RatNestsSpawnGoldRule.cs" />
-        <Compile Include="Rule\SampleRule.cs" />
-        <Compile Include="Rule\PieceConfigAdjustedRule.cs" />
-        <Compile Include="Rule\StartHealthAdjustedRule.cs" />
-        <Compile Include="Rule\ZapStartingInventoryAdjustedRule.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <Reference Include="Assembly-CSharp">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
-        </Reference>
-        <Reference Include="MelonLoader">
-            <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
-        </Reference>
-        <Reference Include="System" />
-        <Reference Include="UnityEngine.CoreModule">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-        </Reference>
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\RulesAPI\RulesAPI.csproj">
-            <Project>{b412463f-a4f7-46ce-ac4e-37448762b45b}</Project>
-            <Name>RulesAPI</Name>
-        </ProjectReference>
-    </ItemGroup>
-    <ItemGroup>
-        <Content Include="README.md" />
-    </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-    <Target Name="CopyToModsDir" AfterTargets="Build">
-        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(SteamDemeoDir)\Mods" />
-        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(OculusDemeoDir)\Mods" />
-    </Target>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8FC09405-8E06-4090-BB68-94882F0A52D8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Rules</RootNamespace>
+    <AssemblyName>Rules</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RulesMod.cs" />
+    <Compile Include="Rule\AbilityActionCostAdjustedRule.cs" />
+    <Compile Include="Rule\AbilityDamageAdjustedRule.cs" />
+    <Compile Include="Rule\ActionPointsAdjustedRule.cs" />
+    <Compile Include="Rule\CardEnergyFromAttackMultipliedRule.cs" />
+    <Compile Include="Rule\CardEnergyFromRecyclingMultipliedRule.cs" />
+    <Compile Include="Rule\CardSellValueMultipliedRule.cs" />
+    <Compile Include="Rule\EnemyAttackScaledRule.cs" />
+    <Compile Include="Rule\EnemyDoorOpeningDisabledRule.cs" />
+    <Compile Include="Rule\EnemyHealthScaledRule.cs" />
+    <Compile Include="Rule\EnemyRespawnDisabledRule.cs" />
+    <Compile Include="Rule\GoldPickedUpMultipliedRule.cs" />
+    <Compile Include="Rule\RatNestsSpawnGoldRule.cs" />
+    <Compile Include="Rule\SampleRule.cs" />
+    <Compile Include="Rule\PieceConfigAdjustedRule.cs" />
+    <Compile Include="Rule\StartHealthAdjustedRule.cs" />
+    <Compile Include="Rule\ZapStartingInventoryAdjustedRule.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="MelonLoader">
+      <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\RulesAPI\RulesAPI.csproj">
+      <Project>{b412463f-a4f7-46ce-ac4e-37448762b45b}</Project>
+      <Name>RulesAPI</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="README.md" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="CopyToModsDir" AfterTargets="Build">
+    <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(SteamDemeoDir)\Mods" />
+    <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(OculusDemeoDir)\Mods" />
+  </Target>
 </Project>

--- a/Rules/RulesMod.cs
+++ b/Rules/RulesMod.cs
@@ -18,6 +18,7 @@
             var registrar = RulesAPI.Registrar.Instance();
             registrar.Register(typeof(Rule.SampleRule));
             registrar.Register(typeof(Rule.AbilityDamageAdjustedRule));
+            registrar.Register(typeof(Rule.AbilityActionCostAdjustedRule));
             registrar.Register(typeof(Rule.ActionPointsAdjustedRule));
             registrar.Register(typeof(Rule.CardEnergyFromAttackMultipliedRule));
             registrar.Register(typeof(Rule.CardEnergyFromRecyclingMultipliedRule));


### PR DESCRIPTION
# What

As a quality of life improvement, it can be nice to set some of the cards which usually have a cost to be free to cast instead. In particular I feel that the Wizard is a much better character when Zap is a 0AP cost. It might also work well for the Bard's Courage buff which is usually in high-demand and effectively means that the Bard only has one action per turn for themselves. 

This new rule takes a Dictionary<string, bool> containing the names of the cards, and the value you'd like them to be set to. I originally thought about just passing a list of strings, but realised there might be other use cases (such as if you'd boosted Hero Pieces to have more AP, but wanted to make Heal have a cost to cast etc).

I was a little bit lazy around the OnDeactivate method, and just set the values to the inverse of whatever was specified in the Dict. If someone were to pass in a Dict with the values unchanged from the defaults, then it would mean that when Deactivated they would change to non-default values. I'm not sure if this would cause any real-world issues, but will happily invest some more time solving it if you think it's worthwhile. 

## Suggested Ruleset for reviewing this PR.
```
var sorcererTestRules = new HashSet<RulesAPI.Rule> {
                                new Rule.ZapStartingInventoryAdjustedRule(),
                                new Rule.AbilityDamageAdjustedRule(new Dictionary<string, int>() { { "Zap", 8 } }),
                                new Rule.AbilityActionCostAdjustedRule(new Dictionary<string, bool>() { { "Zap", false } }),
                                };
var sorcererTestRuleset = RulesAPI.Ruleset.NewInstance("SorcererTest", "Test set of rules which apply to the Sorcerer.", sorcererTestRules);
registrar.Register(sorcererTestRuleset);
```

