### PR TITLE
Add ConfigManager functionality allowing loading rulesets specified from config.

### DIFF
--- a/RulesAPI_Configuration/ConfigManager.cs
+++ b/RulesAPI_Configuration/ConfigManager.cs
@@ -179,7 +179,7 @@
             }
         }
 
-        public struct RuleConfigEntry
+        private struct RuleConfigEntry
         {
             public string Rule;
             public JsonElement Config;

--- a/RulesAPI_Configuration/ConfigManager.cs
+++ b/RulesAPI_Configuration/ConfigManager.cs
@@ -42,11 +42,18 @@
         /// <summary>
         /// Writes the specified ruleset to the configuration file.
         /// </summary>
-        /// <param name="configName">A name under which to write the ruleset.</param>
         /// <param name="ruleset">The ruleset to write.</param>
-        public static void WriteRuleset(string configName, Ruleset ruleset)
+        /// <remarks>
+        /// The ruleset is saved under a category with the same name as the ruleset.
+        /// </remarks>
+        public static void WriteRuleset(Ruleset ruleset)
         {
-            var configCategory = MelonPreferences.CreateCategory(configName);
+            if (string.IsNullOrEmpty(ruleset.Name))
+            {
+                throw new ArgumentException("Ruleset name must not be empty.");
+            }
+
+            var configCategory = MelonPreferences.CreateCategory(ruleset.Name);
 
             var ruleEntries = new List<RuleConfigEntry>();
             foreach (var rule in ruleset.Rules)
@@ -78,7 +85,7 @@
         /// Reads a ruleset from the configuration file.
         /// </summary>
         /// <param name="configName">The name under which the desired ruleset is written.</param>
-        /// <returns>The ruleset read the configuration.</returns>
+        /// <returns>The ruleset read from configuration.</returns>
         public static Ruleset ReadRuleset(string configName)
         {
             var configCategory = MelonPreferences.CreateCategory(configName);

--- a/RulesAPI_Configuration/ConfigManager.cs
+++ b/RulesAPI_Configuration/ConfigManager.cs
@@ -15,7 +15,8 @@
         };
 
         private readonly MelonPreferences_Category _configCategory;
-        private readonly MelonPreferences_Entry<string> _selectedRulesetEntry;
+        private readonly MelonPreferences_Entry<string> _rulesetEntry;
+        private readonly MelonPreferences_Entry<bool> _loadFromConfigEntry;
 
         internal static ConfigManager NewInstance()
         {
@@ -25,18 +26,33 @@
         private ConfigManager()
         {
             _configCategory = MelonPreferences.CreateCategory("RulesAPI");
-            _selectedRulesetEntry = _configCategory.CreateEntry("ruleset", string.Empty);
+            _rulesetEntry = _configCategory.CreateEntry("ruleset", string.Empty);
+            _loadFromConfigEntry = _configCategory.CreateEntry("loadFromConfig", false);
         }
 
-        internal void SaveSelectedRuleset(string rulesetName)
+        internal void SetRuleset(string rulesetName)
         {
-            _selectedRulesetEntry.Value = rulesetName;
+            _rulesetEntry.Value = rulesetName;
+        }
+
+        internal void SetLoadFromConfig(bool loadFromConfig)
+        {
+            _loadFromConfigEntry.Value = loadFromConfig;
+        }
+
+        internal string GetRuleset()
+        {
+            return _rulesetEntry.Value;
+        }
+
+        internal bool GetLoadFromConfig()
+        {
+            return _loadFromConfigEntry.Value;
+        }
+
+        internal void Save()
+        {
             _configCategory.SaveToFile();
-        }
-
-        internal string LoadSelectedRuleset()
-        {
-            return _selectedRulesetEntry.Value;
         }
 
         /// <summary>

--- a/RulesAPI_Configuration/ConfigurationMod.cs
+++ b/RulesAPI_Configuration/ConfigurationMod.cs
@@ -107,7 +107,7 @@
                 aaca, aaa, ada, apa, cefam1, cefam2, cefam3, cefam4, cefrm, csvm, eas, edod, ehs, erd, gpus, pca, rnsg, sscm, sha,
             });
 
-            ConfigManager.WriteRuleset("SavedRuleset1", customRuleset);
+            ConfigManager.WriteRuleset(customRuleset);
         }
 
         private static void DemoReadRuleset()

--- a/RulesAPI_Configuration/ConfigurationMod.cs
+++ b/RulesAPI_Configuration/ConfigurationMod.cs
@@ -15,7 +15,7 @@
             DemoWriteRuleset();
             // DemoReadRuleset();
 
-            var configSelectedRuleset = ConfigManager.LoadSelectedRuleset();
+            var configSelectedRuleset = ConfigManager.GetRuleset();
             if (string.IsNullOrEmpty(configSelectedRuleset))
             {
                 return;
@@ -34,7 +34,7 @@
         public override void OnApplicationQuit()
         {
             var rulesetName = RulesAPI.SelectedRuleset != null ? RulesAPI.SelectedRuleset.Name : string.Empty;
-            ConfigManager.SaveSelectedRuleset(rulesetName);
+            ConfigManager.SetRuleset(rulesetName);
         }
 
         private static void DemoWriteRuleset()


### PR DESCRIPTION
**Changes:**
- Write rulesets to a category with the same name as the ruleset.
- Add ConfigManager methods for writing/reading new fields.
- Create method explicitly for saving state to config file.

If `loadFromConfig` is set to `true`, the ruleset with the selected name will be loaded from config.

### Example 1

`loadFromConfig = true` : The mod will look for `DemoConfigurableRuleset` in configuration and load it.

```toml
[RulesAPI]
ruleset = "DemoConfigurableRuleset"
loadFromConfig = true

[DemoConfigurableRuleset]
name = "DemoConfigurableRuleset"
description = "Just a random description."
rules = ""
```

### Example 1

`loadFromConfig = false` : The mod will look for the _pre-registered_ `SampleRuleset` ruleset (not specified in configuration).

```toml
[RulesAPI]
ruleset = "SampleRuleset"
loadFromConfig = false

[DemoConfigurableRuleset]
name = "DemoConfigurableRuleset"
description = "Just a random description."
rules = ""
```