### PR TITLE
Add RulesAPI_ConfigurationRulesets mod.

### DIFF
--- a/DemeoMods.sln
+++ b/DemeoMods.sln
@@ -23,6 +23,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{8C7F69F7-5
 		docs\PieceConfig.md = docs\PieceConfig.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RulesAPI_ConfigurableRulesets", "RulesAPI_ConfigurableRulesets\RulesAPI_ConfigurableRulesets.csproj", "{ED5D884D-FC02-4095-886E-C18369F4051D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,6 +51,10 @@ Global
 		{E986568C-684F-4DD3-980C-8D8443982EC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E986568C-684F-4DD3-980C-8D8443982EC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E986568C-684F-4DD3-980C-8D8443982EC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED5D884D-FC02-4095-886E-C18369F4051D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED5D884D-FC02-4095-886E-C18369F4051D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED5D884D-FC02-4095-886E-C18369F4051D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED5D884D-FC02-4095-886E-C18369F4051D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -40,7 +40,7 @@
     <Compile Include="Rule\CardEnergyFromAttackMultipliedRule.cs" />
     <Compile Include="Rule\CardEnergyFromRecyclingMultipliedRule.cs" />
     <Compile Include="Rule\CardSellValueMultipliedRule.cs" />
-    <Compile Include="Rule\AbilityAOEAdjustedRule.cs" />
+    <Compile Include="Rule\AbilityAoeAdjustedRule.cs" />
     <Compile Include="Rule\EnemyAttackScaledRule.cs" />
     <Compile Include="Rule\EnemyDoorOpeningDisabledRule.cs" />
     <Compile Include="Rule\EnemyHealthScaledRule.cs" />

--- a/RulesAPI_ConfigurableRulesets/ConfigManager.cs
+++ b/RulesAPI_ConfigurableRulesets/ConfigManager.cs
@@ -1,0 +1,136 @@
+﻿namespace RulesAPI.ConfigurableRulesets
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text.Json;
+    using HarmonyLib;
+    using MelonLoader;
+
+    public static class ConfigManager
+    {
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions { IncludeFields = true, WriteIndented = true };
+
+        /// <summary>
+        /// Writes the specified ruleset to the configuration file.
+        /// </summary>
+        /// <param name="configName">A name under which to write the ruleset.</param>
+        /// <param name="ruleset">The ruleset to write.</param>
+        public static void WriteRuleset(string configName, Ruleset ruleset)
+        {
+            var configCategory = MelonPreferences.CreateCategory(configName);
+
+            var ruleEntries = new List<RuleConfigEntry>();
+            foreach (var rule in ruleset.Rules)
+            {
+                try
+                {
+                    FindRuleAndConfigType(rule.GetType().FullName);
+                    var configObject = Traverse.Create(rule).Method("GetConfigObject").GetValue();
+                    var configJson = JsonSerializer.SerializeToElement(configObject, SerializerOptions);
+
+                    var ruleEntry = new RuleConfigEntry { Rule = rule.GetType().Name, Config = configJson };
+                    ruleEntries.Add(ruleEntry);
+                }
+                catch (Exception e)
+                {
+                    ConfigurableRulesetsMod.Logger.Warning($"Failed to write rule entry {rule.GetType().Name} to config. Skipping that rule: {e}");
+                }
+            }
+
+            var serializedRuleEntries = JsonSerializer.Serialize(ruleEntries, SerializerOptions);
+
+            configCategory.CreateEntry("name", string.Empty).Value = ruleset.Name;
+            configCategory.CreateEntry("description", string.Empty).Value = ruleset.Description;
+            configCategory.CreateEntry("rules", string.Empty).Value = serializedRuleEntries;
+            configCategory.SaveToFile();
+        }
+
+        /// <summary>
+        /// Reads a ruleset from the configuration file.
+        /// </summary>
+        /// <param name="configName">The name under which the desired ruleset is written.</param>
+        /// <returns>The ruleset read the configuration.</returns>
+        public static Ruleset ReadRuleset(string configName)
+        {
+            var configCategory = MelonPreferences.CreateCategory(configName);
+
+            var rulesetNameEntry = configCategory.CreateEntry("name", string.Empty);
+            var descriptionEntry = configCategory.CreateEntry("description", string.Empty);
+            var rulesEntry = configCategory.CreateEntry("rules", string.Empty);
+
+            var rules = new List<Rule>();
+            using (var document = JsonDocument.Parse(rulesEntry.Value))
+            {
+                foreach (var ruleEntryJson in document.RootElement.EnumerateArray())
+                {
+                    try
+                    {
+                        var ruleEntry = ruleEntryJson.Deserialize<RuleConfigEntry>(SerializerOptions);
+                        var (ruleType, configType) = FindRuleAndConfigType(ruleEntry.Rule);
+                        var configObject = JsonSerializer.Deserialize(ruleEntry.Config, configType, SerializerOptions);
+
+                        var instantiateRuleNew = InstantiateRule(ruleType, configType, configObject);
+                        rules.Add(instantiateRuleNew);
+                    }
+                    catch (Exception e)
+                    {
+                        ConfigurableRulesetsMod.Logger.Warning($"Failed to read rule entry from config. Skipping that rule: {e}");
+                    }
+                }
+            }
+
+            return Ruleset.NewInstance(rulesetNameEntry.Value, descriptionEntry.Value, rules);
+        }
+
+        private static (Type RuleType, Type ConfigType) FindRuleAndConfigType(string ruleName)
+        {
+            var ruleType = AccessTools.TypeByName(ruleName);
+            if (ruleType == null || !typeof(Rule).IsAssignableFrom(ruleType))
+            {
+                throw new ArgumentException($"Could not find a rule type corresponding to name: {ruleName}");
+            }
+
+            foreach (var i in ruleType.GetInterfaces())
+            {
+                if (i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IConfigWritable<>))
+                {
+                    return (ruleType, i.GetGenericArguments()[0]);
+                }
+            }
+
+            throw new ArgumentException($"Found rule type does not implement IConfigWritable: {ruleType.FullName}");
+        }
+
+        /// <summary>
+        /// Instantiates a rule given the rule name and its configuration object.
+        /// </summary>
+        /// <param name="ruleType">The type of the rule to instantiate.</param>
+        /// <param name="configType">The type of the rule's config object.</param>
+        /// <param name="configObject">The object representing the rule's configuration.</param>
+        /// <returns>An instantiated rule configured with the specified configuration.</returns>
+        /// <exception cref="ArgumentException">If an appropriate rule could not be instantiated.</exception>
+        private static Rule InstantiateRule(Type ruleType, Type configType, object configObject)
+        {
+            var constructor = AccessTools.Constructor(ruleType, new[] { configType });
+            if (constructor == null)
+            {
+                throw new ArgumentException($"Could not find suitable constructor for rule [{ruleType}].");
+            }
+
+            try
+            {
+                return constructor.Invoke(new[] { configObject }) as Rule;
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException($"Failed to call rule [{ruleType}] constructor with type [{configType}]: {e}");
+            }
+        }
+
+        public struct RuleConfigEntry
+        {
+            public string Rule;
+            public JsonElement Config;
+        }
+    }
+}

--- a/RulesAPI_ConfigurableRulesets/ConfigurableRulesetsMod.cs
+++ b/RulesAPI_ConfigurableRulesets/ConfigurableRulesetsMod.cs
@@ -11,7 +11,7 @@
 
         public override void OnApplicationStart()
         {
-            DemoWriteRuleset();
+            // DemoWriteRuleset();
             // DemoReadRuleset();
         }
 

--- a/RulesAPI_ConfigurableRulesets/ConfigurableRulesetsMod.cs
+++ b/RulesAPI_ConfigurableRulesets/ConfigurableRulesetsMod.cs
@@ -1,0 +1,98 @@
+﻿namespace RulesAPI.ConfigurableRulesets
+{
+    using System.Collections.Generic;
+    using DataKeys;
+    using MelonLoader;
+    using Rules.Rule;
+
+    internal class ConfigurableRulesetsMod : MelonMod
+    {
+        internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("RulesAPI:ConfigurableRulesets");
+
+        public override void OnApplicationStart()
+        {
+            DemoWriteRuleset();
+            // DemoReadRuleset();
+        }
+
+        private static void DemoWriteRuleset()
+        {
+            var aaca = new AbilityActionCostAdjustedRule(new Dictionary<string, bool>
+            {
+                { "Zap", false }, // 0 casting cost for zap
+                { "StrengthenCourage", false }, // 0 casting cost for Courage
+            });
+            var aaa = new AbilityAoeAdjustedRule(new Dictionary<string, int>
+            {
+                { "Fireball", 1 }, // 5x5 fireball
+                { "Zap", 1 }, // Just testing
+                { "StrengthenCourage", 1 }, // Everyone should hear the bard sing the courage song
+                { "Strength", 1 }, // Everyone nearby should share the strength potion
+                { "Speed", 1 }, // Everyone nearby should share the speed potion
+            });
+            var ada = new AbilityDamageAdjustedRule(new Dictionary<string, int> { { "Zap", 1 } });
+            var apa = new ActionPointsAdjustedRule(new Dictionary<string, int>
+            {
+                { "HeroSorcerer", 13 },
+                { "HeroGuardian", 2 },
+            });
+            var cefam1 = new CardEnergyFromAttackMultipliedRule(2f);
+            var cefam2 = new CardEnergyFromAttackMultipliedRule(2f);
+            var cefam3 = new CardEnergyFromAttackMultipliedRule(2f);
+            var cefam4 = new CardEnergyFromAttackMultipliedRule(2f);
+            var cefrm = new CardEnergyFromRecyclingMultipliedRule(5f);
+            var csvm = new CardSellValueMultipliedRule(2f);
+            var eas = new EnemyAttackScaledRule(0.5f);
+            var edod = new EnemyDoorOpeningDisabledRule(default);
+            var ehs = new EnemyHealthScaledRule(2);
+            var erd = new EnemyRespawnDisabledRule(default);
+            var gpus = new GoldPickedUpScaledRule(2f);
+            var pca = new PieceConfigAdjustedRule(new List<List<string>>
+            {
+                new List<string> { "HeroSorcerer", "MoveRange", "1" }, // 1 more movement range
+                new List<string> { "HeroSorcerer", "StartHealth", "10" }, // 10 extra HP
+                new List<string> { "HeroGuardian", "MoveRange", "1" },
+                new List<string> { "HeroGuardian", "StartHealth", "10" },
+                new List<string> { "HeroHunter", "MoveRange", "1" },
+                new List<string> { "HeroHunter", "StartHealth", "10" },
+                new List<string> { "HeroBard", "MoveRange", "1" },
+                new List<string> { "HeroBard", "StartHealth", "10" },
+                new List<string> { "HeroRogue", "MoveRange", "1" },
+                new List<string> { "HeroRogue", "StartHealth", "10" },
+                new List<string> { "WolfCompanion", "StartHealth", "20" }, // Wolf wastes this many HP wandering through gas
+                new List<string> { "SwordOfAvalon", "StartHealth", "10" },
+                new List<string> { "BeaconOfSmite", "StartHealth", "10" },
+                new List<string> { "BeaconOfSmite", "ActionPoint", "1" }, // Behemoth gets to fire two rounds
+                new List<string> { "MonsterBait", "StartHealth", "20" }, // Lure needs to last a little longer
+            });
+            var rnsg = new RatNestsSpawnGoldRule(8);
+            var sscm = new SorcererStartCardsModifiedRule(new List<SorcererStartCardsModifiedRule.CardConfig>
+            {
+                new SorcererStartCardsModifiedRule.CardConfig { Card = AbilityKey.Blink, IsReplenishable = false },
+                new SorcererStartCardsModifiedRule.CardConfig { Card = AbilityKey.Whirlwind, IsReplenishable = false },
+                new SorcererStartCardsModifiedRule.CardConfig { Card = AbilityKey.PoisonedTip, IsReplenishable = false },
+                new SorcererStartCardsModifiedRule.CardConfig { Card = AbilityKey.PoisonedTip, IsReplenishable = false },
+            });
+            var sha = new StartHealthAdjustedRule(new Dictionary<string, int>
+            {
+                { "HeroSorcerer", 50 },
+                { "HeroGuardian", 20 },
+                { "Rat", 100 },
+            });
+
+            var customRuleset = Ruleset.NewInstance("DemoConfigurableRuleset", "Just a random description.", new List<Rule>
+            {
+                aaca, aaa, ada, apa, cefam1, cefam2, cefam3, cefam4, cefrm, csvm, eas, edod, ehs, erd, gpus, pca, rnsg, sscm, sha,
+            });
+
+            ConfigManager.WriteRuleset("SavedRuleset1", customRuleset);
+        }
+
+        private static void DemoReadRuleset()
+        {
+            var readRuleset = ConfigManager.ReadRuleset("SavedRuleset1");
+            Registrar.Instance().Register(readRuleset);
+            RulesAPI.SelectRuleset(readRuleset.Name);
+        }
+    }
+}

--- a/RulesAPI_ConfigurableRulesets/ConfigurableRulesetsMod.cs
+++ b/RulesAPI_ConfigurableRulesets/ConfigurableRulesetsMod.cs
@@ -7,11 +7,11 @@
 
     internal class ConfigurableRulesetsMod : MelonMod
     {
-        internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("RulesAPI:ConfigurableRulesets");
+        internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("RulesAPI: Configurable Rulesets");
 
-        public override void OnApplicationStart()
+        public override void OnApplicationLateStart()
         {
-            // DemoWriteRuleset();
+            DemoWriteRuleset();
             // DemoReadRuleset();
         }
 
@@ -43,9 +43,9 @@
             var cefrm = new CardEnergyFromRecyclingMultipliedRule(5f);
             var csvm = new CardSellValueMultipliedRule(2f);
             var eas = new EnemyAttackScaledRule(0.5f);
-            var edod = new EnemyDoorOpeningDisabledRule(default);
+            var edod = new EnemyDoorOpeningDisabledRule(true);
             var ehs = new EnemyHealthScaledRule(2);
-            var erd = new EnemyRespawnDisabledRule(default);
+            var erd = new EnemyRespawnDisabledRule(true);
             var gpus = new GoldPickedUpScaledRule(2f);
             var pca = new PieceConfigAdjustedRule(new List<List<string>>
             {

--- a/RulesAPI_ConfigurableRulesets/Properties/AssemblyInfo.cs
+++ b/RulesAPI_ConfigurableRulesets/Properties/AssemblyInfo.cs
@@ -42,4 +42,3 @@ using RulesAPI.ConfigurableRulesets;
 [assembly: MelonID("576572")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]
 [assembly: MelonAdditionalDependencies("RulesAPI")]
-// [assembly: MelonOptionalDependencies("System.Text.Json")]

--- a/RulesAPI_ConfigurableRulesets/Properties/AssemblyInfo.cs
+++ b/RulesAPI_ConfigurableRulesets/Properties/AssemblyInfo.cs
@@ -1,0 +1,45 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+using MelonLoader;
+using RulesAPI.ConfigurableRulesets;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RulesAPI: Configurable Rulesets")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Orendain")]
+[assembly: AssemblyProduct("RulesAPI: Configurable Rulesets")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ED5D884D-FC02-4095-886E-C18369F4051D")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+
+// Melon Loader.
+[assembly: MelonInfo(typeof(ConfigurableRulesetsMod), "RulesAPI: Configurable Rulesets", "0.1.0", "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonGame("Resolution Games", "Demeo")]
+[assembly: MelonID("576572")]
+[assembly: VerifyLoaderVersion("0.5.3", true)]
+[assembly: MelonAdditionalDependencies("RulesAPI")]
+// [assembly: MelonOptionalDependencies("System.Text.Json")]

--- a/RulesAPI_ConfigurableRulesets/RulesAPI_ConfigurableRulesets.csproj
+++ b/RulesAPI_ConfigurableRulesets/RulesAPI_ConfigurableRulesets.csproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <ProjectGuid>{ED5D884D-FC02-4095-886E-C18369F4051D}</ProjectGuid>
+        <OutputType>Library</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <RootNamespace>RulesAPI.ConfigurableRulesets</RootNamespace>
+        <AssemblyName>RulesAPI_ConfigurableRulesets</AssemblyName>
+        <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+        <FileAlignment>512</FileAlignment>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <OutputPath>bin\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugType>pdbonly</DebugType>
+        <Optimize>true</Optimize>
+        <OutputPath>bin\Release\</OutputPath>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="Assembly-CSharp">
+            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
+        </Reference>
+        <Reference Include="MelonLoader">
+            <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
+        </Reference>
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="ConfigManager.cs" />
+        <Compile Include="ConfigurableRulesetsMod.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="System.Text.Json" Version="6.0.1" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\RulesAPI\RulesAPI.csproj">
+            <Project>{b412463f-a4f7-46ce-ac4e-37448762b45b}</Project>
+            <Name>RulesAPI</Name>
+        </ProjectReference>
+        <ProjectReference Include="..\Rules\Rules.csproj">
+          <Project>{8fc09405-8e06-4090-bb68-94882f0a52d8}</Project>
+          <Name>Rules</Name>
+        </ProjectReference>
+    </ItemGroup>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <Target Name="CopyToModsDir" AfterTargets="Build">
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(SteamDemeoDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(OculusDemeoDir)\Mods" />
+    </Target>
+</Project>


### PR DESCRIPTION
Follow-up to https://github.com/orendain/DemeoMods/pull/103:

The reason(s) that the read/write rulesets feature was move to a separate mod:
- There were several limitations with the JSON library bundled with MelonLoader (TinyJSON).
- `Newtonsoft.json` was available in MelonLoader managed libs, but decided against it (explanation out of scope of this PR).
- Ended up leveraging `system.text.json` library instead, _which does indeed require_ a number of libs to be included along with the mod in order to use.
- Users may not need/want this mod.  Requiring them to download a bundle of required libs for RulesAPI core would be unfriendly.

There are things in this PR that are included mostly for demo purposes and can be removed later:
- `DemoWriteRuleset()` method.  Uncomment this to write a long ruleset (every currently existing rule) to configuration.
- `DemoReadRuleset()` method.  Uncomment this to test loading a ruleset from config.

---

Note:  In order to "install" this mod, there are a number of libs that must be copied over to the `UserLibs` folder in the Demeo directory.

The following libs are generated in the build directory (e.g., `RulesAPI_ConfigurableRulesets/bin`) when the project is built, which you can copy/paste to the `UserLibs` folder.  These will be bundled during a release in the future, making it easier for end users.
```
Microsoft.Bcl.AsyncInterfaces.dll
System.Buffers.dll
System.Memory.dll
System.Numerics.Vectors.dll
System.Runtime.CompilerServices.Unsafe.dll
System.Text.Encodings.Web.dll
System.Text.Json.dll
System.Threading.Tasks.Extensions.dll
System.ValueTuple.dll
```

---

When running `DemoWriteRuleset()`, the following config is generated and written to config.

Note:  The reason why the same rule is included 4 times is intentional.  This is to demonstrate that non-`IPatchable` rules are indeed allowed to appear multiple times.  This allows for the feature mentioned here to be made: https://github.com/orendain/DemeoMods/pull/92#discussion_r796825078

```
[SavedRuleset1]
name = "DemoConfigurableRuleset"
description = "Just a random description."
rules = '''
[
  {
    "Rule": "AbilityActionCostAdjustedRule",
    "Config": {
      "Zap": false,
      "StrengthenCourage": false
    }
  },
  {
    "Rule": "AbilityAoeAdjustedRule",
    "Config": {
      "Fireball": 1,
      "Zap": 1,
      "StrengthenCourage": 1,
      "Strength": 1,
      "Speed": 1
    }
  },
  {
    "Rule": "AbilityDamageAdjustedRule",
    "Config": {
      "Zap": 1
    }
  },
  {
    "Rule": "ActionPointsAdjustedRule",
    "Config": {
      "HeroSorcerer": 13,
      "HeroGuardian": 2
    }
  },
  {
    "Rule": "CardEnergyFromAttackMultipliedRule",
    "Config": 2
  },
  {
    "Rule": "CardEnergyFromAttackMultipliedRule",
    "Config": 2
  },
  {
    "Rule": "CardEnergyFromAttackMultipliedRule",
    "Config": 2
  },
  {
    "Rule": "CardEnergyFromAttackMultipliedRule",
    "Config": 2
  },
  {
    "Rule": "CardEnergyFromRecyclingMultipliedRule",
    "Config": 5
  },
  {
    "Rule": "CardSellValueMultipliedRule",
    "Config": 2
  },
  {
    "Rule": "EnemyAttackScaledRule",
    "Config": 0.5
  },
  {
    "Rule": "EnemyDoorOpeningDisabledRule",
    "Config": true
  },
  {
    "Rule": "EnemyHealthScaledRule",
    "Config": 2
  },
  {
    "Rule": "EnemyRespawnDisabledRule",
    "Config": true
  },
  {
    "Rule": "GoldPickedUpScaledRule",
    "Config": 2
  },
  {
    "Rule": "PieceConfigAdjustedRule",
    "Config": [
      [
        "HeroSorcerer",
        "MoveRange",
        "1"
      ],
      [
        "HeroSorcerer",
        "StartHealth",
        "10"
      ],
      [
        "HeroGuardian",
        "MoveRange",
        "1"
      ],
      [
        "HeroGuardian",
        "StartHealth",
        "10"
      ],
      [
        "HeroHunter",
        "MoveRange",
        "1"
      ],
      [
        "HeroHunter",
        "StartHealth",
        "10"
      ],
      [
        "HeroBard",
        "MoveRange",
        "1"
      ],
      [
        "HeroBard",
        "StartHealth",
        "10"
      ],
      [
        "HeroRogue",
        "MoveRange",
        "1"
      ],
      [
        "HeroRogue",
        "StartHealth",
        "10"
      ],
      [
        "WolfCompanion",
        "StartHealth",
        "20"
      ],
      [
        "SwordOfAvalon",
        "StartHealth",
        "10"
      ],
      [
        "BeaconOfSmite",
        "StartHealth",
        "10"
      ],
      [
        "BeaconOfSmite",
        "ActionPoint",
        "1"
      ],
      [
        "MonsterBait",
        "StartHealth",
        "20"
      ]
    ]
  },
  {
    "Rule": "RatNestsSpawnGoldRule",
    "Config": 8
  },
  {
    "Rule": "SorcererStartCardsModifiedRule",
    "Config": [
      {
        "Card": 15,
        "IsReplenishable": false
      },
      {
        "Card": 10,
        "IsReplenishable": false
      },
      {
        "Card": 23,
        "IsReplenishable": false
      },
      {
        "Card": 23,
        "IsReplenishable": false
      }
    ]
  },
  {
    "Rule": "StartHealthAdjustedRule",
    "Config": {
      "HeroSorcerer": 50,
      "HeroGuardian": 20,
      "Rat": 100
    }
  }
]'''

```