### PR TITLE
Pass GameContext in as argument to hook calls.

### DIFF
--- a/RulesAPI_Core/ModPatcher.cs
+++ b/RulesAPI_Core/ModPatcher.cs
@@ -62,10 +62,10 @@
                 return;
             }
 
-            RulesAPI.TriggerActivateRuleset();
+            RulesAPI.TriggerActivateRuleset(_gameContext);
 
             _isStartingGame = true;
-            RulesAPI.TriggerPreGameCreated();
+            RulesAPI.TriggerPreGameCreated(_gameContext);
         }
 
         private static void GameStateMachine_GoToPlayingState_Postfix()
@@ -76,25 +76,25 @@
             }
 
             _isStartingGame = false;
-            RulesAPI.TriggerPostGameCreated();
+            RulesAPI.TriggerPostGameCreated(_gameContext);
             RulesAPI.TriggerWelcomeMessage();
         }
 
         private static void PostGameControllerBase_OnPlayAgainClicked_Postfix()
         {
-            RulesAPI.TriggerActivateRuleset();
+            RulesAPI.TriggerActivateRuleset(_gameContext);
             _isStartingGame = true;
-            RulesAPI.TriggerPreGameCreated();
+            RulesAPI.TriggerPreGameCreated(_gameContext);
         }
 
         private static void GameStateMachine_EndGame_Prefix()
         {
-            RulesAPI.TriggerDeactivateRuleset();
+            RulesAPI.TriggerDeactivateRuleset(_gameContext);
         }
 
         private static void SerializableEventQueue_DisconnectLocalPlayer_Prefix()
         {
-            RulesAPI.TriggerDeactivateRuleset();
+            RulesAPI.TriggerDeactivateRuleset(_gameContext);
         }
     }
 }

--- a/RulesAPI_Core/Rule.cs
+++ b/RulesAPI_Core/Rule.cs
@@ -1,5 +1,7 @@
 ﻿namespace RulesAPI
 {
+    using Boardgame;
+
     public abstract class Rule
     {
         /// <summary>
@@ -10,6 +12,7 @@
         /// <summary>
         /// Called when the rule is activated.
         /// </summary>
+        /// <param name="gameContext">The game's global GameContext.</param>
         /// <remarks>
         ///     <para>
         ///     Rules should use this as an indication that they may begin to take effect.
@@ -19,34 +22,37 @@
         ///     to be created.
         ///     </para>
         /// </remarks>
-        protected internal virtual void OnActivate()
+        protected internal virtual void OnActivate(GameContext gameContext)
         {
         }
 
         /// <summary>
         /// Called when the rule is deactivated.
         /// </summary>
+        /// <param name="gameContext">The game's global GameContext.</param>
         /// <remarks>
         /// This method should undo any persisting changes made by the rule up until this point.
         /// </remarks>
-        protected internal virtual void OnDeactivate()
+        protected internal virtual void OnDeactivate(GameContext gameContext)
         {
         }
 
         /// <summary>
         /// Called before a game is created.
         /// </summary>
-        protected internal virtual void OnPreGameCreated()
+        /// <param name="gameContext">The game's global GameContext.</param>
+        protected internal virtual void OnPreGameCreated(GameContext gameContext)
         {
         }
 
         /// <summary>
         /// Called after a game is created.
         /// </summary>
+        /// <param name="gameContext">The game's global GameContext.</param>
         /// <remarks>
         /// Note that even though the game is created, the level/POIs/enemies may not yet fully be loaded/spawned.
         /// </remarks>
-        protected internal virtual void OnPostGameCreated()
+        protected internal virtual void OnPostGameCreated(GameContext gameContext)
         {
         }
     }

--- a/RulesAPI_Core/RulesAPI.cs
+++ b/RulesAPI_Core/RulesAPI.cs
@@ -16,10 +16,9 @@ namespace RulesAPI
 
         public static void SelectRuleset(string ruleset)
         {
-            if (!string.IsNullOrEmpty(ruleset) && _isRulesetActive)
+            if (_isRulesetActive)
             {
-                Logger.Msg($"Deactivating current ruleset before selecting a new one.");
-                TriggerDeactivateRuleset();
+                throw new InvalidOperationException("May not select a new ruleset while one is currently active.");
             }
 
             try

--- a/RulesAPI_Core/RulesAPI.cs
+++ b/RulesAPI_Core/RulesAPI.cs
@@ -35,7 +35,7 @@ namespace RulesAPI
             Logger.Msg($"Selected ruleset: {SelectedRuleset.Name}");
         }
 
-        internal static void TriggerActivateRuleset()
+        internal static void TriggerActivateRuleset(GameContext gameContext)
         {
             if (_isRulesetActive)
             {
@@ -56,7 +56,7 @@ namespace RulesAPI
                 try
                 {
                     Logger.Msg($"Activating rule type: {rule.GetType()}");
-                    rule.OnActivate();
+                    rule.OnActivate(gameContext);
                 }
                 catch (Exception e)
                 {
@@ -66,7 +66,7 @@ namespace RulesAPI
             }
         }
 
-        internal static void TriggerDeactivateRuleset()
+        internal static void TriggerDeactivateRuleset(GameContext gameContext)
         {
             if (!_isRulesetActive)
             {
@@ -81,7 +81,7 @@ namespace RulesAPI
                 try
                 {
                     Logger.Msg($"Deactivating rule type: {rule.GetType()}");
-                    rule.OnDeactivate();
+                    rule.OnDeactivate(gameContext);
                 }
                 catch (Exception e)
                 {
@@ -91,7 +91,7 @@ namespace RulesAPI
             }
         }
 
-        internal static void TriggerPreGameCreated()
+        internal static void TriggerPreGameCreated(GameContext gameContext)
         {
             if (SelectedRuleset == null)
             {
@@ -103,7 +103,7 @@ namespace RulesAPI
                 try
                 {
                     Logger.Msg($"Calling OnPreGameCreated for rule type: {rule.GetType()}");
-                    rule.OnPreGameCreated();
+                    rule.OnPreGameCreated(gameContext);
                 }
                 catch (Exception e)
                 {
@@ -113,7 +113,7 @@ namespace RulesAPI
             }
         }
 
-        internal static void TriggerPostGameCreated()
+        internal static void TriggerPostGameCreated(GameContext gameContext)
         {
             if (SelectedRuleset == null)
             {
@@ -125,7 +125,7 @@ namespace RulesAPI
                 try
                 {
                     Logger.Msg($"Calling OnPostGameCreated for rule type: {rule.GetType()}");
-                    rule.OnPostGameCreated();
+                    rule.OnPostGameCreated(gameContext);
                 }
                 catch (Exception e)
                 {

--- a/RulesAPI_Essentials/Rules/AbilityAOEAdjustedRule.cs
+++ b/RulesAPI_Essentials/Rules/AbilityAOEAdjustedRule.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using Boardgame;
     using Boardgame.BoardEntities.Abilities;
     using HarmonyLib;
     using UnityEngine;
@@ -24,7 +25,7 @@
 
         public Dictionary<string, int> GetConfigObject() => _adjustments;
 
-        protected override void OnPostGameCreated()
+        protected override void OnPostGameCreated(GameContext gameContext)
         {
             var abilities = Resources.FindObjectsOfTypeAll<Ability>();
             foreach (var item in _adjustments)
@@ -36,7 +37,7 @@
             }
         }
 
-        protected override void OnDeactivate()
+        protected override void OnDeactivate(GameContext gameContext)
         {
             var abilities = Resources.FindObjectsOfTypeAll<Ability>();
             foreach (var item in _adjustments)

--- a/RulesAPI_Essentials/Rules/AbilityActionCostAdjustedRule.cs
+++ b/RulesAPI_Essentials/Rules/AbilityActionCostAdjustedRule.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using Boardgame;
     using Boardgame.BoardEntities.Abilities;
     using UnityEngine;
 
@@ -23,7 +24,7 @@
 
         public Dictionary<string, bool> GetConfigObject() => _adjustments;
 
-        protected override void OnPostGameCreated()
+        protected override void OnPostGameCreated(GameContext gameContext)
         {
             var abilities = Resources.FindObjectsOfTypeAll<Ability>();
             foreach (var item in _adjustments)
@@ -33,7 +34,7 @@
             }
         }
 
-        protected override void OnDeactivate()
+        protected override void OnDeactivate(GameContext gameContext)
         {
             var abilities = Resources.FindObjectsOfTypeAll<Ability>();
             foreach (var item in _adjustments)

--- a/RulesAPI_Essentials/Rules/AbilityDamageAdjustedRule.cs
+++ b/RulesAPI_Essentials/Rules/AbilityDamageAdjustedRule.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using Boardgame;
     using Boardgame.BoardEntities.Abilities;
     using UnityEngine;
 
@@ -23,7 +24,7 @@
 
         public Dictionary<string, int> GetConfigObject() => _adjustments;
 
-        protected override void OnPostGameCreated()
+        protected override void OnPostGameCreated(GameContext gameContext)
         {
             var abilities = Resources.FindObjectsOfTypeAll<Ability>();
             foreach (var item in _adjustments)
@@ -34,7 +35,7 @@
             }
         }
 
-        protected override void OnDeactivate()
+        protected override void OnDeactivate(GameContext gameContext)
         {
             var abilities = Resources.FindObjectsOfTypeAll<Ability>();
             foreach (var item in _adjustments)

--- a/RulesAPI_Essentials/Rules/ActionPointsAdjustedRule.cs
+++ b/RulesAPI_Essentials/Rules/ActionPointsAdjustedRule.cs
@@ -24,7 +24,7 @@
 
         public Dictionary<string, int> GetConfigObject() => _adjustments;
 
-        protected override void OnPostGameCreated()
+        protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _adjustments)
@@ -35,7 +35,7 @@
             }
         }
 
-        protected override void OnDeactivate()
+        protected override void OnDeactivate(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _adjustments)

--- a/RulesAPI_Essentials/Rules/CardEnergyFromAttackMultipliedRule.cs
+++ b/RulesAPI_Essentials/Rules/CardEnergyFromAttackMultipliedRule.cs
@@ -1,5 +1,6 @@
 ﻿namespace RulesAPI.Essentials.Rules
 {
+    using Boardgame;
     using Data.GameData;
     using HarmonyLib;
 
@@ -17,14 +18,14 @@
 
         public float GetConfigObject() => _multiplier;
 
-        protected override void OnPostGameCreated()
+        protected override void OnPostGameCreated(GameContext gameContext)
         {
             _originalValue = AIDirectorConfig.CardEnergy_EnergyToGetFromDealingDamage;
             Traverse.Create(typeof(AIDirectorConfig))
                 .Field<float>("CardEnergy_EnergyToGetFromDealingDamage").Value = _originalValue * _multiplier;
         }
 
-        protected override void OnDeactivate()
+        protected override void OnDeactivate(GameContext gameContext)
         {
             Traverse.Create(typeof(AIDirectorConfig))
                 .Field<float>("CardEnergy_EnergyToGetFromDealingDamage").Value = _originalValue;

--- a/RulesAPI_Essentials/Rules/CardEnergyFromRecyclingMultipliedRule.cs
+++ b/RulesAPI_Essentials/Rules/CardEnergyFromRecyclingMultipliedRule.cs
@@ -17,9 +17,9 @@
 
         public float GetConfigObject() => _multiplier;
 
-        protected override void OnActivate() => _isActivated = true;
+        protected override void OnActivate(GameContext gameContext) => _isActivated = true;
 
-        protected override void OnDeactivate() => _isActivated = false;
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
 
         private static void Patch(Harmony harmony)
         {

--- a/RulesAPI_Essentials/Rules/CardSellValueMultipliedRule.cs
+++ b/RulesAPI_Essentials/Rules/CardSellValueMultipliedRule.cs
@@ -1,6 +1,7 @@
 ﻿namespace RulesAPI.Essentials.Rules
 {
     using System.Reflection;
+    using Boardgame;
     using HarmonyLib;
 
     public sealed class CardSellValueMultipliedRule : Rule, IConfigWritable<float>, IPatchable
@@ -17,9 +18,9 @@
 
         public float GetConfigObject() => _multiplier;
 
-        protected override void OnActivate() => _isActivated = true;
+        protected override void OnActivate(GameContext gameContext) => _isActivated = true;
 
-        protected override void OnDeactivate() => _isActivated = false;
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
 
         private static void Patch(Harmony harmony)
         {

--- a/RulesAPI_Essentials/Rules/EnemyAttackScaledRule.cs
+++ b/RulesAPI_Essentials/Rules/EnemyAttackScaledRule.cs
@@ -18,9 +18,9 @@
 
         public float GetConfigObject() => _multiplier;
 
-        protected override void OnActivate() => _isActivated = true;
+        protected override void OnActivate(GameContext gameContext) => _isActivated = true;
 
-        protected override void OnDeactivate() => _isActivated = false;
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
 
         private static void Patch(Harmony harmony)
         {

--- a/RulesAPI_Essentials/Rules/EnemyDoorOpeningDisabledRule.cs
+++ b/RulesAPI_Essentials/Rules/EnemyDoorOpeningDisabledRule.cs
@@ -15,9 +15,9 @@
 
         public bool GetConfigObject() => true;
 
-        protected override void OnActivate() => _isActivated = true;
+        protected override void OnActivate(GameContext gameContext) => _isActivated = true;
 
-        protected override void OnDeactivate() => _isActivated = false;
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
 
         private static void Patch(Harmony harmony)
         {

--- a/RulesAPI_Essentials/Rules/EnemyHealthScaledRule.cs
+++ b/RulesAPI_Essentials/Rules/EnemyHealthScaledRule.cs
@@ -18,9 +18,9 @@
 
         public float GetConfigObject() => _multiplier;
 
-        protected override void OnActivate() => _isActivated = true;
+        protected override void OnActivate(GameContext gameContext) => _isActivated = true;
 
-        protected override void OnDeactivate() => _isActivated = false;
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
 
         private static void Patch(Harmony harmony)
         {

--- a/RulesAPI_Essentials/Rules/EnemyRespawnDisabledRule.cs
+++ b/RulesAPI_Essentials/Rules/EnemyRespawnDisabledRule.cs
@@ -1,5 +1,6 @@
 ﻿namespace RulesAPI.Essentials.Rules
 {
+    using Boardgame;
     using Boardgame.AIDirector;
     using HarmonyLib;
 
@@ -15,9 +16,9 @@
 
         public bool GetConfigObject() => true;
 
-        protected override void OnActivate() => _isActivated = true;
+        protected override void OnActivate(GameContext gameContext) => _isActivated = true;
 
-        protected override void OnDeactivate() => _isActivated = false;
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
 
         private static void Patch(Harmony harmony)
         {

--- a/RulesAPI_Essentials/Rules/GoldPickedUpMultipliedRule.cs
+++ b/RulesAPI_Essentials/Rules/GoldPickedUpMultipliedRule.cs
@@ -1,5 +1,6 @@
 ﻿namespace RulesAPI.Essentials.Rules
 {
+    using Boardgame;
     using Boardgame.Data;
     using Boardgame.SerializableEvents;
     using HarmonyLib;
@@ -16,9 +17,9 @@
             _multiplier = multiplier;
         }
 
-        protected override void OnActivate() => _isActivated = true;
+        protected override void OnActivate(GameContext gameContext) => _isActivated = true;
 
-        protected override void OnDeactivate() => _isActivated = false;
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
 
         private static void Patch(Harmony harmony)
         {

--- a/RulesAPI_Essentials/Rules/GoldPickedUpScaledRule.cs
+++ b/RulesAPI_Essentials/Rules/GoldPickedUpScaledRule.cs
@@ -1,5 +1,6 @@
 ﻿namespace RulesAPI.Essentials.Rules
 {
+    using Boardgame;
     using Boardgame.Data;
     using Boardgame.SerializableEvents;
     using HarmonyLib;
@@ -18,9 +19,9 @@
 
         public float GetConfigObject() => _multiplier;
 
-        protected override void OnActivate() => _isActivated = true;
+        protected override void OnActivate(GameContext gameContext) => _isActivated = true;
 
-        protected override void OnDeactivate() => _isActivated = false;
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
 
         private static void Patch(Harmony harmony)
         {

--- a/RulesAPI_Essentials/Rules/LevelPropertiesModifiedRule.cs
+++ b/RulesAPI_Essentials/Rules/LevelPropertiesModifiedRule.cs
@@ -22,7 +22,7 @@
 
         public Dictionary<string, int> GetConfigObject() => _levelProperties;
 
-        protected override void OnDeactivate()
+        protected override void OnDeactivate(GameContext gameContext)
         {
             var allLevelProperties = Traverse.Create<GameDataAPI>()
                 .Field<Dictionary<GameConfigType, List<DreadLevelsDTO>>>("DreadLevelsDTOlist").Value.Values;
@@ -34,7 +34,7 @@
             }
         }
 
-        protected override void OnPreGameCreated()
+        protected override void OnPreGameCreated(GameContext gameContext)
         {
             var allLevelProperties = Traverse.Create<GameDataAPI>()
                 .Field<Dictionary<GameConfigType, List<DreadLevelsDTO>>>("DreadLevelsDTOlist").Value.Values;

--- a/RulesAPI_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/RulesAPI_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -24,7 +24,7 @@
 
         public List<List<string>> GetConfigObject() => _adjustments;
 
-        protected override void OnPostGameCreated()
+        protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _adjustments)
@@ -35,7 +35,7 @@
             }
         }
 
-        protected override void OnDeactivate()
+        protected override void OnDeactivate(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _adjustments)

--- a/RulesAPI_Essentials/Rules/RatNestsSpawnGoldRule.cs
+++ b/RulesAPI_Essentials/Rules/RatNestsSpawnGoldRule.cs
@@ -1,6 +1,7 @@
 ﻿namespace RulesAPI.Essentials.Rules
 {
     using System.Linq;
+    using Boardgame;
     using Boardgame.BoardEntities.Abilities;
     using DataKeys;
     using UnityEngine;
@@ -19,7 +20,7 @@
 
         public int GetConfigObject() => _pileCount;
 
-        protected override void OnPostGameCreated()
+        protected override void OnPostGameCreated(GameContext gameContext)
         {
             var abilities = Resources.FindObjectsOfTypeAll<Ability>();
             var ability = abilities.First(c => c.name.Equals("SpawnRat(Clone)"));
@@ -28,7 +29,7 @@
             ability.spawnMaxAmount = _pileCount;
         }
 
-        protected override void OnDeactivate()
+        protected override void OnDeactivate(GameContext gameContext)
         {
             var abilities = Resources.FindObjectsOfTypeAll<Ability>();
             var ability = abilities.First(c => c.name.Equals("SpawnRat(Clone)"));

--- a/RulesAPI_Essentials/Rules/SampleRule.cs
+++ b/RulesAPI_Essentials/Rules/SampleRule.cs
@@ -1,5 +1,7 @@
 ﻿namespace RulesAPI.Essentials.Rules
 {
+    using Boardgame;
+
     /// <summary>
     /// Represents a modular gameplay modification.
     /// </summary>
@@ -30,7 +32,7 @@
         ///     to be created.
         ///     </para>
         /// </remarks>
-        protected override void OnActivate()
+        protected override void OnActivate(GameContext gameContext)
         {
         }
 
@@ -40,14 +42,14 @@
         /// <remarks>
         /// This method should undo any persisting changes made by the rule up until this point.
         /// </remarks>
-        protected override void OnDeactivate()
+        protected override void OnDeactivate(GameContext gameContext)
         {
         }
 
         /// <summary>
         /// Called before a game is created.
         /// </summary>
-        protected override void OnPreGameCreated()
+        protected override void OnPreGameCreated(GameContext gameContext)
         {
         }
 
@@ -57,7 +59,7 @@
         /// <remarks>
         /// Note that even though the game is created, the level/POIs/enemies may not yet fully be loaded/spawned.
         /// </remarks>
-        protected override void OnPostGameCreated()
+        protected override void OnPostGameCreated(GameContext gameContext)
         {
         }
 

--- a/RulesAPI_Essentials/Rules/SorcererStartCardsModifiedRule.cs
+++ b/RulesAPI_Essentials/Rules/SorcererStartCardsModifiedRule.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Boardgame;
     using Boardgame.BoardEntities;
     using DataKeys;
     using HarmonyLib;
@@ -32,9 +33,9 @@
 
         public List<CardConfig> GetConfigObject() => _cards;
 
-        protected override void OnActivate() => _isActivated = true;
+        protected override void OnActivate(GameContext gameContext) => _isActivated = true;
 
-        protected override void OnDeactivate() => _isActivated = false;
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
 
         private static void Patch(Harmony harmony)
         {

--- a/RulesAPI_Essentials/Rules/StartHealthAdjustedRule.cs
+++ b/RulesAPI_Essentials/Rules/StartHealthAdjustedRule.cs
@@ -24,7 +24,7 @@
 
         public Dictionary<string, int> GetConfigObject() => _adjustments;
 
-        protected override void OnPostGameCreated()
+        protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _adjustments)
@@ -35,7 +35,7 @@
             }
         }
 
-        protected override void OnDeactivate()
+        protected override void OnDeactivate(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _adjustments)

--- a/RulesAPI_Essentials/Rules/ZapStartingInventoryAdjustedRule.cs
+++ b/RulesAPI_Essentials/Rules/ZapStartingInventoryAdjustedRule.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Reflection.Emit;
+    using Boardgame;
     using Boardgame.BoardEntities;
     using DataKeys;
     using HarmonyLib;
@@ -12,9 +13,9 @@
 
         private static bool _isActivated;
 
-        protected override void OnActivate() => _isActivated = true;
+        protected override void OnActivate(GameContext gameContext) => _isActivated = true;
 
-        protected override void OnDeactivate() => _isActivated = false;
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
 
         private static void Patch(Harmony harmony)
         {


### PR DESCRIPTION
Pass GameContext in as argument to hook calls.

This allows rules that need access to game state to be implementing without capturing game state itself,or patching into parts of the code to change state that it could otherwise do if context was given to it.

This will reduce the likelihood that a rule will need to implement the `IPatchable` interface, in turn becoming simpler to implement.