### PR TITLE
Make even more rules config writeable

### DIFF
--- a/Rules/Rule/AbilityAOEAdjustedRule.cs
+++ b/Rules/Rule/AbilityAOEAdjustedRule.cs
@@ -4,9 +4,10 @@
     using System.Linq;
     using Boardgame.BoardEntities.Abilities;
     using HarmonyLib;
+    using MelonLoader.TinyJSON;
     using UnityEngine;
 
-    public sealed class AbilityAOEAdjustedRule : RulesAPI.Rule
+    public sealed class AbilityAOEAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable
     {
         public override string Description => "Ability AOE Ranges are adjusted";
 
@@ -17,6 +18,16 @@
         /// </summary>
         /// <param name="adjustments">Key-value pairs mapping the name of an ability and the AOE range
         /// added to their base. Adding '1' to a 3x3 spell will make a 5x5. Negative values will reduce AOE.</param>
+        public static ActionPointsAdjustedRule FromConfigString(string configString)
+        {
+            JSON.MakeInto(JSON.Load(configString), out Dictionary<string, int> conf);
+            return new ActionPointsAdjustedRule(conf);
+        }
+
+        public string ToConfigString()
+        {
+            return JSON.Dump(_adjustments, EncodeOptions.NoTypeHints);
+        }
         public AbilityAOEAdjustedRule(Dictionary<string, int> adjustments)
         {
             _adjustments = adjustments;

--- a/Rules/Rule/AbilityActionCostAdjustedRule.cs
+++ b/Rules/Rule/AbilityActionCostAdjustedRule.cs
@@ -3,9 +3,10 @@
     using System.Collections.Generic;
     using System.Linq;
     using Boardgame.BoardEntities.Abilities;
+    using MelonLoader.TinyJSON;
     using UnityEngine;
 
-    public sealed class AbilityActionCostAdjustedRule : RulesAPI.Rule
+    public sealed class AbilityActionCostAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable
     {
         public override string Description => "Ability AP costs are adjusted";
 
@@ -16,6 +17,17 @@
         /// </summary>
         /// <param name="adjustments">Key-value pairs mapping the name of an entity to the number of action points
         /// added to their base. Negative numbers are allowed.</param>
+
+        public static ActionPointsAdjustedRule FromConfigString(string configString)
+        {
+            JSON.MakeInto(JSON.Load(configString), out Dictionary<string, int> conf);
+            return new ActionPointsAdjustedRule(conf);
+        }
+
+        public string ToConfigString()
+        {
+            return JSON.Dump(_adjustments, EncodeOptions.NoTypeHints);
+        }
         public AbilityActionCostAdjustedRule(Dictionary<string, bool> adjustments)
         {
             _adjustments = adjustments;

--- a/Rules/Rule/AbilityDamageAdjustedRule.cs
+++ b/Rules/Rule/AbilityDamageAdjustedRule.cs
@@ -3,9 +3,10 @@
     using System.Collections.Generic;
     using System.Linq;
     using Boardgame.BoardEntities.Abilities;
+    using MelonLoader.TinyJSON;
     using UnityEngine;
 
-    public sealed class AbilityDamageAdjustedRule : RulesAPI.Rule
+    public sealed class AbilityDamageAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable
     {
         public override string Description => "Ability damage is adjusted";
 
@@ -16,6 +17,16 @@
         /// </summary>
         /// <param name="adjustments">Key-value pairs mapping the name of an entity to the number of action points
         /// added to their base. Negative numbers are allowed.</param>
+        public static ActionPointsAdjustedRule FromConfigString(string configString)
+        {
+            JSON.MakeInto(JSON.Load(configString), out Dictionary<string, int> conf);
+            return new ActionPointsAdjustedRule(conf);
+        }
+
+        public string ToConfigString()
+        {
+            return JSON.Dump(_adjustments, EncodeOptions.NoTypeHints);
+        }
         public AbilityDamageAdjustedRule(Dictionary<string, int> adjustments)
         {
             _adjustments = adjustments;

--- a/Rules/Rule/PieceConfigAdjustedRule.cs
+++ b/Rules/Rule/PieceConfigAdjustedRule.cs
@@ -4,9 +4,10 @@
     using System.Linq;
     using Boardgame;
     using HarmonyLib;
+    using MelonLoader.TinyJSON;
     using UnityEngine;
 
-    public sealed class PieceConfigAdjustedRule : RulesAPI.Rule
+    public sealed class PieceConfigAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable
     {
         public override string Description => "Piece configuration is adjusted";
 
@@ -17,6 +18,17 @@
         /// </summary>
         /// <param name="adjustments">Lists of PieceNames, PropertyNames and Values
         /// added to their base. Negative numbers are allowed.</param>
+        public static ActionPointsAdjustedRule FromConfigString(string configString)
+        {
+            JSON.MakeInto(JSON.Load(configString), out Dictionary<string, int> conf);
+            return new ActionPointsAdjustedRule(conf);
+        }
+
+        public string ToConfigString()
+        {
+            return JSON.Dump(_adjustments, EncodeOptions.NoTypeHints);
+        }
+
         public PieceConfigAdjustedRule(List<List<string>> adjustments)
         {
             _adjustments = adjustments;


### PR DESCRIPTION
Add config write functions to four more rules.

* Make AbilityActionCostAdjustedRule config writeable.
* Make AbilityAOEAdjustedRule config writeable.
* Make AbilityDamageAdjustedRule config writeable.
* Make PieceConfigAdjustedRule config writeable.


I've tested this with the following ruleset.

```
            var cards = new List<Rule.SorcererStartCardsModifiedRule.Card>()
                {
                    new Rule.SorcererStartCardsModifiedRule.Card() { Name = AbilityKey.Whirlwind, IsReplenishable = true },
                    new Rule.SorcererStartCardsModifiedRule.Card() { Name = AbilityKey.Zap, IsReplenishable = true },
                    new Rule.SorcererStartCardsModifiedRule.Card() { Name = AbilityKey.Fireball, IsReplenishable = false },
                    new Rule.SorcererStartCardsModifiedRule.Card() { Name = AbilityKey.Fireball, IsReplenishable = false },
                    new Rule.SorcererStartCardsModifiedRule.Card() { Name = AbilityKey.Fireball, IsReplenishable = false },
                    new Rule.SorcererStartCardsModifiedRule.Card() { Name = AbilityKey.Heal, IsReplenishable = false },
                };
            var TestingRules = new List<RulesAPI.Rule> { new Rule.SorcererStartCardsModifiedRule(cards),
                                                            new Rule.AbilityDamageAdjustedRule(new Dictionary<string, int>() { { "Zap", 1 } }), // High voltage zap 
                                                            new Rule.AbilityAOEAdjustedRule(new Dictionary<string, int>() { { "Fireball", 1 }, // 5x5 fireball
                                                                                                                            { "Zap", 1 }, // Just testing
                                                                                                                            { "StrengthenCourage", 1 }, // Everyone should hear the bard sing the courage song
                                                                                                                            { "Strength", 1 }, // Everyone nearby should share the strength potion
                                                                                                                            { "Speed",1 } // Everyone nearby should share the speed potion
                                                                                                                            }),
                                                            new Rule.PieceConfigAdjustedRule(new List<List<string>>() {new List<string>(){ "HeroSorcerer", "MoveRange", "1"}, // 1 more movement range
                                                                                                                       new List<string>(){ "HeroSorcerer", "StartHealth", "10"}, // 10 extra HP
                                                                                                                       new List<string>(){ "HeroGuardian", "MoveRange", "1"},
                                                                                                                       new List<string>(){ "HeroGuardian", "StartHealth", "10"},
                                                                                                                       new List<string>(){ "HeroHunter", "MoveRange", "1"},
                                                                                                                       new List<string>(){ "HeroHunter", "StartHealth", "10"},
                                                                                                                       new List<string>(){ "HeroBard", "MoveRange", "1"},
                                                                                                                       new List<string>(){ "HeroBard", "StartHealth", "10"},
                                                                                                                       new List<string>(){ "HeroRogue", "MoveRange", "1"},
                                                                                                                       new List<string>(){ "HeroRogue", "StartHealth", "10"},
                                                                                                                       new List<string>(){ "WolfCompanion", "StartHealth","20"}, // Wolf wastes this many HP wandering through gas
                                                                                                                       new List<string>(){ "SwordOfAvalon", "StartHealth","10"},
                                                                                                                       new List<string>(){ "BeaconOfSmite", "StartHealth","10"},
                                                                                                                       new List<string>(){ "BeaconOfSmite", "ActionPoint","1"}, // Behemoth gets to fire two rounds
                                                                                                                       new List<string>(){ "MonsterBait", "StartHealth","20"}, // Lure needs to last a little longer
                                                                                                                       } ),
                                                            new Rule.AbilityActionCostAdjustedRule(new Dictionary<string, bool>() { { "Zap", false }, // 0 casting cost for zap
                                                                                                                                    { "StrengthenCourage", false } // 0 casting cost for Courage
                                                                                                                                    }),
                                                            new Rule.CardEnergyFromAttackMultipliedRule(2),
                                                            new Rule.CardEnergyFromRecyclingMultipliedRule(2)
                                                            };
            var TestingRuleSet = RulesAPI.Ruleset.NewInstance("TestingRuleSet", "Test ruleset for rapid gameplay", TestingRules);
            registrar.Register(TestingRuleSet);
            RulesAPI.ConfigManager.WriteRuleset("TestingRuleSet", TestingRuleSet);
```

which produced the following output for me.

```
[TestingRuleSet]
SorcererStartCardsModifiedRule = '[{"Name":"Whirlwind","IsReplenishable":true},{"Name":"Zap","IsReplenishable":true},{"Name":"Fireball","IsReplenishable":false},{"Name":"Fireball","IsReplenishable":false},{"Name":"Fireball","IsReplenishable":false},{"Name":"Heal","IsReplenishable":false}]'
CardEnergyFromAttackMultipliedRule = "2"
CardEnergyFromRecyclingMultipliedRule = "2"
AbilityDamageAdjustedRule = '{"Zap":1}'
AbilityAOEAdjustedRule = '{"Fireball":1,"Zap":1,"StrengthenCourage":1,"Strength":1,"Speed":1}'
PieceConfigAdjustedRule = '[["HeroSorcerer","MoveRange","1"],["HeroSorcerer","StartHealth","10"],["HeroGuardian","MoveRange","1"],["HeroGuardian","StartHealth","10"],["HeroHunter","MoveRange","1"],["HeroHunter","StartHealth","10"],["HeroBard","MoveRange","1"],["HeroBard","StartHealth","10"],["HeroRogue","MoveRange","1"],["HeroRogue","StartHealth","10"],["WolfCompanion","StartHealth","20"],["SwordOfAvalon","StartHealth","10"],["BeaconOfSmite","StartHealth","10"],["BeaconOfSmite","ActionPoint","1"],["MonsterBait","StartHealth","20"]]'
AbilityActionCostAdjustedRule = '{"Zap":false,"StrengthenCourage":false}'
```
