### PR TITLE
Move HomeRules types (e.g., Rule, all rule interfaces, Ruleset) to 'Types' namespace.

### DIFF
--- a/HouseRules_Configuration/ConfigManager.cs
+++ b/HouseRules_Configuration/ConfigManager.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using HarmonyLib;
+    using HouseRules.Types;
     using MelonLoader;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;

--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -38,7 +38,7 @@
 
             try
             {
-                HouseRules.SelectRuleset(rulesetName);
+                HR.SelectRuleset(rulesetName);
             }
             catch (ArgumentException e)
             {
@@ -48,7 +48,7 @@
 
         public override void OnApplicationQuit()
         {
-            var rulesetName = HouseRules.SelectedRuleset != null ? HouseRules.SelectedRuleset.Name : string.Empty;
+            var rulesetName = HR.SelectedRuleset != null ? HR.SelectedRuleset.Name : string.Empty;
             ConfigManager.SetRuleset(rulesetName);
             ConfigManager.Save();
         }

--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using DataKeys;
+    using HouseRules.Types;
     using MelonLoader;
 
     internal class ConfigurationMod : MelonMod

--- a/HouseRules_Core/CoreMod.cs
+++ b/HouseRules_Core/CoreMod.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using HarmonyLib;
+    using HouseRules.Types;
     using MelonLoader;
 
     internal class CoreMod : MelonMod

--- a/HouseRules_Core/CoreMod.cs
+++ b/HouseRules_Core/CoreMod.cs
@@ -24,16 +24,16 @@
         {
             var patchableRules = Registrar.Instance().RuleTypes.Where(typ => typeof(IPatchable).IsAssignableFrom(typ)).ToList();
 
-            HouseRules.Logger.Msg($"Found [{patchableRules.Count}] registered rules that require game patching.");
+            HR.Logger.Msg($"Found [{patchableRules.Count}] registered rules that require game patching.");
 
             foreach (var ruleType in patchableRules)
             {
-                HouseRules.Logger.Msg($"Patching game with rule type: {ruleType}");
+                HR.Logger.Msg($"Patching game with rule type: {ruleType}");
 
                 var traverse = Traverse.Create(ruleType).Method("Patch", paramTypes: new[] { typeof(Harmony) }, arguments: new object[] { RulesPatcher });
                 if (!traverse.MethodExists())
                 {
-                    HouseRules.Logger.Warning($"Could not find expected Patch method for rule [{ruleType}]. Skipping patching for that rule.");
+                    HR.Logger.Warning($"Could not find expected Patch method for rule [{ruleType}]. Skipping patching for that rule.");
                     continue;
                 }
 
@@ -44,7 +44,7 @@
                 catch (Exception e)
                 {
                     // TODO(orendain): Perm disable rules/rulesets that fail to patch/load.
-                    HouseRules.Logger.Error($"Failed to patch game with rule type [{ruleType}]: {e}");
+                    HR.Logger.Error($"Failed to patch game with rule type [{ruleType}]: {e}");
                 }
             }
         }

--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -4,6 +4,7 @@ namespace HouseRules
     using System.Linq;
     using System.Text;
     using Boardgame;
+    using HouseRules.Types;
     using MelonLoader;
 
     public static class HR

--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -6,7 +6,7 @@ namespace HouseRules
     using Boardgame;
     using MelonLoader;
 
-    public static class HouseRules
+    public static class HR
     {
         internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("HouseRules:Core");
         private const float WelcomeMessageDurationSeconds = 30f;

--- a/HouseRules_Core/HouseRules_Core.csproj
+++ b/HouseRules_Core/HouseRules_Core.csproj
@@ -47,15 +47,15 @@
         </Reference>
     </ItemGroup>
     <ItemGroup>
-        <Compile Include="IPatchable.cs" />
-        <Compile Include="IConfigWritable.cs" />
         <Compile Include="ModPatcher.cs" />
         <Compile Include="Properties\AssemblyInfo.cs" />
-        <Compile Include="Rule.cs" />
         <Compile Include="HR.cs" />
-        <Compile Include="Ruleset.cs" />
         <Compile Include="CoreMod.cs" />
         <Compile Include="Registrar.cs" />
+        <Compile Include="Types\IConfigWritable.cs" />
+        <Compile Include="Types\IPatchable.cs" />
+        <Compile Include="Types\Rule.cs" />
+        <Compile Include="Types\Ruleset.cs" />
     </ItemGroup>
     <ItemGroup>
         <Content Include="README.md" />

--- a/HouseRules_Core/HouseRules_Core.csproj
+++ b/HouseRules_Core/HouseRules_Core.csproj
@@ -52,7 +52,7 @@
         <Compile Include="ModPatcher.cs" />
         <Compile Include="Properties\AssemblyInfo.cs" />
         <Compile Include="Rule.cs" />
-        <Compile Include="HouseRules.cs" />
+        <Compile Include="HR.cs" />
         <Compile Include="Ruleset.cs" />
         <Compile Include="CoreMod.cs" />
         <Compile Include="Registrar.cs" />

--- a/HouseRules_Core/ModPatcher.cs
+++ b/HouseRules_Core/ModPatcher.cs
@@ -62,10 +62,9 @@
                 return;
             }
 
-            HouseRules.TriggerActivateRuleset(_gameContext);
-
+            HR.TriggerActivateRuleset(_gameContext);
             _isStartingGame = true;
-            HouseRules.TriggerPreGameCreated(_gameContext);
+            HR.TriggerPreGameCreated(_gameContext);
         }
 
         private static void GameStateMachine_GoToPlayingState_Postfix()
@@ -76,25 +75,25 @@
             }
 
             _isStartingGame = false;
-            HouseRules.TriggerPostGameCreated(_gameContext);
-            HouseRules.TriggerWelcomeMessage();
+            HR.TriggerPostGameCreated(_gameContext);
+            HR.TriggerWelcomeMessage();
         }
 
         private static void PostGameControllerBase_OnPlayAgainClicked_Postfix()
         {
-            HouseRules.TriggerActivateRuleset(_gameContext);
+            HR.TriggerActivateRuleset(_gameContext);
             _isStartingGame = true;
-            HouseRules.TriggerPreGameCreated(_gameContext);
+            HR.TriggerPreGameCreated(_gameContext);
         }
 
         private static void GameStateMachine_EndGame_Prefix()
         {
-            HouseRules.TriggerDeactivateRuleset(_gameContext);
+            HR.TriggerDeactivateRuleset(_gameContext);
         }
 
         private static void SerializableEventQueue_DisconnectLocalPlayer_Prefix()
         {
-            HouseRules.TriggerDeactivateRuleset(_gameContext);
+            HR.TriggerDeactivateRuleset(_gameContext);
         }
     }
 }

--- a/HouseRules_Core/Registrar.cs
+++ b/HouseRules_Core/Registrar.cs
@@ -32,7 +32,7 @@
         // TODO(orendain): Disallow registration after a certain point in init process.
         public void Register(Type ruleType)
         {
-            HouseRules.Logger.Msg($"Registering rule type: {ruleType}");
+            HR.Logger.Msg($"Registering rule type: {ruleType}");
 
             if (RuleTypes.Contains(ruleType))
             {
@@ -49,7 +49,7 @@
 
         public void Register(Ruleset ruleset)
         {
-            HouseRules.Logger.Msg($"Registering ruleset: {ruleset.Name} (with {ruleset.Rules.Count} rules)");
+            HR.Logger.Msg($"Registering ruleset: {ruleset.Name} (with {ruleset.Rules.Count} rules)");
 
             if (IsRulesetRegistered(ruleset.Name))
             {

--- a/HouseRules_Core/Registrar.cs
+++ b/HouseRules_Core/Registrar.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using HouseRules.Types;
 
     public class Registrar
     {

--- a/HouseRules_Core/Types/IConfigWritable.cs
+++ b/HouseRules_Core/Types/IConfigWritable.cs
@@ -1,4 +1,4 @@
-﻿namespace HouseRules
+﻿namespace HouseRules.Types
 {
     /// <summary>
     /// Represents a rule whose configuration can be written.

--- a/HouseRules_Core/Types/IPatchable.cs
+++ b/HouseRules_Core/Types/IPatchable.cs
@@ -1,4 +1,4 @@
-﻿namespace HouseRules
+﻿namespace HouseRules.Types
 {
     public interface IPatchable
     {

--- a/HouseRules_Core/Types/Rule.cs
+++ b/HouseRules_Core/Types/Rule.cs
@@ -1,4 +1,4 @@
-﻿namespace HouseRules
+﻿namespace HouseRules.Types
 {
     using Boardgame;
 

--- a/HouseRules_Core/Types/Ruleset.cs
+++ b/HouseRules_Core/Types/Ruleset.cs
@@ -1,4 +1,4 @@
-﻿namespace HouseRules
+﻿namespace HouseRules.Types
 {
     using System.Collections.Generic;
 

--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -1,6 +1,8 @@
 ﻿namespace HouseRules.Essentials
 {
     using System.Collections.Generic;
+    using HouseRules.Essentials.Rules;
+    using HouseRules.Types;
     using MelonLoader;
 
     internal class EssentialsMod : MelonMod
@@ -16,31 +18,31 @@
         private static void RegisterNewRuleTypes()
         {
             var registrar = Registrar.Instance();
-            registrar.Register(typeof(Rules.SampleRule));
-            registrar.Register(typeof(Rules.AbilityAoeAdjustedRule));
-            registrar.Register(typeof(Rules.AbilityDamageAdjustedRule));
-            registrar.Register(typeof(Rules.AbilityActionCostAdjustedRule));
-            registrar.Register(typeof(Rules.ActionPointsAdjustedRule));
-            registrar.Register(typeof(Rules.CardEnergyFromAttackMultipliedRule));
-            registrar.Register(typeof(Rules.CardEnergyFromRecyclingMultipliedRule));
-            registrar.Register(typeof(Rules.CardLimitModifiedRule));
-            registrar.Register(typeof(Rules.CardSellValueMultipliedRule));
-            registrar.Register(typeof(Rules.EnemyAttackScaledRule));
-            registrar.Register(typeof(Rules.EnemyDoorOpeningDisabledRule));
-            registrar.Register(typeof(Rules.EnemyHealthScaledRule));
-            registrar.Register(typeof(Rules.EnemyRespawnDisabledRule));
-            registrar.Register(typeof(Rules.GoldPickedUpMultipliedRule));
-            registrar.Register(typeof(Rules.GoldPickedUpScaledRule));
-            registrar.Register(typeof(Rules.LevelPropertiesModifiedRule));
-            registrar.Register(typeof(Rules.PieceConfigAdjustedRule));
-            registrar.Register(typeof(Rules.RatNestsSpawnGoldRule));
-            registrar.Register(typeof(Rules.StartCardsModifiedRule));
-            registrar.Register(typeof(Rules.StartHealthAdjustedRule));
+            registrar.Register(typeof(SampleRule));
+            registrar.Register(typeof(AbilityAoeAdjustedRule));
+            registrar.Register(typeof(AbilityDamageAdjustedRule));
+            registrar.Register(typeof(AbilityActionCostAdjustedRule));
+            registrar.Register(typeof(ActionPointsAdjustedRule));
+            registrar.Register(typeof(CardEnergyFromAttackMultipliedRule));
+            registrar.Register(typeof(CardEnergyFromRecyclingMultipliedRule));
+            registrar.Register(typeof(CardLimitModifiedRule));
+            registrar.Register(typeof(CardSellValueMultipliedRule));
+            registrar.Register(typeof(EnemyAttackScaledRule));
+            registrar.Register(typeof(EnemyDoorOpeningDisabledRule));
+            registrar.Register(typeof(EnemyHealthScaledRule));
+            registrar.Register(typeof(EnemyRespawnDisabledRule));
+            registrar.Register(typeof(GoldPickedUpMultipliedRule));
+            registrar.Register(typeof(GoldPickedUpScaledRule));
+            registrar.Register(typeof(LevelPropertiesModifiedRule));
+            registrar.Register(typeof(PieceConfigAdjustedRule));
+            registrar.Register(typeof(RatNestsSpawnGoldRule));
+            registrar.Register(typeof(StartCardsModifiedRule));
+            registrar.Register(typeof(StartHealthAdjustedRule));
         }
 
         private static void RegisterNewRulesets()
         {
-            var sampleRules = new List<Rule> { new Rules.SampleRule() };
+            var sampleRules = new List<Rule> { new SampleRule() };
             var sampleRuleset = Ruleset.NewInstance("SampleRuleset", "Just a sample ruleset.", sampleRules);
 
             var registrar = Registrar.Instance();

--- a/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
@@ -5,6 +5,7 @@
     using Boardgame;
     using Boardgame.BoardEntities.Abilities;
     using HarmonyLib;
+    using HouseRules.Types;
     using UnityEngine;
 
     public sealed class AbilityAoeAdjustedRule : Rule, IConfigWritable<Dictionary<string, int>>

--- a/HouseRules_Essentials/Rules/AbilityActionCostAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityActionCostAdjustedRule.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using Boardgame;
     using Boardgame.BoardEntities.Abilities;
+    using HouseRules.Types;
     using UnityEngine;
 
     public sealed class AbilityActionCostAdjustedRule : Rule, IConfigWritable<Dictionary<string, bool>>

--- a/HouseRules_Essentials/Rules/AbilityDamageAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityDamageAdjustedRule.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using Boardgame;
     using Boardgame.BoardEntities.Abilities;
+    using HouseRules.Types;
     using UnityEngine;
 
     public sealed class AbilityDamageAdjustedRule : Rule, IConfigWritable<Dictionary<string, int>>

--- a/HouseRules_Essentials/Rules/ActionPointsAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/ActionPointsAdjustedRule.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using Boardgame;
     using HarmonyLib;
+    using HouseRules.Types;
     using UnityEngine;
 
     public sealed class ActionPointsAdjustedRule : Rule, IConfigWritable<Dictionary<string, int>>

--- a/HouseRules_Essentials/Rules/CardEnergyFromAttackMultipliedRule.cs
+++ b/HouseRules_Essentials/Rules/CardEnergyFromAttackMultipliedRule.cs
@@ -3,6 +3,7 @@
     using Boardgame;
     using Data.GameData;
     using HarmonyLib;
+    using HouseRules.Types;
 
     public sealed class CardEnergyFromAttackMultipliedRule : Rule, IConfigWritable<float>
     {

--- a/HouseRules_Essentials/Rules/CardEnergyFromRecyclingMultipliedRule.cs
+++ b/HouseRules_Essentials/Rules/CardEnergyFromRecyclingMultipliedRule.cs
@@ -2,6 +2,7 @@
 {
     using Boardgame;
     using HarmonyLib;
+    using HouseRules.Types;
 
     public sealed class CardEnergyFromRecyclingMultipliedRule : Rule, IConfigWritable<float>, IPatchable
     {

--- a/HouseRules_Essentials/Rules/CardLimitModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/CardLimitModifiedRule.cs
@@ -5,6 +5,7 @@
     using Boardgame;
     using Boardgame.BoardEntities;
     using HarmonyLib;
+    using HouseRules.Types;
 
     public sealed class CardLimitModifiedRule : Rule, IConfigWritable<int>, IPatchable
     {

--- a/HouseRules_Essentials/Rules/CardSellValueMultipliedRule.cs
+++ b/HouseRules_Essentials/Rules/CardSellValueMultipliedRule.cs
@@ -3,6 +3,7 @@
     using System.Reflection;
     using Boardgame;
     using HarmonyLib;
+    using HouseRules.Types;
 
     public sealed class CardSellValueMultipliedRule : Rule, IConfigWritable<float>, IPatchable
     {

--- a/HouseRules_Essentials/Rules/EnemyAttackScaledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyAttackScaledRule.cs
@@ -3,6 +3,7 @@
     using Boardgame;
     using DataKeys;
     using HarmonyLib;
+    using HouseRules.Types;
 
     public sealed class EnemyAttackScaledRule : Rule, IConfigWritable<float>, IPatchable
     {

--- a/HouseRules_Essentials/Rules/EnemyDoorOpeningDisabledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyDoorOpeningDisabledRule.cs
@@ -2,6 +2,7 @@
 {
     using Boardgame;
     using HarmonyLib;
+    using HouseRules.Types;
 
     public sealed class EnemyDoorOpeningDisabledRule : Rule, IConfigWritable<bool>, IPatchable
     {

--- a/HouseRules_Essentials/Rules/EnemyHealthScaledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyHealthScaledRule.cs
@@ -3,6 +3,7 @@
     using Boardgame;
     using DataKeys;
     using HarmonyLib;
+    using HouseRules.Types;
 
     public sealed class EnemyHealthScaledRule : Rule, IConfigWritable<float>, IPatchable
     {

--- a/HouseRules_Essentials/Rules/EnemyRespawnDisabledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyRespawnDisabledRule.cs
@@ -3,6 +3,7 @@
     using Boardgame;
     using Boardgame.AIDirector;
     using HarmonyLib;
+    using HouseRules.Types;
 
     public sealed class EnemyRespawnDisabledRule : Rule, IConfigWritable<bool>, IPatchable
     {

--- a/HouseRules_Essentials/Rules/GoldPickedUpMultipliedRule.cs
+++ b/HouseRules_Essentials/Rules/GoldPickedUpMultipliedRule.cs
@@ -4,6 +4,7 @@
     using Boardgame.Data;
     using Boardgame.SerializableEvents;
     using HarmonyLib;
+    using HouseRules.Types;
 
     public sealed class GoldPickedUpMultipliedRule : Rule, IPatchable
     {

--- a/HouseRules_Essentials/Rules/GoldPickedUpScaledRule.cs
+++ b/HouseRules_Essentials/Rules/GoldPickedUpScaledRule.cs
@@ -4,6 +4,7 @@
     using Boardgame.Data;
     using Boardgame.SerializableEvents;
     using HarmonyLib;
+    using HouseRules.Types;
 
     public sealed class GoldPickedUpScaledRule : Rule, IConfigWritable<float>, IPatchable
     {

--- a/HouseRules_Essentials/Rules/LevelPropertiesModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/LevelPropertiesModifiedRule.cs
@@ -5,6 +5,7 @@
     using Boardgame.PlayerData;
     using Data.GameData;
     using HarmonyLib;
+    using HouseRules.Types;
 
     public sealed class LevelPropertiesModifiedRule : Rule, IConfigWritable<Dictionary<string, int>>
     {

--- a/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using Boardgame;
     using HarmonyLib;
+    using HouseRules.Types;
     using UnityEngine;
 
     public sealed class PieceConfigAdjustedRule : Rule, IConfigWritable<List<List<string>>>

--- a/HouseRules_Essentials/Rules/RatNestsSpawnGoldRule.cs
+++ b/HouseRules_Essentials/Rules/RatNestsSpawnGoldRule.cs
@@ -4,6 +4,7 @@
     using Boardgame;
     using Boardgame.BoardEntities.Abilities;
     using DataKeys;
+    using HouseRules.Types;
     using UnityEngine;
 
     public sealed class RatNestsSpawnGoldRule : Rule, IConfigWritable<int>

--- a/HouseRules_Essentials/Rules/SampleRule.cs
+++ b/HouseRules_Essentials/Rules/SampleRule.cs
@@ -1,6 +1,8 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
     using Boardgame;
+    using HarmonyLib;
+    using HouseRules.Types;
 
     /// <summary>
     /// Represents a modular gameplay modification.
@@ -70,7 +72,7 @@
         /// Rules should use a static flag (e.g., <c>_isActivated</c>) in the patched method to
         /// ensure it makes modifications only when it is activated.
         /// </remarks>
-        private static void Patch(HarmonyLib.Harmony harmony)
+        private static void Patch(Harmony harmony)
         {
         }
     }

--- a/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
@@ -7,6 +7,7 @@
     using Boardgame.BoardEntities;
     using DataKeys;
     using HarmonyLib;
+    using HouseRules.Types;
 
     public sealed class StartCardsModifiedRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<StartCardsModifiedRule.CardConfig>>>, IPatchable
     {

--- a/HouseRules_Essentials/Rules/StartHealthAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/StartHealthAdjustedRule.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using Boardgame;
     using HarmonyLib;
+    using HouseRules.Types;
     using UnityEngine;
 
     public sealed class StartHealthAdjustedRule : Rule, IConfigWritable<Dictionary<string, int>>


### PR DESCRIPTION
There have been a number of types, other than just `Rule` and `Rulesets`, that need to be organized.  In fact, at least 1 more type may be incoming soon.  Will benefit if these were moved to a `Types` sub namespace.

- Move HomeRules types (e.g., Rule, all rule interfaces, Ruleset) to 'Types' namespace.
- Rename HouseRules class to HR so as to not cause namespace conflicts.
  - Arguably not the best name (`HR`), but can change later.  For now, had to change it to something other than `HouseRules` as that is the name of the base namespace directly preceeding the class, causing issues.