### PR TITLE
Fix card limit rule assuming the card limit was 0 by default.

### DIFF
--- a/HouseRules_Essentials/Rules/CardLimitModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/CardLimitModifiedRule.cs
@@ -10,6 +10,7 @@
     {
         public override string Description => "Card limit is modified";
 
+        private const int MaxLimit = 100;
         private static int _limit;
         private static bool _isActivated;
 
@@ -48,7 +49,7 @@
             {
                 if (instruction.opcode == OpCodes.Ldc_I4_S && instruction.operand.ToString().Contains("11"))
                 {
-                    yield return new CodeInstruction(OpCodes.Ldc_I4_S, _limit);
+                    yield return new CodeInstruction(OpCodes.Ldc_I4_S, MaxLimit);
                     continue;
                 }
 
@@ -62,7 +63,7 @@
             {
                 if (instruction.opcode == OpCodes.Ldc_R4 && instruction.operand.ToString().Contains("11"))
                 {
-                    yield return new CodeInstruction(OpCodes.Ldc_R4, (float)_limit);
+                    yield return new CodeInstruction(OpCodes.Ldc_R4, (float)MaxLimit);
                     continue;
                 }
 


### PR DESCRIPTION
Since the game patch is applied exactly once at game init time, the limit is set to `0` unless the rule is instantiated somewhere in the code before patch time.  Thanks @jimconner for catching this.

This PR increases the max hand limit to a constant (`100` was an arbitrary number), so that the _max_ limit is increased whether or not the rule is used.

That is not to say that the max hand size is always `MaxLimit` - that is just the max limit that the game now allows.  The practical max is still modified in lines `76-81` of the code, and behaves as expect (or at least, it should).