### PR TITLE
Add rulesets for easy/hard/legendary difficulty.

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -43,6 +43,9 @@
         private static void RegisterRulesets()
         {
             HR.Rulebook.Register(SampleRuleset.Create());
+            HR.Rulebook.Register(DifficultyEasyRuleset.Create());
+            HR.Rulebook.Register(DifficultyHardRuleset.Create());
+            HR.Rulebook.Register(DifficultyLegendaryRuleset.Create());
         }
     }
 }

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -34,6 +34,9 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="EssentialsMod.cs" />
+    <Compile Include="Rulesets\DifficultyEasyRuleset.cs" />
+    <Compile Include="Rulesets\DifficultyHardRuleset.cs" />
+    <Compile Include="Rulesets\DifficultyLegendaryRuleset.cs" />
     <Compile Include="Rulesets\SampleRuleset.cs" />
     <Compile Include="Rules\AbilityActionCostAdjustedRule.cs" />
     <Compile Include="Rules\AbilityDamageAdjustedRule.cs" />

--- a/HouseRules_Essentials/Rulesets/DifficultyEasyRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/DifficultyEasyRuleset.cs
@@ -1,0 +1,23 @@
+﻿namespace HouseRules.Essentials.Rulesets
+{
+    using HouseRules.Essentials.Rules;
+    using HouseRules.Types;
+
+    internal static class DifficultyEasyRuleset
+    {
+        internal static Ruleset Create()
+        {
+            const string name = "Difficulty: Easy";
+            const string description = "This mode decreases the default game difficulty for a more casual playstyle.";
+
+            return Ruleset.NewInstance(
+                name,
+                description,
+                new EnemyDoorOpeningDisabledRule(true),
+                new EnemyRespawnDisabledRule(true),
+                new CardEnergyFromAttackMultipliedRule(1.5f),
+                new EnemyHealthScaledRule(0.8f),
+                new EnemyAttackScaledRule(0.6f));
+        }
+    }
+}

--- a/HouseRules_Essentials/Rulesets/DifficultyHardRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/DifficultyHardRuleset.cs
@@ -1,0 +1,21 @@
+﻿namespace HouseRules.Essentials.Rulesets
+{
+    using HouseRules.Essentials.Rules;
+    using HouseRules.Types;
+
+    internal static class DifficultyHardRuleset
+    {
+        internal static Ruleset Create()
+        {
+            const string name = "Difficulty: Hard";
+            const string description = "This mode increases the default game difficulty for a greater challenge.";
+
+            return Ruleset.NewInstance(
+                name,
+                description,
+                new CardEnergyFromAttackMultipliedRule(0.8f),
+                new EnemyHealthScaledRule(1.2f),
+                new EnemyAttackScaledRule(1.2f));
+        }
+    }
+}

--- a/HouseRules_Essentials/Rulesets/DifficultyLegendaryRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/DifficultyLegendaryRuleset.cs
@@ -1,0 +1,21 @@
+﻿namespace HouseRules.Essentials.Rulesets
+{
+    using HouseRules.Essentials.Rules;
+    using HouseRules.Types;
+
+    internal static class DifficultyLegendaryRuleset
+    {
+        internal static Ruleset Create()
+        {
+            const string name = "Difficulty: Legendary";
+            const string description = "This mode increases the default game difficulty for those who want to be a legend.";
+
+            return Ruleset.NewInstance(
+                name,
+                description,
+                new CardEnergyFromAttackMultipliedRule(0.6f),
+                new EnemyHealthScaledRule(1.4f),
+                new EnemyAttackScaledRule(1.4f));
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/orendain/DemeoMods/issues/109.

Marking this PR as a draft until @Buruko gets a chance to try it out and make appropriate tweaks.

Credit to @Buruko for drawing up the following, which is now translated to code:
```
"Difficulty: Easy"
This mode decreases the default game difficulty for a more casual playstyle.

Rules:
EnemyDoorOpeningDisabled
EnemyRespawnDisabled
CardEnergyFromAttackMultiplied (1.5)
EnemyHealthScaled (.8) 20% reduction
EnemyAttackScaled (.6) 40% reduction

"Difficulty: Hard"
This mode increases the default game difficulty for a greater challenge.

Rules:
CardEnergyFromAttackMultiplied (.8)
EnemyHealthScaled (1.2) 20% increase
EnemyAttackScaled (1.2) 20% increase

"Difficutly: Legendary"
This mode increases the default game difficulty for those who want to be a legend.

Rules:
CardEnergyFromAttackMultiplied (.6)
EnemyHealthScaled (1.4) 40% increase
EnemyAttackScaled (1.4) 40% increase
```