### PR TITLE
Serialize enums as strings instead of as ints.

### DIFF
--- a/RulesAPI_Configuration/ConfigManager.cs
+++ b/RulesAPI_Configuration/ConfigManager.cs
@@ -3,12 +3,16 @@
     using System;
     using System.Collections.Generic;
     using System.Text.Json;
+    using System.Text.Json.Serialization;
     using HarmonyLib;
     using MelonLoader;
 
     public class ConfigManager
     {
-        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions { IncludeFields = true, WriteIndented = true };
+        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            IncludeFields = true, WriteIndented = true, Converters = { new JsonStringEnumConverter() },
+        };
 
         private readonly MelonPreferences_Category _configCategory;
         private readonly MelonPreferences_Entry<string> _selectedRulesetEntry;

--- a/RulesAPI_Configuration/ConfigurationMod.cs
+++ b/RulesAPI_Configuration/ConfigurationMod.cs
@@ -7,7 +7,7 @@
 
     internal class ConfigurationMod : MelonMod
     {
-        internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("RulesAPI: Configuration");
+        internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("RulesAPI:Configuration");
         private static readonly ConfigManager ConfigManager = ConfigManager.NewInstance();
 
         public override void OnApplicationLateStart()

--- a/RulesAPI_Configuration/Properties/AssemblyInfo.cs
+++ b/RulesAPI_Configuration/Properties/AssemblyInfo.cs
@@ -39,6 +39,6 @@ using RulesAPI.Configuration;
 // Melon Loader.
 [assembly: MelonInfo(typeof(ConfigurationMod), "RulesAPI: Configuration", "0.1.0", "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
-[assembly: MelonID("")]
+[assembly: MelonID("576572")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]
-[assembly: MelonAdditionalDependencies("RulesAPI: Core")]
+[assembly: MelonAdditionalDependencies("RulesAPI_Core")]

--- a/RulesAPI_Core/RulesAPI.cs
+++ b/RulesAPI_Core/RulesAPI.cs
@@ -8,7 +8,7 @@ namespace RulesAPI
 
     public static class RulesAPI
     {
-        internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("RulesAPI: Core");
+        internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("RulesAPI:Core");
         private const float WelcomeMessageDurationSeconds = 30f;
         private static bool _isRulesetActive;
 

--- a/RulesAPI_Essentials/EssentialsMod.cs
+++ b/RulesAPI_Essentials/EssentialsMod.cs
@@ -5,7 +5,7 @@
 
     internal class EssentialsMod : MelonMod
     {
-        internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("RulesAPI: Essentials");
+        internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("RulesAPI:Essentials");
 
         public override void OnApplicationStart()
         {

--- a/RulesAPI_Essentials/Properties/AssemblyInfo.cs
+++ b/RulesAPI_Essentials/Properties/AssemblyInfo.cs
@@ -41,4 +41,4 @@ using RulesAPI.Essentials;
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonID("574514")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]
-[assembly: MelonAdditionalDependencies("RulesAPI: Core")]
+[assembly: MelonAdditionalDependencies("RulesAPI_Core")]


### PR DESCRIPTION
Example change below.
```
{
    "Rule": "SorcererStartCardsModifiedRule",
    "Config": [
      {
        "Card": "Blink",            // Before, would have been `15`
        "IsReplenishable": false
      },
      {
        "Card": "Whirlwind",             // Before, would have been `10`
        "IsReplenishable": false
      },
      {
        "Card": "PoisonedTip",
        "IsReplenishable": false
      },
      {
        "Card": "PoisonedTip",
        "IsReplenishable": false
      }
    ]
  },
```