### PR TITLE
A rule for adjusting the AOE range of abilities

### DIFF
--- a/Rules/README.md
+++ b/Rules/README.md
@@ -9,6 +9,7 @@ RulesAPI.
 
 - **SampleRule**: A [sample rule](Rule/SampleRule.cs) documenting the anatomy
   of a RulesAPI rule.
+- **AbilityAOEAdjustedRule**: Ability AOEs are adjsuted
 - **AbilityDamageAdjustedRule**: Ability damage is adjusted
 - **AbilityActionCostAdjustedRule**: Ability Action Cost is adjusted
 - **ActionPointsAdjustedRule**: Action points are adjusted

--- a/Rules/Rule/AbilityAOEAdjustedRule.cs
+++ b/Rules/Rule/AbilityAOEAdjustedRule.cs
@@ -1,0 +1,49 @@
+﻿namespace Rules.Rule
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Boardgame.BoardEntities.Abilities;
+    using UnityEngine;
+    using HarmonyLib;
+
+    public sealed class AbilityAOEAdjustedRule : RulesAPI.Rule
+    {
+        public override string Description => "Ability AOE Ranges are adjusted";
+
+        private readonly Dictionary<string, int> _adjustments;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AbilityAOEAdjustedRule"/> class.
+        /// </summary>
+        /// <param name="adjustments">Key-value pairs mapping the name of an ability and the AOE range
+        /// added to their base. Adding '1' to a 3x3 spell will make a 5x5. Negative values will reduce AOE.</param>
+        public AbilityAOEAdjustedRule(Dictionary<string, int> adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        protected override void OnPostGameCreated()
+        {
+            var abilities = Resources.FindObjectsOfTypeAll<Ability>();
+            foreach (var item in _adjustments)
+            {
+                var myAbility = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
+                var myAOE = Traverse.Create(myAbility).Field<AreaOfEffect>("areaOfEffect").Value;
+                Traverse.Create(myAOE).Field<int>("range").Value += item.Value; // Adjust the yellow AOE outline when casting.
+                myAbility.areaOfEffectRange += item.Value; // Adjust value displayed on the card.
+            }
+        }
+
+        protected override void OnDeactivate()
+        {
+            var abilities = Resources.FindObjectsOfTypeAll<Ability>();
+            foreach (var item in _adjustments)
+            {
+                var myAbility = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
+                var myAOE = Traverse.Create(myAbility).Field<AreaOfEffect>("areaofEffect").Value;
+                Traverse.Create(myAOE).Field<int>("range").Value -= item.Value; // Adjust the yellow AOE outline when casting.
+                myAbility.areaOfEffectRange -= item.Value; // Adjust value displayed on the card.
+            }
+        }
+    }
+}

--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -40,6 +40,7 @@
     <Compile Include="Rule\CardEnergyFromAttackMultipliedRule.cs" />
     <Compile Include="Rule\CardEnergyFromRecyclingMultipliedRule.cs" />
     <Compile Include="Rule\CardSellValueMultipliedRule.cs" />
+    <Compile Include="Rule\AbilityAOEAdjustedRule.cs" />
     <Compile Include="Rule\EnemyAttackScaledRule.cs" />
     <Compile Include="Rule\EnemyDoorOpeningDisabledRule.cs" />
     <Compile Include="Rule\EnemyHealthScaledRule.cs" />

--- a/Rules/RulesMod.cs
+++ b/Rules/RulesMod.cs
@@ -17,6 +17,7 @@
         {
             var registrar = RulesAPI.Registrar.Instance();
             registrar.Register(typeof(Rule.SampleRule));
+            registrar.Register(typeof(Rule.AbilityAOEAdjustedRule));
             registrar.Register(typeof(Rule.AbilityDamageAdjustedRule));
             registrar.Register(typeof(Rule.AbilityActionCostAdjustedRule));
             registrar.Register(typeof(Rule.ActionPointsAdjustedRule));


### PR DESCRIPTION
A rule for adjusting the AOE of spells. Works for spells which are already AOE-enabled. Not currently working for others.