### PR TITLE
Add in-game UI for HouseRules.

### DIFF
--- a/Common/UI/UiHelper.cs
+++ b/Common/UI/UiHelper.cs
@@ -93,7 +93,7 @@
             textMeshPro.fontSize = fontSize;
             textMeshPro.fontSizeMax = fontSize;
             textMeshPro.fontSizeMin = 1;
-            textMeshPro.enableAutoSizing = false;
+            textMeshPro.enableAutoSizing = true;
             textMeshPro.transform.localPosition = new Vector3(0, 0, -0.2f);
 
             return WrapObject(textObject);

--- a/Common/UI/UiHelper.cs
+++ b/Common/UI/UiHelper.cs
@@ -93,7 +93,7 @@
             textMeshPro.fontSize = fontSize;
             textMeshPro.fontSizeMax = fontSize;
             textMeshPro.fontSizeMin = 1;
-            textMeshPro.enableAutoSizing = true;
+            textMeshPro.enableAutoSizing = false;
             textMeshPro.transform.localPosition = new Vector3(0, 0, -0.2f);
 
             return WrapObject(textObject);

--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -5,16 +5,20 @@
     using DataKeys;
     using HouseRules.Types;
     using MelonLoader;
+    using UnityEngine;
 
     internal class ConfigurationMod : MelonMod
     {
         internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("HouseRules:Configuration");
         private static readonly ConfigManager ConfigManager = ConfigManager.NewInstance();
+        private const int LobbySceneIndex = 1;
+
+        private GameObject _rulesetSelectionUI;
 
         public override void OnApplicationLateStart()
         {
             // TODO(orendain): Remove when this demo code is no longer necessary.
-            // DemoWriteRuleset();
+            DemoWriteRuleset();
 
             var rulesetName = ConfigManager.GetRuleset();
             if (string.IsNullOrEmpty(rulesetName))
@@ -44,6 +48,14 @@
             catch (ArgumentException e)
             {
                 Logger.Warning($"Failed to select ruleset [{rulesetName}]: {e}");
+            }
+        }
+
+        public override void OnSceneWasInitialized(int buildIndex, string sceneName)
+        {
+            if (buildIndex == LobbySceneIndex)
+            {
+                _rulesetSelectionUI = new GameObject("RulesetSelectionUI", typeof(UI.RulesetSelectionUI));
             }
         }
 

--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -18,7 +18,7 @@
         public override void OnApplicationLateStart()
         {
             // TODO(orendain): Remove when this demo code is no longer necessary.
-            DemoWriteRuleset();
+            // DemoWriteRuleset();
 
             var rulesetName = ConfigManager.GetRuleset();
             if (string.IsNullOrEmpty(rulesetName))

--- a/HouseRules_Configuration/HouseRules_Configuration.csproj
+++ b/HouseRules_Configuration/HouseRules_Configuration.csproj
@@ -38,11 +38,29 @@
         <Reference Include="MelonLoader">
             <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
         </Reference>
+        <Reference Include="System" />
+        <Reference Include="Unity.TextMeshPro">
+            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+        </Reference>
+        <Reference Include="UnityEngine.CoreModule">
+            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+        </Reference>
+        <Reference Include="UnityEngine.PhysicsModule">
+            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+        </Reference>
+        <Reference Include="UnityEngine.UI">
+            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.UI.dll</HintPath>
+        </Reference>
     </ItemGroup>
     <ItemGroup>
         <Compile Include="ConfigManager.cs" />
         <Compile Include="ConfigurationMod.cs" />
         <Compile Include="Properties\AssemblyInfo.cs" />
+        <Compile Include="UI\RulesetSelectionUI.cs" />
+        <Compile Include="UI\RulesetSelectionPanel.cs" />
+        <Compile Include="..\Common\**\*.cs" Exclude="..\Common\Properties\AssemblyInfo.cs;..\Common\bin\**\*.*;..\Common\obj\**\*.*;..\Common\**\*.csproj;..\Common\**\*.user;..\Common\**\*.vstemplate">
+            <Link>Common\%(RecursiveDir)%(Filename)%(Extension)</Link>
+        </Compile>
     </ItemGroup>
     <ItemGroup>
         <!-- Manually download this specific variant during runtime: https://cloudsmith.io/~jillejr/repos/newtonsoft-json-for-unity/packages/detail/npm/jillejr.newtonsoft.json-for-unity/13.0.102 -->

--- a/HouseRules_Configuration/UI/RulesetSelectionPanel.cs
+++ b/HouseRules_Configuration/UI/RulesetSelectionPanel.cs
@@ -1,0 +1,86 @@
+﻿namespace HouseRules.Configuration.UI
+{
+    using System;
+    using System.Linq;
+    using Common.UI;
+    using HouseRules.Types;
+    using UnityEngine;
+
+    internal class RulesetSelectionPanel
+    {
+        private readonly UiHelper _uiHelper;
+
+        private readonly Rulebook _rulebook;
+
+        internal GameObject GameObject { get; }
+
+        internal static RulesetSelectionPanel NewInstance(Rulebook rulebook, UiHelper uiHelper)
+        {
+            return new RulesetSelectionPanel(rulebook, uiHelper, new GameObject("RulesetSelectionPanel"));
+        }
+
+        private RulesetSelectionPanel(Rulebook rulebook, UiHelper uiHelper, GameObject panel)
+        {
+            this._rulebook = rulebook;
+            this._uiHelper = uiHelper;
+            this.GameObject = panel;
+
+            Render();
+        }
+
+        private void Render()
+        {
+            var headerContainer = CreateHeader();
+            headerContainer.transform.SetParent(GameObject.transform, worldPositionStays: false);
+
+            var rulesetsContainer = new GameObject("Rulesets");
+            rulesetsContainer.transform.SetParent(GameObject.transform, worldPositionStays: false);
+            rulesetsContainer.transform.localPosition = new Vector3(0, -1f, 0);
+
+            for (var i = 0; i < _rulebook.Rulesets.Count; i++)
+            {
+                var yOffset = i * -3f;
+                var rulesetRow = CreateRulesetRow(_rulebook.Rulesets.ElementAt(i));
+                rulesetRow.transform.SetParent(rulesetsContainer.transform, worldPositionStays: false);
+                rulesetRow.transform.localPosition = new Vector3(0, yOffset, 0);
+            }
+        }
+
+        private GameObject CreateHeader()
+        {
+            var headerContainer = new GameObject("RulesetSelectionHeader");
+
+            var infoText =
+                _uiHelper.CreateLabelText("Select a ruleset for your next private multiplayer game or skirmish.");
+            infoText.transform.SetParent(headerContainer.transform, worldPositionStays: false);
+            infoText.transform.localPosition = new Vector3(-1.5f, 0.3f, 0);
+
+            return headerContainer;
+        }
+
+        private GameObject CreateRulesetRow(Ruleset ruleset)
+        {
+            var roomRowContainer = new GameObject(ruleset.Name);
+
+            var button = _uiHelper.CreateButton(SelectRulesetAction(ruleset.Name));
+            button.transform.SetParent(roomRowContainer.transform, worldPositionStays: false);
+            button.transform.localScale = new Vector3(1, 1, 1);
+            button.transform.localPosition = new Vector3(0, 0, 0);
+
+            var buttonText = _uiHelper.CreateText(ruleset.Name, Color.white, UiHelper.DefaultLabelFontSize);
+            buttonText.transform.SetParent(roomRowContainer.transform, worldPositionStays: false);
+            buttonText.transform.localPosition = new Vector3(0, 0, 0);
+
+            var descriptionLabel = _uiHelper.CreateLabelText(ruleset.Description);
+            descriptionLabel.transform.SetParent(roomRowContainer.transform, worldPositionStays: false);
+            descriptionLabel.transform.localPosition = new Vector3(0, -1.2f, 0);
+
+            return roomRowContainer;
+        }
+
+        private static Action SelectRulesetAction(string rulesetName)
+        {
+            return () => HR.SelectRuleset(rulesetName);
+        }
+    }
+}

--- a/HouseRules_Configuration/UI/RulesetSelectionPanel.cs
+++ b/HouseRules_Configuration/UI/RulesetSelectionPanel.cs
@@ -35,12 +35,16 @@
 
             var rulesetsContainer = new GameObject("Rulesets");
             rulesetsContainer.transform.SetParent(GameObject.transform, worldPositionStays: false);
-            rulesetsContainer.transform.localPosition = new Vector3(0, -1f, 0);
+            rulesetsContainer.transform.localPosition = new Vector3(0, -2f, 0);
+
+            var rulesetRow = CreateRulesetRow(Ruleset.None);
+            rulesetRow.transform.SetParent(rulesetsContainer.transform, worldPositionStays: false);
+            rulesetRow.transform.localPosition = new Vector3(0, 0, 0);
 
             for (var i = 0; i < _rulebook.Rulesets.Count; i++)
             {
-                var yOffset = i * -3f;
-                var rulesetRow = CreateRulesetRow(_rulebook.Rulesets.ElementAt(i));
+                var yOffset = (i + 1) * -3f;
+                rulesetRow = CreateRulesetRow(_rulebook.Rulesets.ElementAt(i));
                 rulesetRow.transform.SetParent(rulesetsContainer.transform, worldPositionStays: false);
                 rulesetRow.transform.localPosition = new Vector3(0, yOffset, 0);
             }
@@ -50,10 +54,9 @@
         {
             var headerContainer = new GameObject("RulesetSelectionHeader");
 
-            var infoText =
-                _uiHelper.CreateLabelText("Select a ruleset for your next private multiplayer game or skirmish.");
+            var infoText = _uiHelper.CreateLabelText($"Select a ruleset for your next\nprivate multiplayer game or skirmish.");
             infoText.transform.SetParent(headerContainer.transform, worldPositionStays: false);
-            infoText.transform.localPosition = new Vector3(-1.5f, 0.3f, 0);
+            infoText.transform.localPosition = new Vector3(0f, 1f, 0);
 
             return headerContainer;
         }
@@ -64,16 +67,14 @@
 
             var button = _uiHelper.CreateButton(SelectRulesetAction(ruleset.Name));
             button.transform.SetParent(roomRowContainer.transform, worldPositionStays: false);
-            button.transform.localScale = new Vector3(1, 1, 1);
+            button.transform.localScale = new Vector3(2f, 2f, 1);
             button.transform.localPosition = new Vector3(0, 0, 0);
 
-            var buttonText = _uiHelper.CreateText(ruleset.Name, Color.white, UiHelper.DefaultLabelFontSize);
+            var buttonTextString = $"{ruleset.Name}\n{ruleset.Description}";
+
+            var buttonText = _uiHelper.CreateText(buttonTextString, Color.white, UiHelper.DefaultLabelFontSize);
             buttonText.transform.SetParent(roomRowContainer.transform, worldPositionStays: false);
             buttonText.transform.localPosition = new Vector3(0, 0, 0);
-
-            var descriptionLabel = _uiHelper.CreateLabelText(ruleset.Description);
-            descriptionLabel.transform.SetParent(roomRowContainer.transform, worldPositionStays: false);
-            descriptionLabel.transform.localPosition = new Vector3(0, -1.2f, 0);
 
             return roomRowContainer;
         }

--- a/HouseRules_Configuration/UI/RulesetSelectionUI.cs
+++ b/HouseRules_Configuration/UI/RulesetSelectionUI.cs
@@ -35,7 +35,7 @@
         private void Initialize()
         {
             this.transform.SetParent(_uiHelper.DemeoResource.LobbyAnchor.transform, worldPositionStays: true);
-            this.transform.position = new Vector3(33, 30, 0);
+            this.transform.position = new Vector3(32, 29.75f, -11);
             this.transform.rotation = Quaternion.Euler(0, 70, 0);
 
             _background = new GameObject("RulesetSelectionUIBackground");

--- a/HouseRules_Configuration/UI/RulesetSelectionUI.cs
+++ b/HouseRules_Configuration/UI/RulesetSelectionUI.cs
@@ -1,0 +1,63 @@
+﻿namespace HouseRules.Configuration.UI
+{
+    using System.Collections;
+    using Common.UI;
+    using UnityEngine;
+
+    internal class RulesetSelectionUI : MonoBehaviour
+    {
+        private UiHelper _uiHelper;
+        private GameObject _background;
+        private RulesetSelectionPanel _rulesetSelectionPanel;
+
+        private void Start()
+        {
+            StartCoroutine(WaitAndInitialize());
+        }
+
+        private IEnumerator WaitAndInitialize()
+        {
+            while (!UiHelper.IsReady())
+            {
+                ConfigurationMod.Logger.Msg("UI helper not yet ready. Trying again...");
+                yield return new WaitForSecondsRealtime(1);
+            }
+
+            ConfigurationMod.Logger.Msg("UI helper ready. Proceeding with initialization.");
+
+            _uiHelper = UiHelper.Instance();
+            _rulesetSelectionPanel = RulesetSelectionPanel.NewInstance(HR.Rulebook, _uiHelper);
+            Initialize();
+
+            ConfigurationMod.Logger.Msg("Initialization complete.");
+        }
+
+        private void Initialize()
+        {
+            this.transform.SetParent(_uiHelper.DemeoResource.LobbyAnchor.transform, worldPositionStays: true);
+            this.transform.position = new Vector3(-25, 30, 0);
+            this.transform.rotation = Quaternion.Euler(0, -40, 0);
+
+            _background = new GameObject("RulesetSelectionUIBackground");
+            _background.AddComponent<MeshFilter>().mesh = _uiHelper.DemeoResource.MenuBoxMesh;
+            _background.AddComponent<MeshRenderer>().material = _uiHelper.DemeoResource.MenuBoxMaterial;
+
+            _background.transform.SetParent(this.transform, worldPositionStays: false);
+            _background.transform.localPosition = new Vector3(0, -3.6f, 0);
+            _background.transform.localRotation =
+                Quaternion.Euler(-90, 0, 0); // Un-flip card from it's default face-up position.
+            _background.transform.localScale = new Vector3(2, 1, 2.5f);
+
+            var menuTitle = _uiHelper.CreateMenuHeaderText("HouseRules");
+            menuTitle.transform.SetParent(this.transform, worldPositionStays: false);
+            menuTitle.transform.localPosition = new Vector3(0, 2.375f, 0);
+
+            var selectionPanel = _rulesetSelectionPanel.GameObject;
+            selectionPanel.transform.SetParent(this.transform, worldPositionStays: false);
+            selectionPanel.transform.localPosition = new Vector3(-0, -1f, 0);
+
+            // TODO(orendain): Fix so that ray interacts with entire object.
+            this.gameObject.AddComponent<BoxCollider>();
+        }
+    }
+}

--- a/HouseRules_Configuration/UI/RulesetSelectionUI.cs
+++ b/HouseRules_Configuration/UI/RulesetSelectionUI.cs
@@ -35,22 +35,23 @@
         private void Initialize()
         {
             this.transform.SetParent(_uiHelper.DemeoResource.LobbyAnchor.transform, worldPositionStays: true);
-            this.transform.position = new Vector3(-25, 30, 0);
-            this.transform.rotation = Quaternion.Euler(0, -40, 0);
+            this.transform.position = new Vector3(33, 30, 0);
+            this.transform.rotation = Quaternion.Euler(0, 70, 0);
 
             _background = new GameObject("RulesetSelectionUIBackground");
             _background.AddComponent<MeshFilter>().mesh = _uiHelper.DemeoResource.MenuBoxMesh;
             _background.AddComponent<MeshRenderer>().material = _uiHelper.DemeoResource.MenuBoxMaterial;
 
             _background.transform.SetParent(this.transform, worldPositionStays: false);
-            _background.transform.localPosition = new Vector3(0, -3.6f, 0);
+            //
+            _background.transform.localPosition = new Vector3(0, -3.25f, 0);
             _background.transform.localRotation =
                 Quaternion.Euler(-90, 0, 0); // Un-flip card from it's default face-up position.
-            _background.transform.localScale = new Vector3(2, 1, 2.5f);
+            _background.transform.localScale = new Vector3(2.5f, 1, 2.5f);
 
             var menuTitle = _uiHelper.CreateMenuHeaderText("HouseRules");
             menuTitle.transform.SetParent(this.transform, worldPositionStays: false);
-            menuTitle.transform.localPosition = new Vector3(0, 2.375f, 0);
+            menuTitle.transform.localPosition = new Vector3(0, 2.725f, 0);
 
             var selectionPanel = _rulesetSelectionPanel.GameObject;
             selectionPanel.transform.SetParent(this.transform, worldPositionStays: false);

--- a/HouseRules_Configuration/UI/RulesetSelectionUI.cs
+++ b/HouseRules_Configuration/UI/RulesetSelectionUI.cs
@@ -43,7 +43,6 @@
             _background.AddComponent<MeshRenderer>().material = _uiHelper.DemeoResource.MenuBoxMaterial;
 
             _background.transform.SetParent(this.transform, worldPositionStays: false);
-            //
             _background.transform.localPosition = new Vector3(0, -3.25f, 0);
             _background.transform.localRotation =
                 Quaternion.Euler(-90, 0, 0); // Un-flip card from it's default face-up position.

--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -25,6 +25,11 @@ namespace HouseRules
                 throw new InvalidOperationException("May not select a new ruleset while one is currently active.");
             }
 
+            if (Ruleset.None.Name.Equals(ruleset, StringComparison.OrdinalIgnoreCase))
+            {
+                SelectedRuleset = Ruleset.None;
+            }
+
             if (!Rulebook.IsRulesetRegistered(ruleset))
             {
                 throw new ArgumentException("Ruleset must first be registered.");

--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -28,6 +28,8 @@ namespace HouseRules
             if (Ruleset.None.Name.Equals(ruleset, StringComparison.OrdinalIgnoreCase))
             {
                 SelectedRuleset = Ruleset.None;
+                Logger.Msg("Cleared selected ruleset.");
+                return;
             }
 
             if (!Rulebook.IsRulesetRegistered(ruleset))

--- a/HouseRules_Core/Rulebook.cs
+++ b/HouseRules_Core/Rulebook.cs
@@ -9,7 +9,7 @@
     {
         internal HashSet<Type> RuleTypes { get; }
 
-        internal HashSet<Ruleset> Rulesets { get; }
+        public HashSet<Ruleset> Rulesets { get; }
 
         internal static Rulebook NewInstance()
         {


### PR DESCRIPTION
Not the most robust UI, as long lines are not automatically wrapped.  Long ruleset descriptions will wrap at awkward lengths.  Leaving anything non-critical for another time.  We may just need to shorten ruleset descriptions for the time being if we don't want weird cut-offs.

![image](https://user-images.githubusercontent.com/1426304/153721400-b39786dc-7e38-48c1-9b12-2cb4e456b8cb.png)