### PR TITLE
Implement reading and writing rulesets, and their rule configurations, from configuration files.

### DIFF
--- a/Rules/Rule/AbilityActionCostAdjustedRule.cs
+++ b/Rules/Rule/AbilityActionCostAdjustedRule.cs
@@ -37,7 +37,7 @@
             foreach (var item in _adjustments)
             {
                 var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
-                ability.costActionPoint = ! item.Value;
+                ability.costActionPoint = !item.Value;
             }
         }
     }

--- a/Rules/Rule/GoldPickedUpScaledRule.cs
+++ b/Rules/Rule/GoldPickedUpScaledRule.cs
@@ -1,0 +1,59 @@
+﻿namespace Rules.Rule
+{
+    using Boardgame.Data;
+    using Boardgame.SerializableEvents;
+    using HarmonyLib;
+    using MelonLoader.TinyJSON;
+
+    public sealed class GoldPickedUpScaledRule : RulesAPI.Rule, RulesAPI.IConfigurableRule
+    {
+        public override string Description => "Gold picked up is scaled";
+
+        private static Config _config;
+        private static bool _isActivated;
+
+        public struct Config
+        {
+            public float Multiplier;
+        }
+
+        public GoldPickedUpScaledRule(Config config)
+        {
+            _config = config;
+        }
+
+        public static GoldPickedUpScaledRule FromConfigString(string configString)
+        {
+            JSON.MakeInto(JSON.Load(configString), out Config conf);
+            return new GoldPickedUpScaledRule(conf);
+        }
+
+        public string ToConfigString()
+        {
+            return JSON.Dump(_config, EncodeOptions.NoTypeHints | EncodeOptions.PrettyPrint);
+        }
+
+        protected override void OnActivate() => _isActivated = true;
+
+        protected override void OnDeactivate() => _isActivated = false;
+
+        private static void OnPatch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Constructor(
+                    typeof(SerializableEventPickup),
+                    new[] { typeof(int), typeof(IntPoint2D), typeof(bool) }),
+                postfix: new HarmonyMethod(typeof(GoldPickedUpScaledRule), nameof(SerializableEventPickup_Constructor_Postfix)));
+        }
+
+        private static void SerializableEventPickup_Constructor_Postfix(ref SerializableEventPickup __instance)
+        {
+            if (!_isActivated)
+            {
+                return;
+            }
+
+            __instance.goldAmount = (int)(__instance.goldAmount * _config.Multiplier);
+        }
+    }
+}

--- a/Rules/Rule/GoldPickedUpScaledRule.cs
+++ b/Rules/Rule/GoldPickedUpScaledRule.cs
@@ -17,6 +17,11 @@
             public float Multiplier;
         }
 
+        public GoldPickedUpScaledRule(float multiplier)
+            : this(new Config { Multiplier = multiplier })
+        {
+        }
+
         public GoldPickedUpScaledRule(Config config)
         {
             _config = config;

--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -45,6 +45,7 @@
     <Compile Include="Rule\EnemyHealthScaledRule.cs" />
     <Compile Include="Rule\EnemyRespawnDisabledRule.cs" />
     <Compile Include="Rule\GoldPickedUpMultipliedRule.cs" />
+    <Compile Include="Rule\GoldPickedUpScaledRule.cs" />
     <Compile Include="Rule\RatNestsSpawnGoldRule.cs" />
     <Compile Include="Rule\SampleRule.cs" />
     <Compile Include="Rule\PieceConfigAdjustedRule.cs" />

--- a/Rules/RulesMod.cs
+++ b/Rules/RulesMod.cs
@@ -28,6 +28,7 @@
             registrar.Register(typeof(Rule.EnemyHealthScaledRule));
             registrar.Register(typeof(Rule.EnemyRespawnDisabledRule));
             registrar.Register(typeof(Rule.GoldPickedUpMultipliedRule));
+            registrar.Register(typeof(Rule.GoldPickedUpScaledRule));
             registrar.Register(typeof(Rule.PieceConfigAdjustedRule));
             registrar.Register(typeof(Rule.RatNestsSpawnGoldRule));
             registrar.Register(typeof(Rule.StartHealthAdjustedRule));

--- a/RulesAPI/IConfigurableRule.cs
+++ b/RulesAPI/IConfigurableRule.cs
@@ -1,0 +1,26 @@
+﻿namespace RulesAPI
+{
+    public interface IConfigurableRule
+    {
+        /// <summary>
+        /// Gets a string that can represents the rule's configuration.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///     The implementation of this method must guarantee that when the returned string is passed into the
+        ///     corresponding <c>FromConfigString</c>, it will produce a rule identical to the one that
+        ///     <c>ToConfigString</c> was called on.
+        ///     </para>
+        ///     <para>
+        ///     For portability purposes, it is recommended that the configuration string keep to UTF-8 encoding.
+        ///     </para>
+        /// </remarks>
+        /// <returns>a string that represents the rule's configuration.</returns>
+        string ToConfigString();
+
+        /// <summary>
+        /// Returns an instantiated rule initialized with the specified configuration string.
+        /// </summary>
+        // public static <the-rule-type> FromConfigString(string configString);
+    }
+}

--- a/RulesAPI/RuleParser.cs
+++ b/RulesAPI/RuleParser.cs
@@ -1,0 +1,25 @@
+﻿namespace RulesAPI
+{
+    using System;
+    using HarmonyLib;
+
+    internal static class RuleParser
+    {
+        internal static Rule Parse(string ruleName, string configString)
+        {
+            var traverse = Traverse.CreateWithType(ruleName);
+            if (!traverse.TypeExists())
+            {
+                throw new ArgumentException($"Failed to recognize rule of type: {ruleName}");
+            }
+
+            traverse = traverse.Method("FromConfigString", paramTypes: new[] { typeof(string) }, arguments: new object[] { configString });
+            if (!traverse.MethodExists())
+            {
+                throw new ArgumentException($"Failed to find expected FromConfigString method for rule: {ruleName}");
+            }
+
+            return traverse.GetValue<Rule>();
+        }
+    }
+}

--- a/RulesAPI/RulesAPI.csproj
+++ b/RulesAPI/RulesAPI.csproj
@@ -47,9 +47,12 @@
         </Reference>
     </ItemGroup>
     <ItemGroup>
+        <Compile Include="RulesetIO.cs" />
+        <Compile Include="IConfigurableRule.cs" />
         <Compile Include="ModPatcher.cs" />
         <Compile Include="Properties\AssemblyInfo.cs" />
         <Compile Include="Rule.cs" />
+        <Compile Include="RuleParser.cs" />
         <Compile Include="RulesAPI.cs" />
         <Compile Include="Ruleset.cs" />
         <Compile Include="RulesAPIMod.cs" />

--- a/RulesAPI/RulesetIO.cs
+++ b/RulesAPI/RulesetIO.cs
@@ -1,0 +1,57 @@
+﻿namespace RulesAPI
+{
+    using System;
+    using System.Collections.Generic;
+    using MelonLoader;
+
+    internal static class RulesetIO
+    {
+        private const string CategoryName = "CustomRuleset";
+
+        public static void WriteRuleset(Ruleset ruleset)
+        {
+            var configCategory = MelonPreferences.CreateCategory(CategoryName);
+
+            foreach (var rule in ruleset.Rules)
+            {
+                if (!(rule is IConfigurableRule configurableRule))
+                {
+                    RulesAPI.Logger.Warning($"Rule {rule.GetType().Name} is not serializable. Skipping writing rule to config.");
+                    continue;
+                }
+
+                configCategory.CreateEntry(configurableRule.GetType().Name, configurableRule.ToConfigString());
+            }
+        }
+
+        internal static Ruleset ReadRuleset()
+        {
+            var configCategory = MelonPreferences.CreateCategory(CategoryName);
+
+            foreach (var ruleType in Registrar.Instance().RuleTypes)
+            {
+                configCategory.CreateEntry(ruleType.Name, default_value: string.Empty, dont_save_default: true);
+            }
+
+            var rules = new HashSet<Rule>();
+            foreach (var entry in configCategory.Entries)
+            {
+                if (string.IsNullOrEmpty(entry.GetValueAsString()))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    rules.Add(RuleParser.Parse(entry.Identifier, entry.GetValueAsString()));
+                }
+                catch (ArgumentException e)
+                {
+                    RulesAPI.Logger.Warning($"Failed to parse rule configuration with label [{entry.Identifier}]. Skipping parsing rule due to: {e.Message}");
+                }
+            }
+
+            return Ruleset.NewInstance("CustomRuleset", "A custom configured ruleset.", rules);
+        }
+    }
+}


### PR DESCRIPTION
## Additions

### IConfigurableRule

Introduced the `IConfigurableRule` interface.  See the interface for documentation.  In short: rules that implement this interface declare themselves to be readable/writable to configuration files (e.g., think serialization, but not quite as fully (not serializing class-wide, only rule configuration)).

Action items:
  - The inheritance hierarchy of `IConfigurableRule` and `Rule` needs work.  I'm pushing these changes as is, simply to minimize the number of files modified in this PR.  A subsequent PR will focus on modifying the hierarchy of the rules.
  - The name is not great.  Not going for perfect here - can modify the name `IConfigurableRule` whenever a better idea comes along.

### GoldPickedUpScaledRule

Introduced a new rule `GoldPickedUpScaledRule`, that is identical in function to `GoldPickedUpMultipliedRule`.  This duplicate is simply for demonstrating how using a `struct` as the input to a rule would play with in with generating JSON for the config.

Since this class implements `IConfigurableRule`:
- `ToConfigString()` returns a string representing the rule.  In this case, it was easy to generate JSON from the config struct.
- `FromConfigString()` takes some arbitrary string (the rule knows it to be JSON), and parses it into a config struct.

The ease of implementing these two functions is why I originally went with a `struct` as the config object.  However, as I refined the general rule/ruleset IO (with some more sleep under my belt), I landed on an abstraction that cared nothing about the parameter types of a rule 👍🏾.

So now, of course, this rule could have instead implemented the above methods as the following:
- `ToConfigString()`: `return myGoldMultiplierInt.toString()`
- `FromConfigString()`: `return new GoldPickedUpScaledRule(int.Parse(configString));`

So I left the new rule in really just for the demonstration.  TBH, I quite like the ease of using `struct` internally + copy/paste JSON parsing.  Each rule may decide for itself, though, and we can converge later.

An example of how one would instantiate the class to begin with:
```cs
new Rule.GoldPickedUpScaledRule(new Rule.GoldPickedUpScaledRule.Config { Multiplier = 1.5f });
// or just
new Rule.GoldPickedUpScaledRule(1.5f); // because of the overloaded constructor
```

### RulesetsIO

A utility class for writing rulesets to a configuration file, as well as reading them.

#### WriteRuleset

How to write a ruleset **_to_** a configuration file:
```cs
Ruleset myRuleset = ...;
RulesetIO.WriteRuleset(myRuleset);
```

The `WriteRuleset` is not currently integrated with the rest of RulesAPI  - I can't think of a case in our current flow where we would want to arbitrarily write some ruleset to config.  So instead, it is being introduced in this PR as a utility for now.  For developers to call `WriteRuleset()` manually for development purposes.

The following is an example of what is produced.  Currently, this is written to the default `MelonPreferences.cfg` file, for simplicity - but we could parameterize this.

```toml
[CustomRuleset]
GoldPickedUpScaledRule = '''
{
	"Multiplier": 1.5
}'''
```

Or, removing `EncodeOptions.PrettyPrint` from `ToConfigString()`:
```toml
[CustomRuleset]
GoldPickedUpScaledRule = '{"Multiplier":1.5}'
```

(each rule in the ruleset would be on its own line)

#### ReadRuleset

How to write a ruleset **_from_** a configuration file:
```cs
var myRuleset = RulesetIO.ReadRuleset();
```

It does indeed make sense to integrate this into the RulesAPI flow.  For example, if a user has the following in their config:
```toml
ruleset = "CustomRuleset"
```
Then RulesAPI knows to simply parse the ruleset automatically from config.  For simplicity, I've left this out for a separate PR.

---

### RuleParser

A simple internal utility class, `RuleParser` takes in a rule name (as written in config) and its configuration string, and instantiates a rule from it.