### PR TITLE
Use Newtonsoft.Json instead of System.Text.Json for configuration serialization.

### DIFF
--- a/RulesAPI_Configuration/RulesAPI_Configuration.csproj
+++ b/RulesAPI_Configuration/RulesAPI_Configuration.csproj
@@ -45,7 +45,8 @@
         <Compile Include="Properties\AssemblyInfo.cs" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="6.0.1" />
+        <!-- Manually download this specific variant during runtime: https://cloudsmith.io/~jillejr/repos/newtonsoft-json-for-unity/packages/detail/npm/jillejr.newtonsoft.json-for-unity/13.0.102 -->
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\RulesAPI_Core\RulesAPI_Core.csproj">


### PR DESCRIPTION
Resolves https://github.com/orendain/DemeoMods/issues/124.

When running the mod, the `Newtonsoft.Json.dll` DLL must be added to the `UserLibs` folder of the Demeo game directory:

I am attaching the DLL (within a ZIP file) here, for reference:  [Newtonsoft.Json.zip](https://github.com/orendain/DemeoMods/files/8017067/Newtonsoft.Json.zip)

Alternatively, one can download and extract `Newtonsoft.Json.dll` from:
https://cloudsmith.io/~jillejr/repos/newtonsoft-json-for-unity/packages/detail/npm/jillejr.newtonsoft.json-for-unity/13.0.102

The library referenced in `.csproj` is API-equivalent for compiling purposes, but won't run on the Oculus version, hence the instructions above to download one manually.  The one I shared above [is a Unity-friendly variant](https://github.com/jilleJr/Newtonsoft.Json-for-Unity) of the one specified in `.csproj`.