### PR TITLE
Implement full JSON ruleset export/import.

### DIFF
--- a/HouseRules_Configuration/ConfigManager.cs
+++ b/HouseRules_Configuration/ConfigManager.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Security.AccessControl;
     using HarmonyLib;
     using HouseRules.Types;
     using MelonLoader;

--- a/HouseRules_Configuration/ConfigManager.cs
+++ b/HouseRules_Configuration/ConfigManager.cs
@@ -2,6 +2,8 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
+    using System.Security.AccessControl;
     using HarmonyLib;
     using HouseRules.Types;
     using MelonLoader;
@@ -52,13 +54,11 @@
         }
 
         /// <summary>
-        /// Writes the specified ruleset to the configuration file.
+        /// Exports the specified ruleset by writing it to a file.
         /// </summary>
-        /// <param name="ruleset">The ruleset to write.</param>
-        /// <remarks>
-        /// The ruleset is saved under a category with the same name as the ruleset.
-        /// </remarks>
-        public static void WriteRuleset(Ruleset ruleset)
+        /// <param name="ruleset">The ruleset to export.</param>
+        /// <returns>The path of the file that the ruleset was written to.</returns>
+        public static string ExportRuleset(Ruleset ruleset)
         {
             ConfigureDefaultSerializationSettings();
 
@@ -66,8 +66,6 @@
             {
                 throw new ArgumentException("Ruleset name must not be empty.");
             }
-
-            var configCategory = MelonPreferences.CreateCategory(ruleset.Name);
 
             var ruleEntries = new List<RuleConfigEntry>();
             foreach (var rule in ruleset.Rules)
@@ -86,31 +84,39 @@
                 }
             }
 
-            var serializedRuleEntries = JsonConvert.SerializeObject(ruleEntries);
+            var rulesetConfig = new RulesetConfig
+            {
+                Name = ruleset.Name,
+                Description = ruleset.Description,
+                Rules = ruleEntries,
+            };
+            var serializedRuleset = JsonConvert.SerializeObject(rulesetConfig);
 
-            configCategory.CreateEntry("name", string.Empty).Value = ruleset.Name;
-            configCategory.CreateEntry("description", string.Empty).Value = ruleset.Description;
-            configCategory.CreateEntry("rules", string.Empty).Value = serializedRuleEntries;
-            configCategory.SaveToFile();
+            var houseRulesDataDir = Path.Combine(MelonUtils.UserDataDirectory, "HouseRules");
+            var rulesetFilePath = Path.Combine(houseRulesDataDir, $"{ruleset.Name}.json");
+            Directory.CreateDirectory(houseRulesDataDir);
+            File.WriteAllText(rulesetFilePath, serializedRuleset);
+
+            ConfigurationMod.Logger.Msg($"Successfully exported ruleset to: {rulesetFilePath}");
+
+            return rulesetFilePath;
         }
 
         /// <summary>
-        /// Reads a ruleset from the configuration file.
+        /// Imports a ruleset by name.
         /// </summary>
-        /// <param name="configName">The name under which the desired ruleset is written.</param>
-        /// <returns>The ruleset read from configuration.</returns>
-        internal static Ruleset ReadRuleset(string configName)
+        /// <param name="rulesetName">The name of the ruleset to import, saved as a JSON file at an internally-resolved location.</param>
+        /// <returns>The imported ruleset.</returns>
+        internal static Ruleset ImportRuleset(string rulesetName)
         {
             ConfigureDefaultSerializationSettings();
 
-            var configCategory = MelonPreferences.CreateCategory(configName);
-
-            var rulesetNameEntry = configCategory.CreateEntry("name", string.Empty);
-            var descriptionEntry = configCategory.CreateEntry("description", string.Empty);
-            var rulesEntry = configCategory.CreateEntry("rules", string.Empty);
+            var rulesetFilePath = Path.Combine(MelonUtils.UserDataDirectory, "HouseRules", $"{rulesetName}.json");
+            var rulesetJson = File.ReadAllText(rulesetFilePath);
+            var rulesetConfig = JsonConvert.DeserializeObject<RulesetConfig>(rulesetJson);
 
             var rules = new List<Rule>();
-            foreach (var ruleConfigEntry in JsonConvert.DeserializeObject<List<RuleConfigEntry>>(rulesEntry.Value))
+            foreach (var ruleConfigEntry in rulesetConfig.Rules)
             {
                 try
                 {
@@ -125,7 +131,8 @@
                 }
             }
 
-            return Ruleset.NewInstance(rulesetNameEntry.Value, descriptionEntry.Value, rules);
+            ConfigurationMod.Logger.Msg($"Successfully imported ruleset from: {rulesetFilePath}");
+            return Ruleset.NewInstance(rulesetConfig.Name, rulesetConfig.Description, rules);
         }
 
         private static (Type RuleType, Type ConfigType) FindRuleAndConfigType(string ruleName)
@@ -180,6 +187,13 @@
                 Formatting = Formatting.Indented,
                 Converters = { new Newtonsoft.Json.Converters.StringEnumConverter() },
             };
+        }
+
+        private struct RulesetConfig
+        {
+            public string Name;
+            public string Description;
+            public List<RuleConfigEntry> Rules;
         }
 
         private struct RuleConfigEntry

--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -27,7 +27,7 @@
             {
                 try
                 {
-                    var ruleset = ConfigManager.ReadRuleset(rulesetName);
+                    var ruleset = ConfigManager.ImportRuleset(rulesetName);
                     HR.Rulebook.Register(ruleset);
                     Logger.Msg($"Loaded and registered ruleset from config: {rulesetName}");
                 }
@@ -127,7 +127,7 @@
                 aaca, aaa, ada, apa, cefam1, cefam2, cefam3, cefam4, cefrm, csvm, eas, edod, ehs, erd, gpus, pca, rnsg, sscm, sha,
             });
 
-            ConfigManager.WriteRuleset(customRuleset);
+            ConfigManager.ExportRuleset(customRuleset);
         }
     }
 }


### PR DESCRIPTION
As discussed here: https://github.com/orendain/DemeoMods/pull/131#discussion_r801100158

The same flow as before still applies, except:
- `WriteRuleset(myRuleset)` now becomes `ExportRuleset(myRuleset)`.
- `ReadRuleset(rulesetName)` now becomes `ImportRuleset(rulesetName)`.

Stored in `<DemeoDir>/UserData/HouseRules/<ruleset-name>.json`.