### PR TITLE
Establish how to separate ruleset definitions from one another.

### DIFF
--- a/HouseRules_Core/Types/Ruleset.cs
+++ b/HouseRules_Core/Types/Ruleset.cs
@@ -1,6 +1,7 @@
 ﻿namespace HouseRules.Types
 {
     using System.Collections.Generic;
+    using System.Linq;
 
     public class Ruleset
     {
@@ -18,6 +19,11 @@
         /// Gets the rules of the ruleset.
         /// </summary>
         public List<Rule> Rules { get; }
+
+        public static Ruleset NewInstance(string name, string description, params Rule[] rules)
+        {
+            return new Ruleset(name, description, rules.ToList());
+        }
 
         public static Ruleset NewInstance(string name, string description, List<Rule> rules)
         {

--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using HouseRules.Essentials.Rules;
+    using HouseRules.Essentials.Rulesets;
     using HouseRules.Types;
     using MelonLoader;
 
@@ -41,10 +42,7 @@
 
         private static void RegisterRulesets()
         {
-            var sampleRules = new List<Rule> { new SampleRule() };
-            var sampleRuleset = Ruleset.NewInstance("SampleRuleset", "Just a sample ruleset.", sampleRules);
-
-            HR.Rulebook.Register(sampleRuleset);
+            HR.Rulebook.Register(SampleRuleset.Create());
         }
     }
 }

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="EssentialsMod.cs" />
+    <Compile Include="Rulesets\SampleRuleset.cs" />
     <Compile Include="Rules\AbilityActionCostAdjustedRule.cs" />
     <Compile Include="Rules\AbilityDamageAdjustedRule.cs" />
     <Compile Include="Rules\ActionPointsAdjustedRule.cs" />

--- a/HouseRules_Essentials/Rulesets/SampleRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/SampleRuleset.cs
@@ -1,0 +1,18 @@
+﻿namespace HouseRules.Essentials.Rulesets
+{
+    using HouseRules.Essentials.Rules;
+    using HouseRules.Types;
+
+    internal static class SampleRuleset
+    {
+        internal static Ruleset Create()
+        {
+            const string name = "SampleRuleset";
+            const string description = "Just a sample ruleset.";
+
+            var sampleRule = new SampleRule();
+
+            return Ruleset.NewInstance(name, description, sampleRule);
+        }
+    }
+}


### PR DESCRIPTION
**Changes:**
- Add overloaded static method for creating Ruleset without the need to create a list of rules.
  - Instead of having to create a `List<Rule>` before calling `Ruleset.NewInstance(...)`, we can now optionally pass in the rules directly, no matter how many there are.
  - Example:  `Ruleset.NewInstance("MyRuleset", "descriptionHere", myRule1, myRule2, myRule3)`
- Moved sample ruleset to its own file.
  - While rulesets can be defined in very few lines of code, and there's really no functional purpose to moving them to their own file, this makes it easier to find them and maintain them over time.

