### PR TITLE
Add abstraction for labelling rules as being safe for multiplayer use.

### DIFF
--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -152,13 +152,30 @@ namespace HouseRules
 
         internal static void TriggerWelcomeMessage()
         {
-            if (!_isRulesetActive)
+            if (SelectedRuleset == null)
             {
                 return;
             }
 
+            if (!_isRulesetActive)
+            {
+                GameUI.ShowCameraMessage(BuildNotSafeForMultiplayerMessage(), WelcomeMessageDurationSeconds);
+            }
+
+            GameUI.ShowCameraMessage(BuildRulesetActiveMessage(), WelcomeMessageDurationSeconds);
+        }
+
+        private static string BuildNotSafeForMultiplayerMessage()
+        {
+            return new StringBuilder("Notice:")
+                .AppendLine("The HouseRules ruleset you selected is not safe for multiplayer games, and was not activated.")
+                .ToString();
+        }
+
+        private static string BuildRulesetActiveMessage()
+        {
             var sb = new StringBuilder();
-            sb.AppendLine("Welcome to a game using House Rules!");
+            sb.AppendLine("Welcome to a game using HouseRules!");
             sb.AppendLine();
             sb.AppendFormat("{0}: {1}\n", SelectedRuleset.Name, SelectedRuleset.Description);
             sb.AppendLine();
@@ -168,7 +185,7 @@ namespace HouseRules
                 sb.AppendLine(rule.Description);
             }
 
-            GameUI.ShowCameraMessage(sb.ToString(), WelcomeMessageDurationSeconds);
+            return sb.ToString();
         }
     }
 }

--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -34,16 +34,22 @@ namespace HouseRules
             Logger.Msg($"Selected ruleset: {SelectedRuleset.Name}");
         }
 
-        internal static void TriggerActivateRuleset(GameContext gameContext)
+        internal static void TriggerActivateRuleset(GameContext gameContext, GameHub.GameMode gameMode)
         {
             if (_isRulesetActive)
             {
-                Logger.Warning("Ruleset activation was triggered while ruleset was already activated. This should not happen. Please report this to HouseRules developers.");
+                Logger.Warning("Ruleset activation was triggered whilst a ruleset was already activated. This should not happen. Please report this to HouseRules developers.");
                 return;
             }
 
             if (SelectedRuleset == null)
             {
+                return;
+            }
+
+            if (gameMode == GameHub.GameMode.Multiplayer && !SelectedRuleset.IsSafeForMultiplayer)
+            {
+                Logger.Warning($"Selected ruleset [{SelectedRuleset.Name}] is not safe for multiplayer games. Skipping ruleset activation.");
                 return;
             }
 

--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -103,6 +103,11 @@ namespace HouseRules
                 return;
             }
 
+            if (!_isRulesetActive)
+            {
+                return;
+            }
+
             foreach (var rule in SelectedRuleset.Rules)
             {
                 try
@@ -121,6 +126,11 @@ namespace HouseRules
         internal static void TriggerPostGameCreated(GameContext gameContext)
         {
             if (SelectedRuleset == null)
+            {
+                return;
+            }
+
+            if (!_isRulesetActive)
             {
                 return;
             }

--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -49,7 +49,7 @@ namespace HouseRules
 
             if (gameMode == GameHub.GameMode.Multiplayer && !SelectedRuleset.IsSafeForMultiplayer)
             {
-                Logger.Warning($"Selected ruleset [{SelectedRuleset.Name}] is not safe for multiplayer games. Skipping ruleset activation.");
+                Logger.Warning($"The selected ruleset [{SelectedRuleset.Name}] is not safe for multiplayer games. Skipping activation.");
                 return;
             }
 
@@ -160,6 +160,7 @@ namespace HouseRules
             if (!_isRulesetActive)
             {
                 GameUI.ShowCameraMessage(BuildNotSafeForMultiplayerMessage(), WelcomeMessageDurationSeconds);
+                return;
             }
 
             GameUI.ShowCameraMessage(BuildRulesetActiveMessage(), WelcomeMessageDurationSeconds);
@@ -167,7 +168,8 @@ namespace HouseRules
 
         private static string BuildNotSafeForMultiplayerMessage()
         {
-            return new StringBuilder("Notice:")
+            return new StringBuilder()
+                .AppendLine("Attention:")
                 .AppendLine("The HouseRules ruleset you selected is not safe for multiplayer games, and was not activated.")
                 .ToString();
         }
@@ -175,7 +177,7 @@ namespace HouseRules
         private static string BuildRulesetActiveMessage()
         {
             var sb = new StringBuilder();
-            sb.AppendLine("Welcome to a game using HouseRules!");
+            sb.AppendLine("Welcome to a game using House Rules!");
             sb.AppendLine();
             sb.AppendFormat("{0}: {1}\n", SelectedRuleset.Name, SelectedRuleset.Description);
             sb.AppendLine();

--- a/HouseRules_Core/HouseRules_Core.csproj
+++ b/HouseRules_Core/HouseRules_Core.csproj
@@ -53,6 +53,7 @@
         <Compile Include="CoreMod.cs" />
         <Compile Include="Rulebook.cs" />
         <Compile Include="Types\IConfigWritable.cs" />
+        <Compile Include="Types\IMultiplayerSafe.cs" />
         <Compile Include="Types\IPatchable.cs" />
         <Compile Include="Types\ISingular.cs" />
         <Compile Include="Types\Rule.cs" />

--- a/HouseRules_Core/ModPatcher.cs
+++ b/HouseRules_Core/ModPatcher.cs
@@ -62,7 +62,7 @@
                 return;
             }
 
-            HR.TriggerActivateRuleset(_gameContext);
+            HR.TriggerActivateRuleset(_gameContext, GameHub.GetGameMode);
             _isStartingGame = true;
             HR.TriggerPreGameCreated(_gameContext);
         }
@@ -81,7 +81,7 @@
 
         private static void PostGameControllerBase_OnPlayAgainClicked_Postfix()
         {
-            HR.TriggerActivateRuleset(_gameContext);
+            HR.TriggerActivateRuleset(_gameContext, GameHub.GetGameMode);
             _isStartingGame = true;
             HR.TriggerPreGameCreated(_gameContext);
         }

--- a/HouseRules_Core/Types/IMultiplayerSafe.cs
+++ b/HouseRules_Core/Types/IMultiplayerSafe.cs
@@ -1,0 +1,9 @@
+﻿namespace HouseRules.Types
+{
+    /// <summary>
+    /// Represents a rule that is safe to apply in a multiplayer environment.
+    /// </summary>
+    public interface IMultiplayerSafe
+    {
+    }
+}

--- a/HouseRules_Core/Types/Ruleset.cs
+++ b/HouseRules_Core/Types/Ruleset.cs
@@ -20,21 +20,28 @@
         /// </summary>
         public List<Rule> Rules { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether this ruleset is safe to use in multiplayer environments.
+        /// </summary>
+        public bool IsSafeForMultiplayer { get; }
+
         public static Ruleset NewInstance(string name, string description, params Rule[] rules)
         {
-            return new Ruleset(name, description, rules.ToList());
+            return NewInstance(name, description, rules.ToList());
         }
 
         public static Ruleset NewInstance(string name, string description, List<Rule> rules)
         {
-            return new Ruleset(name, description, rules);
+            var safeForMultiplayer = rules.All(r => r is IMultiplayerSafe);
+            return new Ruleset(name, description, rules, safeForMultiplayer);
         }
 
-        private Ruleset(string name, string description, List<Rule> rules)
+        private Ruleset(string name, string description, List<Rule> rules, bool isSafeForMultiplayer)
         {
             Name = name;
             Description = description;
             Rules = rules;
+            IsSafeForMultiplayer = isSafeForMultiplayer;
         }
     }
 }


### PR DESCRIPTION
**Changes:**
- Add `IMultiplayerSafe` interface to represent multiplayer-safe rules.
- Expose an `IsSafeForMultiplayer` property for rulesets.
- Consider game mode (e.g., multiplayer or skirmish) when deciding whether or not to activate ruleset.
- Add additional checks to make sure preGameCreated and postGameCreated callbacks are not called if a rule is not activated.
- Display a message on game load when a ruleset was not activated due to being unsafe for multiplayer environments.

CC @jimconner.