### PR TITLE
Introduce the IPatchable interface.

### DIFF
--- a/RulesAPI/IPatchable.cs
+++ b/RulesAPI/IPatchable.cs
@@ -1,0 +1,14 @@
+﻿namespace RulesAPI
+{
+    public interface IPatchable
+    {
+        /// <summary>
+        /// Patches the game with the given patcher.
+        /// </summary>
+        /// <remarks>
+        /// Rules must check the property <c>IsActivated</c> in the patched method to ensure it makes
+        /// modifications only when it is activated.
+        /// </remarks>
+        // private static void Patch(HarmonyLib.Harmony harmony);
+    }
+}

--- a/RulesAPI/Rule.cs
+++ b/RulesAPI/Rule.cs
@@ -8,6 +8,23 @@
         public abstract string Description { get; }
 
         /// <summary>
+        /// Gets a value indicating whether or not the rule is activated.
+        /// </summary>
+        public bool IsActivated { get; private set; }
+
+        internal void Activate()
+        {
+            IsActivated = true;
+            OnActivate();
+        }
+
+        internal void Deactivate()
+        {
+            IsActivated = false;
+            OnDeactivate();
+        }
+
+        /// <summary>
         /// Called when the rule is activated.
         /// </summary>
         /// <remarks>

--- a/RulesAPI/RulesAPI.csproj
+++ b/RulesAPI/RulesAPI.csproj
@@ -47,6 +47,7 @@
         </Reference>
     </ItemGroup>
     <ItemGroup>
+        <Compile Include="IPatchable.cs" />
         <Compile Include="RulesetIO.cs" />
         <Compile Include="IConfigWritable.cs" />
         <Compile Include="ModPatcher.cs" />


### PR DESCRIPTION
- Add `IsActivated` property to Rule.
  - Implemented rules may now know if they have been activated without having to keep track of it themselves.
- Introduce the `IPatchable` interface that may implemented by Rules.

> Note: Due to limitations in when, during runtime, patching is done, `Patch()` must be static.  Hence the interface with only documentation and a commented-out method signature.

A subsequent PR will tag all current rules that requiring patching with this interface.