### PR TITLE
Add rule modifying level properties.

### DIFF
--- a/RulesAPI_Essentials/EssentialsMod.cs
+++ b/RulesAPI_Essentials/EssentialsMod.cs
@@ -35,11 +35,22 @@
             registrar.Register(typeof(Rules.SorcererStartCardsModifiedRule));
             registrar.Register(typeof(Rules.StartHealthAdjustedRule));
             registrar.Register(typeof(Rules.ZapStartingInventoryAdjustedRule));
+            registrar.Register(typeof(Rules.LevelPropertiesModifiedRule));
         }
 
         private static void RegisterNewRulesets()
         {
-            var sampleRules = new List<Rule> { new Rules.SampleRule() };
+            var dictionary = new Dictionary<string, int>();
+            dictionary.Add("BigGoldPileChance", 100);
+            dictionary.Add("FloorOneHealingFountains", 9);
+            dictionary.Add("FloorOneLootChests", 9);
+            dictionary.Add("FloorTwoHealingFountains", 9);
+            dictionary.Add("FloorTwoLootChests", 9);
+            dictionary.Add("FloorThreeHealingFountains", 9);
+            dictionary.Add("FloorThreeLootChests", 9);
+            var levelPropertiesModifiedRule = new Rules.LevelPropertiesModifiedRule(dictionary);
+
+            var sampleRules = new List<Rule> { levelPropertiesModifiedRule };
             var sampleRuleset = Ruleset.NewInstance("SampleRuleset", "Just a sample ruleset.", sampleRules);
 
             var registrar = Registrar.Instance();

--- a/RulesAPI_Essentials/EssentialsMod.cs
+++ b/RulesAPI_Essentials/EssentialsMod.cs
@@ -30,12 +30,12 @@
             registrar.Register(typeof(Rules.EnemyRespawnDisabledRule));
             registrar.Register(typeof(Rules.GoldPickedUpMultipliedRule));
             registrar.Register(typeof(Rules.GoldPickedUpScaledRule));
+            registrar.Register(typeof(Rules.LevelPropertiesModifiedRule));
             registrar.Register(typeof(Rules.PieceConfigAdjustedRule));
             registrar.Register(typeof(Rules.RatNestsSpawnGoldRule));
             registrar.Register(typeof(Rules.SorcererStartCardsModifiedRule));
             registrar.Register(typeof(Rules.StartHealthAdjustedRule));
             registrar.Register(typeof(Rules.ZapStartingInventoryAdjustedRule));
-            registrar.Register(typeof(Rules.LevelPropertiesModifiedRule));
         }
 
         private static void RegisterNewRulesets()

--- a/RulesAPI_Essentials/EssentialsMod.cs
+++ b/RulesAPI_Essentials/EssentialsMod.cs
@@ -40,17 +40,7 @@
 
         private static void RegisterNewRulesets()
         {
-            var dictionary = new Dictionary<string, int>();
-            dictionary.Add("BigGoldPileChance", 100);
-            dictionary.Add("FloorOneHealingFountains", 9);
-            dictionary.Add("FloorOneLootChests", 9);
-            dictionary.Add("FloorTwoHealingFountains", 9);
-            dictionary.Add("FloorTwoLootChests", 9);
-            dictionary.Add("FloorThreeHealingFountains", 9);
-            dictionary.Add("FloorThreeLootChests", 9);
-            var levelPropertiesModifiedRule = new Rules.LevelPropertiesModifiedRule(dictionary);
-
-            var sampleRules = new List<Rule> { levelPropertiesModifiedRule };
+            var sampleRules = new List<Rule> { new Rules.SampleRule() };
             var sampleRuleset = Ruleset.NewInstance("SampleRuleset", "Just a sample ruleset.", sampleRules);
 
             var registrar = Registrar.Instance();

--- a/RulesAPI_Essentials/README.md
+++ b/RulesAPI_Essentials/README.md
@@ -21,6 +21,7 @@ RulesAPI.
 - **EnemyHealthScaledRule**: Enemy health is scaled
 - **EnemyRespawnDisabledRule**: Enemy respawns are disabled
 - **GoldPickedUpMultipliedRule**: Gold picked up is multiplied
+- **LevelPropertiesModifiedRule**: Level properties are modified
 - **PieceConfigAdjustedRule**: Piece configuration is adjusted
   - See [PieceConfig.md](../docs/PieceConfig.md) for information about modifiable fields.
 - **RatNestsSpawnGoldRule**: Rat nests spawn gold

--- a/RulesAPI_Essentials/Rules/LevelPropertiesModifiedRule.cs
+++ b/RulesAPI_Essentials/Rules/LevelPropertiesModifiedRule.cs
@@ -1,0 +1,60 @@
+﻿namespace RulesAPI.Essentials.Rules
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Boardgame;
+    using Data.GameData;
+    using HarmonyLib;
+
+    public sealed class LevelPropertiesModifiedRule : Rule, IConfigWritable<Dictionary<string, int>>
+    {
+        public override string Description => "Level properties are modified";
+
+        private const int IndexOfDreadLevelOne = 0;
+        private readonly Dictionary<string, int> _levelProperties;
+        private readonly List<DreadLevelsDTO> _defaultLevelProperties;
+
+        public LevelPropertiesModifiedRule(Dictionary<string, int> levelProperties)
+        {
+            _levelProperties = levelProperties;
+            _defaultLevelProperties = new List<DreadLevelsDTO>();
+        }
+
+        public Dictionary<string, int> GetConfigObject() => _levelProperties;
+
+        protected override void OnDeactivate()
+        {
+            var allLevelProperties = Traverse.Create<GameDataAPI>()
+                .Field<Dictionary<GameConfigType, List<DreadLevelsDTO>>>("DreadLevelsDTOlist").Value.Values;
+
+            for (var i = 0; i < allLevelProperties.Count; i++)
+            {
+                var levelProperties = allLevelProperties.ElementAt(i);
+                levelProperties.Insert(IndexOfDreadLevelOne, _defaultLevelProperties[i]);
+            }
+        }
+
+        protected override void OnPreGameCreated()
+        {
+            var allLevelProperties = Traverse.Create<GameDataAPI>()
+                .Field<Dictionary<GameConfigType, List<DreadLevelsDTO>>>("DreadLevelsDTOlist").Value.Values;
+
+            for (var i = 0; i < allLevelProperties.Count; i++)
+            {
+                var levelProperties = allLevelProperties.ElementAt(i);
+                var defaultLevelProperties = levelProperties[IndexOfDreadLevelOne];
+                _defaultLevelProperties.Insert(i, defaultLevelProperties);
+                ModifyDefaultDreadMode(ref defaultLevelProperties);
+                levelProperties.Insert(IndexOfDreadLevelOne, defaultLevelProperties);
+            }
+        }
+
+        private void ModifyDefaultDreadMode(ref DreadLevelsDTO dreadLevelDto)
+        {
+            foreach (var modification in _levelProperties)
+            {
+                AccessTools.StructFieldRefAccess<DreadLevelsDTO, int>(ref dreadLevelDto, modification.Key) = modification.Value;
+            }
+        }
+    }
+}

--- a/RulesAPI_Essentials/RulesAPI_Essentials.csproj
+++ b/RulesAPI_Essentials/RulesAPI_Essentials.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Rules\EnemyRespawnDisabledRule.cs" />
     <Compile Include="Rules\GoldPickedUpMultipliedRule.cs" />
     <Compile Include="Rules\GoldPickedUpScaledRule.cs" />
+    <Compile Include="Rules\LevelPropertiesModifiedRule.cs" />
     <Compile Include="Rules\PieceConfigAdjustedRule.cs" />
     <Compile Include="Rules\RatNestsSpawnGoldRule.cs" />
     <Compile Include="Rules\SampleRule.cs" />


### PR DESCRIPTION
Resolves https://github.com/orendain/DemeoMods/issues/113

See `DreadLevelsDTO.cs` in the Demeo code for the values that can be modified.  However, not all fields are actually used (e.g., gold amount properties are ignored).

Example of 50 POIs on one level:
![image](https://user-images.githubusercontent.com/1426304/152671839-e554dc04-6f49-446b-85c8-2713b1580942.png)

Example ruleset code:
```cs
var dictionary = new Dictionary<string, int>();
dictionary.Add("BigGoldPileChance", 100);
dictionary.Add("FloorOneHealingFountains", 9);
dictionary.Add("FloorOneLootChests", 9);
dictionary.Add("FloorTwoHealingFountains", 9);
dictionary.Add("FloorTwoLootChests", 9);
dictionary.Add("FloorThreeHealingFountains", 9);
dictionary.Add("FloorThreeLootChests", 9);

var levelPropertiesModifiedRule = new Rules.LevelPropertiesModifiedRule(dictionary);
var sampleRules = new List<Rule> { levelPropertiesModifiedRule };
var sampleRuleset = Ruleset.NewInstance("SampleRuleset", "Just a sample ruleset.", sampleRules);
```

Example ruleset config:
```toml
[SavedRuleset1]
name = "DemoConfigurableRuleset"
description = "Just a random description."
rules = '''
[
  {
    "Rule": "LevelPropertiesModifiedRule",
    "Config": {
      "BigGoldPileChance": 100,
      "FloorOneHealingFountains": 9,
      "FloorOneLootChests": 9,
      "FloorTwoHealingFountains": 9,
      "FloorTwoLootChests": 9,
      "FloorThreeHealingFountains": 9,
      "FloorThreeLootChests": 9
    }
  }
]'''
```