### PR TITLE
Modify the IConfigWritable interface.

### DIFF
--- a/Rules/Rule/AbilityAOEAdjustedRule.cs
+++ b/Rules/Rule/AbilityAOEAdjustedRule.cs
@@ -4,44 +4,35 @@
     using System.Linq;
     using Boardgame.BoardEntities.Abilities;
     using HarmonyLib;
-    using MelonLoader.TinyJSON;
     using UnityEngine;
 
-    public sealed class AbilityAOEAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable
+    public sealed class AbilityAoeAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable<Dictionary<string, int>>
     {
         public override string Description => "Ability AOE Ranges are adjusted";
 
         private readonly Dictionary<string, int> _adjustments;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AbilityAOEAdjustedRule"/> class.
+        /// Initializes a new instance of the <see cref="AbilityAoeAdjustedRule"/> class.
         /// </summary>
         /// <param name="adjustments">Key-value pairs mapping the name of an ability and the AOE range
         /// added to their base. Adding '1' to a 3x3 spell will make a 5x5. Negative values will reduce AOE.</param>
-        public static ActionPointsAdjustedRule FromConfigString(string configString)
-        {
-            JSON.MakeInto(JSON.Load(configString), out Dictionary<string, int> conf);
-            return new ActionPointsAdjustedRule(conf);
-        }
-
-        public string ToConfigString()
-        {
-            return JSON.Dump(_adjustments, EncodeOptions.NoTypeHints);
-        }
-        public AbilityAOEAdjustedRule(Dictionary<string, int> adjustments)
+        public AbilityAoeAdjustedRule(Dictionary<string, int> adjustments)
         {
             _adjustments = adjustments;
         }
+
+        public Dictionary<string, int> GetConfigObject() => _adjustments;
 
         protected override void OnPostGameCreated()
         {
             var abilities = Resources.FindObjectsOfTypeAll<Ability>();
             foreach (var item in _adjustments)
             {
-                var myAbility = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
-                var myAOE = Traverse.Create(myAbility).Field<AreaOfEffect>("areaOfEffect").Value;
-                Traverse.Create(myAOE).Field<int>("range").Value += item.Value; // Adjust the yellow AOE outline when casting.
-                myAbility.areaOfEffectRange += item.Value; // Adjust value displayed on the card.
+                var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
+                var aoe = Traverse.Create(ability).Field<AreaOfEffect>("areaOfEffect").Value;
+                Traverse.Create(aoe).Field<int>("range").Value += item.Value; // Adjust the yellow AOE outline when casting.
+                ability.areaOfEffectRange += item.Value; // Adjust value displayed on the card.
             }
         }
 
@@ -50,10 +41,10 @@
             var abilities = Resources.FindObjectsOfTypeAll<Ability>();
             foreach (var item in _adjustments)
             {
-                var myAbility = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
-                var myAOE = Traverse.Create(myAbility).Field<AreaOfEffect>("areaofEffect").Value;
-                Traverse.Create(myAOE).Field<int>("range").Value -= item.Value; // Adjust the yellow AOE outline when casting.
-                myAbility.areaOfEffectRange -= item.Value; // Adjust value displayed on the card.
+                var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
+                var aoe = Traverse.Create(ability).Field<AreaOfEffect>("areaofEffect").Value;
+                Traverse.Create(aoe).Field<int>("range").Value -= item.Value; // Adjust the yellow AOE outline when casting.
+                ability.areaOfEffectRange -= item.Value; // Adjust value displayed on the card.
             }
         }
     }

--- a/Rules/Rule/AbilityActionCostAdjustedRule.cs
+++ b/Rules/Rule/AbilityActionCostAdjustedRule.cs
@@ -3,10 +3,9 @@
     using System.Collections.Generic;
     using System.Linq;
     using Boardgame.BoardEntities.Abilities;
-    using MelonLoader.TinyJSON;
     using UnityEngine;
 
-    public sealed class AbilityActionCostAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable
+    public sealed class AbilityActionCostAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable<Dictionary<string, bool>>
     {
         public override string Description => "Ability AP costs are adjusted";
 
@@ -17,21 +16,12 @@
         /// </summary>
         /// <param name="adjustments">Key-value pairs mapping the name of an entity to the number of action points
         /// added to their base. Negative numbers are allowed.</param>
-
-        public static ActionPointsAdjustedRule FromConfigString(string configString)
-        {
-            JSON.MakeInto(JSON.Load(configString), out Dictionary<string, int> conf);
-            return new ActionPointsAdjustedRule(conf);
-        }
-
-        public string ToConfigString()
-        {
-            return JSON.Dump(_adjustments, EncodeOptions.NoTypeHints);
-        }
         public AbilityActionCostAdjustedRule(Dictionary<string, bool> adjustments)
         {
             _adjustments = adjustments;
         }
+
+        public Dictionary<string, bool> GetConfigObject() => _adjustments;
 
         protected override void OnPostGameCreated()
         {

--- a/Rules/Rule/AbilityDamageAdjustedRule.cs
+++ b/Rules/Rule/AbilityDamageAdjustedRule.cs
@@ -3,10 +3,9 @@
     using System.Collections.Generic;
     using System.Linq;
     using Boardgame.BoardEntities.Abilities;
-    using MelonLoader.TinyJSON;
     using UnityEngine;
 
-    public sealed class AbilityDamageAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable
+    public sealed class AbilityDamageAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable<Dictionary<string, int>>
     {
         public override string Description => "Ability damage is adjusted";
 
@@ -17,20 +16,12 @@
         /// </summary>
         /// <param name="adjustments">Key-value pairs mapping the name of an entity to the number of action points
         /// added to their base. Negative numbers are allowed.</param>
-        public static ActionPointsAdjustedRule FromConfigString(string configString)
-        {
-            JSON.MakeInto(JSON.Load(configString), out Dictionary<string, int> conf);
-            return new ActionPointsAdjustedRule(conf);
-        }
-
-        public string ToConfigString()
-        {
-            return JSON.Dump(_adjustments, EncodeOptions.NoTypeHints);
-        }
         public AbilityDamageAdjustedRule(Dictionary<string, int> adjustments)
         {
             _adjustments = adjustments;
         }
+
+        public Dictionary<string, int> GetConfigObject() => _adjustments;
 
         protected override void OnPostGameCreated()
         {

--- a/Rules/Rule/ActionPointsAdjustedRule.cs
+++ b/Rules/Rule/ActionPointsAdjustedRule.cs
@@ -4,10 +4,9 @@
     using System.Linq;
     using Boardgame;
     using HarmonyLib;
-    using MelonLoader.TinyJSON;
     using UnityEngine;
 
-    public sealed class ActionPointsAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable
+    public sealed class ActionPointsAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable<Dictionary<string, int>>
     {
         public override string Description => "Action points are adjusted";
 
@@ -23,16 +22,7 @@
             _adjustments = adjustments;
         }
 
-        public static ActionPointsAdjustedRule FromConfigString(string configString)
-        {
-            JSON.MakeInto(JSON.Load(configString), out Dictionary<string, int> conf);
-            return new ActionPointsAdjustedRule(conf);
-        }
-
-        public string ToConfigString()
-        {
-            return JSON.Dump(_adjustments, EncodeOptions.NoTypeHints);
-        }
+        public Dictionary<string, int> GetConfigObject() => _adjustments;
 
         protected override void OnPostGameCreated()
         {
@@ -40,8 +30,8 @@
             foreach (var item in _adjustments)
             {
                 var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
-                var actionPoint = Traverse.Create(pieceConfig).Property<int>("ActionPoint");
-                actionPoint.Value += item.Value;
+                var property = Traverse.Create(pieceConfig).Property<int>("ActionPoint");
+                property.Value += item.Value;
             }
         }
 
@@ -51,8 +41,8 @@
             foreach (var item in _adjustments)
             {
                 var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
-                var actionPoint = Traverse.Create(pieceConfig).Property<int>("ActionPoint");
-                actionPoint.Value -= item.Value;
+                var property = Traverse.Create(pieceConfig).Property<int>("ActionPoint");
+                property.Value -= item.Value;
             }
         }
     }

--- a/Rules/Rule/CardEnergyFromAttackMultipliedRule.cs
+++ b/Rules/Rule/CardEnergyFromAttackMultipliedRule.cs
@@ -2,34 +2,24 @@
 {
     using Data.GameData;
     using HarmonyLib;
-    using MelonLoader.TinyJSON;
 
-    public sealed class CardEnergyFromAttackMultipliedRule : RulesAPI.Rule, RulesAPI.IConfigWritable
+    public sealed class CardEnergyFromAttackMultipliedRule : RulesAPI.Rule, RulesAPI.IConfigWritable<float>
     {
-        public override string Description => "Card energy from attack is multiplied";
+        public override string Description => "CardConfig energy from attack is multiplied";
 
         private readonly float _multiplier;
-        private readonly float _originalValue;
+        private float _originalValue;
 
         public CardEnergyFromAttackMultipliedRule(float multiplier)
         {
             _multiplier = multiplier;
-            _originalValue = AIDirectorConfig.CardEnergy_EnergyToGetFromDealingDamage;
         }
 
-        public static CardEnergyFromAttackMultipliedRule FromConfigString(string configString)
-        {
-            JSON.MakeInto(JSON.Load(configString), out float conf);
-            return new CardEnergyFromAttackMultipliedRule(conf);
-        }
-
-        public string ToConfigString()
-        {
-            return JSON.Dump(_multiplier, EncodeOptions.NoTypeHints);
-        }
+        public float GetConfigObject() => _multiplier;
 
         protected override void OnPostGameCreated()
         {
+            _originalValue = AIDirectorConfig.CardEnergy_EnergyToGetFromDealingDamage;
             Traverse.Create(typeof(AIDirectorConfig))
                 .Field<float>("CardEnergy_EnergyToGetFromDealingDamage").Value = _originalValue * _multiplier;
         }
@@ -37,7 +27,7 @@
         protected override void OnDeactivate()
         {
             Traverse.Create(typeof(AIDirectorConfig))
-                    .Field<float>("CardEnergy_EnergyToGetFromDealingDamage").Value = _originalValue;
+                .Field<float>("CardEnergy_EnergyToGetFromDealingDamage").Value = _originalValue;
         }
     }
 }

--- a/Rules/Rule/CardEnergyFromRecyclingMultipliedRule.cs
+++ b/Rules/Rule/CardEnergyFromRecyclingMultipliedRule.cs
@@ -2,31 +2,20 @@
 {
     using Boardgame;
     using HarmonyLib;
-    using MelonLoader.TinyJSON;
 
-    public sealed class CardEnergyFromRecyclingMultipliedRule : RulesAPI.Rule, RulesAPI.IConfigWritable, RulesAPI.IPatchable
+    public sealed class CardEnergyFromRecyclingMultipliedRule : RulesAPI.Rule, RulesAPI.IConfigWritable<float>, RulesAPI.IPatchable
     {
-        public override string Description => "Card energy from recycling is multiplied";
-
-        private static bool _isActivated;
+        public override string Description => "CardConfig energy from recycling is multiplied";
 
         private static float _multiplier;
+        private static bool _isActivated;
 
         public CardEnergyFromRecyclingMultipliedRule(float multiplier)
         {
             _multiplier = multiplier;
         }
 
-        public static CardEnergyFromRecyclingMultipliedRule FromConfigString(string configString)
-        {
-            JSON.MakeInto(JSON.Load(configString), out float conf);
-            return new CardEnergyFromRecyclingMultipliedRule(conf);
-        }
-
-        public string ToConfigString()
-        {
-            return JSON.Dump(_multiplier, EncodeOptions.NoTypeHints);
-        }
+        public float GetConfigObject() => _multiplier;
 
         protected override void OnActivate() => _isActivated = true;
 

--- a/Rules/Rule/CardSellValueMultipliedRule.cs
+++ b/Rules/Rule/CardSellValueMultipliedRule.cs
@@ -10,7 +10,6 @@
         private static float _multiplier;
         private static bool _isActivated;
 
-
         public CardSellValueMultipliedRule(float multiplier)
         {
             _multiplier = multiplier;

--- a/Rules/Rule/CardSellValueMultipliedRule.cs
+++ b/Rules/Rule/CardSellValueMultipliedRule.cs
@@ -2,30 +2,21 @@
 {
     using System.Reflection;
     using HarmonyLib;
-    using MelonLoader.TinyJSON;
 
-    public sealed class CardSellValueMultipliedRule : RulesAPI.Rule, RulesAPI.IConfigWritable, RulesAPI.IPatchable
+    public sealed class CardSellValueMultipliedRule : RulesAPI.Rule, RulesAPI.IConfigWritable<float>, RulesAPI.IPatchable
     {
-        public override string Description => "Card sell values are multiplied";
+        public override string Description => "CardConfig sell values are multiplied";
 
         private static float _multiplier;
         private static bool _isActivated;
+
 
         public CardSellValueMultipliedRule(float multiplier)
         {
             _multiplier = multiplier;
         }
 
-        public static CardSellValueMultipliedRule FromConfigString(string configString)
-        {
-            JSON.MakeInto(JSON.Load(configString), out float conf);
-            return new CardSellValueMultipliedRule(conf);
-        }
-
-        public string ToConfigString()
-        {
-            return JSON.Dump(_multiplier, EncodeOptions.NoTypeHints);
-        }
+        public float GetConfigObject() => _multiplier;
 
         protected override void OnActivate() => _isActivated = true;
 

--- a/Rules/Rule/EnemyAttackScaledRule.cs
+++ b/Rules/Rule/EnemyAttackScaledRule.cs
@@ -3,9 +3,8 @@
     using Boardgame;
     using DataKeys;
     using HarmonyLib;
-    using MelonLoader.TinyJSON;
 
-    public sealed class EnemyAttackScaledRule : RulesAPI.Rule, RulesAPI.IConfigWritable, RulesAPI.IPatchable
+    public sealed class EnemyAttackScaledRule : RulesAPI.Rule, RulesAPI.IConfigWritable<float>, RulesAPI.IPatchable
     {
         public override string Description => "Enemy attack damage is scaled";
 
@@ -17,16 +16,7 @@
             _multiplier = multiplier;
         }
 
-        public static EnemyAttackScaledRule FromConfigString(string configString)
-        {
-            JSON.MakeInto(JSON.Load(configString), out float conf);
-            return new EnemyAttackScaledRule(conf);
-        }
-
-        public string ToConfigString()
-        {
-            return JSON.Dump(_multiplier, EncodeOptions.NoTypeHints);
-        }
+        public float GetConfigObject() => _multiplier;
 
         protected override void OnActivate() => _isActivated = true;
 

--- a/Rules/Rule/EnemyDoorOpeningDisabledRule.cs
+++ b/Rules/Rule/EnemyDoorOpeningDisabledRule.cs
@@ -2,23 +2,18 @@
 {
     using Boardgame;
     using HarmonyLib;
-    using MelonLoader.TinyJSON;
 
-    public sealed class EnemyDoorOpeningDisabledRule : RulesAPI.Rule, RulesAPI.IConfigWritable, RulesAPI.IPatchable
+    public sealed class EnemyDoorOpeningDisabledRule : RulesAPI.Rule, RulesAPI.IConfigWritable<bool>, RulesAPI.IPatchable
     {
         public override string Description => "Enemy door opening ability is disabled";
 
         private static bool _isActivated;
 
-        public static EnemyDoorOpeningDisabledRule FromConfigString(string configString)
+        public EnemyDoorOpeningDisabledRule(bool value)
         {
-            return new EnemyDoorOpeningDisabledRule();
         }
 
-        public string ToConfigString()
-        {
-            return JSON.Dump(string.Empty, EncodeOptions.NoTypeHints);
-        }
+        public bool GetConfigObject() => true;
 
         protected override void OnActivate() => _isActivated = true;
 

--- a/Rules/Rule/EnemyHealthScaledRule.cs
+++ b/Rules/Rule/EnemyHealthScaledRule.cs
@@ -3,9 +3,8 @@
     using Boardgame;
     using DataKeys;
     using HarmonyLib;
-    using MelonLoader.TinyJSON;
 
-    public sealed class EnemyHealthScaledRule : RulesAPI.Rule, RulesAPI.IConfigWritable, RulesAPI.IPatchable
+    public sealed class EnemyHealthScaledRule : RulesAPI.Rule, RulesAPI.IConfigWritable<float>, RulesAPI.IPatchable
     {
         public override string Description => "Enemy health is scaled";
 
@@ -17,16 +16,7 @@
             _multiplier = multiplier;
         }
 
-        public static EnemyHealthScaledRule FromConfigString(string configString)
-        {
-            JSON.MakeInto(JSON.Load(configString), out float conf);
-            return new EnemyHealthScaledRule(conf);
-        }
-
-        public string ToConfigString()
-        {
-            return JSON.Dump(_multiplier, EncodeOptions.NoTypeHints);
-        }
+        public float GetConfigObject() => _multiplier;
 
         protected override void OnActivate() => _isActivated = true;
 

--- a/Rules/Rule/EnemyRespawnDisabledRule.cs
+++ b/Rules/Rule/EnemyRespawnDisabledRule.cs
@@ -2,23 +2,18 @@
 {
     using Boardgame.AIDirector;
     using HarmonyLib;
-    using MelonLoader.TinyJSON;
 
-    public sealed class EnemyRespawnDisabledRule : RulesAPI.Rule, RulesAPI.IConfigWritable, RulesAPI.IPatchable
+    public sealed class EnemyRespawnDisabledRule : RulesAPI.Rule, RulesAPI.IConfigWritable<bool>, RulesAPI.IPatchable
     {
         public override string Description => "Enemy respawns are disabled";
 
         private static bool _isActivated;
 
-        public static EnemyRespawnDisabledRule FromConfigString(string configString)
+        public EnemyRespawnDisabledRule(bool value)
         {
-            return new EnemyRespawnDisabledRule();
         }
 
-        public string ToConfigString()
-        {
-            return JSON.Dump(string.Empty, EncodeOptions.NoTypeHints);
-        }
+        public bool GetConfigObject() => true;
 
         protected override void OnActivate() => _isActivated = true;
 

--- a/Rules/Rule/GoldPickedUpScaledRule.cs
+++ b/Rules/Rule/GoldPickedUpScaledRule.cs
@@ -3,40 +3,20 @@
     using Boardgame.Data;
     using Boardgame.SerializableEvents;
     using HarmonyLib;
-    using MelonLoader.TinyJSON;
 
-    public sealed class GoldPickedUpScaledRule : RulesAPI.Rule, RulesAPI.IConfigWritable, RulesAPI.IPatchable
+    public sealed class GoldPickedUpScaledRule : RulesAPI.Rule, RulesAPI.IConfigWritable<float>, RulesAPI.IPatchable
     {
         public override string Description => "Gold picked up is scaled";
 
-        private static Config _config;
+        private static float _multiplier;
         private static bool _isActivated;
 
-        private struct Config
-        {
-            public float Multiplier;
-        }
-
         public GoldPickedUpScaledRule(float multiplier)
-            : this(new Config { Multiplier = multiplier })
         {
+            _multiplier = multiplier;
         }
 
-        private GoldPickedUpScaledRule(Config config)
-        {
-            _config = config;
-        }
-
-        public static GoldPickedUpScaledRule FromConfigString(string configString)
-        {
-            JSON.MakeInto(JSON.Load(configString), out Config conf);
-            return new GoldPickedUpScaledRule(conf);
-        }
-
-        public string ToConfigString()
-        {
-            return JSON.Dump(_config, EncodeOptions.NoTypeHints);
-        }
+        public float GetConfigObject() => _multiplier;
 
         protected override void OnActivate() => _isActivated = true;
 
@@ -58,7 +38,7 @@
                 return;
             }
 
-            __instance.goldAmount = (int)(__instance.goldAmount * _config.Multiplier);
+            __instance.goldAmount = (int)(__instance.goldAmount * _multiplier);
         }
     }
 }

--- a/Rules/Rule/PieceConfigAdjustedRule.cs
+++ b/Rules/Rule/PieceConfigAdjustedRule.cs
@@ -4,10 +4,9 @@
     using System.Linq;
     using Boardgame;
     using HarmonyLib;
-    using MelonLoader.TinyJSON;
     using UnityEngine;
 
-    public sealed class PieceConfigAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable
+    public sealed class PieceConfigAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable<List<List<string>>>
     {
         public override string Description => "Piece configuration is adjusted";
 
@@ -18,21 +17,12 @@
         /// </summary>
         /// <param name="adjustments">Lists of PieceNames, PropertyNames and Values
         /// added to their base. Negative numbers are allowed.</param>
-        public static ActionPointsAdjustedRule FromConfigString(string configString)
-        {
-            JSON.MakeInto(JSON.Load(configString), out Dictionary<string, int> conf);
-            return new ActionPointsAdjustedRule(conf);
-        }
-
-        public string ToConfigString()
-        {
-            return JSON.Dump(_adjustments, EncodeOptions.NoTypeHints);
-        }
-
         public PieceConfigAdjustedRule(List<List<string>> adjustments)
         {
             _adjustments = adjustments;
         }
+
+        public List<List<string>> GetConfigObject() => _adjustments;
 
         protected override void OnPostGameCreated()
         {

--- a/Rules/Rule/RatNestsSpawnGoldRule.cs
+++ b/Rules/Rule/RatNestsSpawnGoldRule.cs
@@ -3,31 +3,21 @@
     using System.Linq;
     using Boardgame.BoardEntities.Abilities;
     using DataKeys;
-    using MelonLoader.TinyJSON;
     using UnityEngine;
 
-    public sealed class RatNestsSpawnGoldRule : RulesAPI.Rule, RulesAPI.IConfigWritable
+    public sealed class RatNestsSpawnGoldRule : RulesAPI.Rule, RulesAPI.IConfigWritable<int>
     {
         public override string Description => "Rat nests spawn gold";
 
-        private readonly int _maxPileCount;
+        private readonly int _pileCount;
         private int _originalSpawnAmount;
 
-        public RatNestsSpawnGoldRule(int maxPileCount)
+        public RatNestsSpawnGoldRule(int pileCount)
         {
-            _maxPileCount = maxPileCount;
+            _pileCount = pileCount;
         }
 
-        public static RatNestsSpawnGoldRule FromConfigString(string configString)
-        {
-            JSON.MakeInto(JSON.Load(configString), out int conf);
-            return new RatNestsSpawnGoldRule(conf);
-        }
-
-        public string ToConfigString()
-        {
-            return JSON.Dump(_maxPileCount, EncodeOptions.NoTypeHints);
-        }
+        public int GetConfigObject() => _pileCount;
 
         protected override void OnPostGameCreated()
         {
@@ -35,7 +25,7 @@
             var ability = abilities.First(c => c.name.Equals("SpawnRat(Clone)"));
             ability.pieceToSpawn = BoardPieceId.GoldPile;
             _originalSpawnAmount = ability.spawnMaxAmount;
-            ability.spawnMaxAmount = _maxPileCount;
+            ability.spawnMaxAmount = _pileCount;
         }
 
         protected override void OnDeactivate()

--- a/Rules/Rule/StartHealthAdjustedRule.cs
+++ b/Rules/Rule/StartHealthAdjustedRule.cs
@@ -4,10 +4,9 @@
     using System.Linq;
     using Boardgame;
     using HarmonyLib;
-    using MelonLoader.TinyJSON;
     using UnityEngine;
 
-    public sealed class StartHealthAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable
+    public sealed class StartHealthAdjustedRule : RulesAPI.Rule, RulesAPI.IConfigWritable<Dictionary<string, int>>
     {
         public override string Description => "Start Health is adjusted";
 
@@ -23,16 +22,7 @@
             _adjustments = adjustments;
         }
 
-        public static StartHealthAdjustedRule FromConfigString(string configString)
-        {
-            JSON.MakeInto(JSON.Load(configString), out Dictionary<string, int> conf);
-            return new StartHealthAdjustedRule(conf);
-        }
-
-        public string ToConfigString()
-        {
-            return JSON.Dump(_adjustments, EncodeOptions.NoTypeHints);
-        }
+        public Dictionary<string, int> GetConfigObject() => _adjustments;
 
         protected override void OnPostGameCreated()
         {

--- a/Rules/RulesMod.cs
+++ b/Rules/RulesMod.cs
@@ -17,7 +17,7 @@
         {
             var registrar = RulesAPI.Registrar.Instance();
             registrar.Register(typeof(Rule.SampleRule));
-            registrar.Register(typeof(Rule.AbilityAOEAdjustedRule));
+            registrar.Register(typeof(Rule.AbilityAoeAdjustedRule));
             registrar.Register(typeof(Rule.AbilityDamageAdjustedRule));
             registrar.Register(typeof(Rule.AbilityActionCostAdjustedRule));
             registrar.Register(typeof(Rule.ActionPointsAdjustedRule));

--- a/RulesAPI/ConfigManager.cs
+++ b/RulesAPI/ConfigManager.cs
@@ -1,8 +1,5 @@
 ﻿namespace RulesAPI
 {
-    using System;
-    using System.Collections.Generic;
-    using HarmonyLib;
     using MelonLoader;
 
     public class ConfigManager
@@ -30,93 +27,6 @@
         internal string LoadSelectedRuleset()
         {
             return _selectedRulesetEntry.Value;
-        }
-
-        /// <summary>
-        /// Writes the specified ruleset to the configuration file.
-        /// </summary>
-        /// <param name="configName">A name under which to write the ruleset.</param>
-        /// <param name="ruleset">The ruleset to write.</param>
-        public static void WriteRuleset(string configName, Ruleset ruleset)
-        {
-            var configCategory = MelonPreferences.CreateCategory(configName);
-            foreach (var rule in ruleset.Rules)
-            {
-                if (!(rule is IConfigWritable writableRule))
-                {
-                    RulesAPI.Logger.Warning($"Rule {rule.GetType().FullName} does not implement IConfigWritable. Skipping writing rule.");
-                    continue;
-                }
-
-                configCategory.CreateEntry(writableRule.GetType().Name, writableRule.ToConfigString());
-            }
-
-            configCategory.SaveToFile();
-        }
-
-        /// <summary>
-        /// Reads a ruleset from the configuration file.
-        /// </summary>
-        /// <param name="configName">The name under which the desired ruleset is written.</param>
-        /// <returns>The ruleset read the configuration.</returns>
-        public static Ruleset ReadRuleset(string configName)
-        {
-            var configCategory = MelonPreferences.CreateCategory(configName);
-
-            foreach (var ruleType in Registrar.Instance().RuleTypes)
-            {
-                configCategory.CreateEntry(ruleType.Name, default_value: string.Empty, dont_save_default: true);
-            }
-
-            var rules = new List<Rule>();
-            foreach (var entry in configCategory.Entries)
-            {
-                if (string.IsNullOrEmpty(entry.GetValueAsString()))
-                {
-                    continue;
-                }
-
-                try
-                {
-                    var rule = InstantiateRule(entry.Identifier, entry.GetValueAsString());
-                    rules.Add(rule);
-                }
-                catch (ArgumentException e)
-                {
-                    RulesAPI.Logger.Warning($"Failed to parse rule configuration with label [{entry.Identifier}]. Skipping rule due to: {e.Message}");
-                }
-            }
-
-            return Ruleset.NewInstance(configName, "A custom ruleset.", rules);
-        }
-
-        /// <summary>
-        /// Instantiates a rule given the rule name and its configuration string.
-        /// </summary>
-        /// <param name="ruleName">The name of the rule.</param>
-        /// <param name="configString">The string representing the rule's configuration.</param>
-        /// <returns>An instantiated rule configured with the specified configuration.</returns>
-        /// <exception cref="ArgumentException">If the specified rule could not be found, or is not configurable.</exception>
-        private static Rule InstantiateRule(string ruleName, string configString)
-        {
-            var typ = AccessTools.TypeByName(ruleName);
-            if (typ == null || !typeof(Rule).IsAssignableFrom(typ))
-            {
-                throw new ArgumentException($"Could not find a rule type corresponding to rule name: {ruleName}");
-            }
-
-            if (!typeof(IConfigWritable).IsAssignableFrom(typ))
-            {
-                throw new ArgumentException($"Could not recognize rule type as implementing IConfigWritable: {typ.FullName}");
-            }
-
-            var traverse = Traverse.Create(typ).Method("FromConfigString", paramTypes: new[] { typeof(string) }, arguments: new object[] { configString });
-            if (!traverse.MethodExists())
-            {
-                throw new ArgumentException($"Could not find expected FromConfigString method for rule type: {typ.FullName}");
-            }
-
-            return traverse.GetValue<Rule>();
         }
     }
 }

--- a/RulesAPI/IConfigWritable.cs
+++ b/RulesAPI/IConfigWritable.cs
@@ -1,26 +1,25 @@
 ﻿namespace RulesAPI
 {
-    public interface IConfigWritable
+    /// <summary>
+    /// Represents a rule whose configuration can be written.
+    /// </summary>
+    /// <remarks>
+    /// If the implementing class defines a constructor whose exactly one parameter is of the type
+    /// of this interface's argument type, that constructor may be used to instantiate a rule from configuration.
+    /// </remarks>
+    /// <returns>The type of this rule's configuration.</returns>
+    public interface IConfigWritable<T>
     {
         /// <summary>
-        /// Gets a string that can represents the rule in configuration.
+        /// Gets the object that represents the rule's configuration.
         /// </summary>
         /// <remarks>
         ///     <para>
-        ///     The implementation of this method must guarantee that when the returned string is passed into a
-        ///     corresponding <c>FromConfigString</c>, it will produce a rule identical to the one that
-        ///     <c>ToConfigString</c> was called on.
-        ///     </para>
-        ///     <para>
-        ///     For portability purposes, it is recommended that the configuration string keep to UTF-8 encoding.
+        ///     To maximum compatibility, the object must be either a primitive, string or enum,
+        ///     or a struct, list, dictionary or array with primitive, string or enum types.
         ///     </para>
         /// </remarks>
-        /// <returns>A string representing the instance of this rule.</returns>
-        string ToConfigString();
-
-        /// <summary>
-        /// Returns a rule initialized with the specified configuration string.
-        /// </summary>
-        // public static RulesAPI.Rule FromConfigString(string configString);
+        /// <returns>An object representing this rule's configuration.</returns>
+        T GetConfigObject();
     }
 }


### PR DESCRIPTION
**Changes:**
- Modify the IConfigWritable interface.
- Updated rules to adhere to the new IConfigWritable interface.
- Removed feature for reading and writing rulesets to config.

---

This improves the `IConfigWritable` interface even further.

Notice how implementing classes:
- No longer require deserialization logic.  This is abstracted out as part of the interface.
- No longer requires multiple supporting methods.  The only requirement is the `GetConfigObject()` defined in the interface, and an _optional_ supportive constructor.
- No longer requires dependencies on the mod loading library.

For more information, see the documentation in `IConfigWritable.cs`.

---

Reading/writing rulesets code is removed in this PR.  A subsequent PR will introduce a new subproject/mod that is capable of reading/writing the new version of `IConfigWritable` implementing rules to configuration.  More info on that in the upcoming PR (including why it was removed from the core RulesAPI mod).