### PR TITLE
Fix spelling in demo rule

### DIFF
--- a/RulesAPI_Configuration/ConfigurationMod.cs
+++ b/RulesAPI_Configuration/ConfigurationMod.cs
@@ -96,8 +96,8 @@
                 new List<string> { "HeroHunter", "StartHealth", "10" },
                 new List<string> { "HeroBard", "MoveRange", "1" },
                 new List<string> { "HeroBard", "StartHealth", "10" },
-                new List<string> { "HeroRogue", "MoveRange", "1" },
-                new List<string> { "HeroRogue", "StartHealth", "10" },
+                new List<string> { "HeroRouge", "MoveRange", "1" },
+                new List<string> { "HeroRouge", "StartHealth", "10" },
                 new List<string> { "WolfCompanion", "StartHealth", "20" }, // Wolf wastes this many HP wandering through gas
                 new List<string> { "SwordOfAvalon", "StartHealth", "10" },
                 new List<string> { "BeaconOfSmite", "StartHealth", "10" },


### PR DESCRIPTION
Fix spelling - because a mis-spelled piece name means that subsequent changes do not get applied.

I had thought that the Assassin was a Rogue-like character, but apparently that is incorrect. The piecename is actually HeroRouge  .. like the costmetics
