### PR TITLE
Force board state resync in cases where a client may register a new spawn.

### DIFF
--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -11,15 +11,16 @@ namespace HouseRules
     {
         internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("HouseRules:Core");
         private const float WelcomeMessageDurationSeconds = 30f;
-        private static bool _isRulesetActive;
 
         public static readonly Rulebook Rulebook = Rulebook.NewInstance();
 
         public static Ruleset SelectedRuleset { get; private set; }
 
+        internal static bool IsRulesetActive { get; private set; }
+
         public static void SelectRuleset(string ruleset)
         {
-            if (_isRulesetActive)
+            if (IsRulesetActive)
             {
                 throw new InvalidOperationException("May not select a new ruleset while one is currently active.");
             }
@@ -36,7 +37,7 @@ namespace HouseRules
 
         internal static void TriggerActivateRuleset(GameContext gameContext, GameHub.GameMode gameMode)
         {
-            if (_isRulesetActive)
+            if (IsRulesetActive)
             {
                 Logger.Warning("Ruleset activation was triggered whilst a ruleset was already activated. This should not happen. Please report this to HouseRules developers.");
                 return;
@@ -53,7 +54,7 @@ namespace HouseRules
                 return;
             }
 
-            _isRulesetActive = true;
+            IsRulesetActive = true;
 
             Logger.Msg($"Activating ruleset: {SelectedRuleset.Name} (with {SelectedRuleset.Rules.Count} rules)");
             foreach (var rule in SelectedRuleset.Rules)
@@ -73,12 +74,12 @@ namespace HouseRules
 
         internal static void TriggerDeactivateRuleset(GameContext gameContext)
         {
-            if (!_isRulesetActive)
+            if (!IsRulesetActive)
             {
                 return;
             }
 
-            _isRulesetActive = false;
+            IsRulesetActive = false;
 
             Logger.Msg($"Deactivating ruleset: {SelectedRuleset.Name} (with {SelectedRuleset.Rules.Count} rules)");
             foreach (var rule in SelectedRuleset.Rules)
@@ -103,7 +104,7 @@ namespace HouseRules
                 return;
             }
 
-            if (!_isRulesetActive)
+            if (!IsRulesetActive)
             {
                 return;
             }
@@ -130,7 +131,7 @@ namespace HouseRules
                 return;
             }
 
-            if (!_isRulesetActive)
+            if (!IsRulesetActive)
             {
                 return;
             }
@@ -157,7 +158,7 @@ namespace HouseRules
                 return;
             }
 
-            if (!_isRulesetActive)
+            if (!IsRulesetActive)
             {
                 GameUI.ShowCameraMessage(BuildNotSafeForMultiplayerMessage(), WelcomeMessageDurationSeconds);
                 return;

--- a/HouseRules_Core/ModPatcher.cs
+++ b/HouseRules_Core/ModPatcher.cs
@@ -2,7 +2,10 @@
 {
     using System.Reflection;
     using Boardgame;
+    using Boardgame.BoardEntities;
     using Boardgame.Networking;
+    using Boardgame.SerializableEvents;
+    using DataKeys;
     using HarmonyLib;
 
     internal class ModPatcher
@@ -35,6 +38,12 @@
             harmony.Patch(
                 original: AccessTools.Method(typeof(SerializableEventQueue), "DisconnectLocalPlayer"),
                 prefix: new HarmonyMethod(typeof(ModPatcher), nameof(SerializableEventQueue_DisconnectLocalPlayer_Prefix)));
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(SerializableEventQueue), "SendResponseEvent"),
+                postfix: new HarmonyMethod(
+                    typeof(ModPatcher),
+                    nameof(SerializableEventQueue_SendResponseEvent_Postfix)));
         }
 
         private static void GameStartup_InitializeGame_Postfix(GameStartup __instance)
@@ -94,6 +103,91 @@
         private static void SerializableEventQueue_DisconnectLocalPlayer_Prefix()
         {
             HR.TriggerDeactivateRuleset(_gameContext);
+        }
+
+        private static void SerializableEventQueue_SendResponseEvent_Postfix(SerializableEvent serializableEvent)
+        {
+            if (!HR.IsRulesetActive)
+            {
+                return;
+            }
+
+            if (!DoesEventRepresentNewSpawn(serializableEvent))
+            {
+                return;
+            }
+
+            _gameContext.serializableEventQueue.SendResponseEvent(SerializableEvent.CreateRecovery());
+        }
+
+        private static bool DoesEventRepresentNewSpawn(SerializableEvent serializableEvent)
+        {
+            switch (serializableEvent.type)
+            {
+                case SerializableEvent.Type.SpawnPiece:
+                case SerializableEvent.Type.UpdateFogAndSpawn:
+                case SerializableEvent.Type.SetBoardPieceID:
+                case SerializableEvent.Type.SlimeFusion:
+                case SerializableEvent.Type.GoToNextLevel:
+                    return true;
+            }
+
+            if (serializableEvent.type == SerializableEvent.Type.OnAbilityUsed)
+            {
+                return DoesAbilityEventRepresentNewSpawn((SerializableEventOnAbilityUsed) serializableEvent);
+            }
+
+            if (serializableEvent.type == SerializableEvent.Type.PieceDied)
+            {
+                return DoesPieceDiedEventRepresentNewSpawn((SerializableEventPieceDied) serializableEvent);
+            }
+
+            return false;
+        }
+
+        private static bool DoesAbilityEventRepresentNewSpawn(SerializableEventOnAbilityUsed onAbilityUsedEvent)
+        {
+            var abilityKey = Traverse.Create(onAbilityUsedEvent).Field<AbilityKey>("abilityKey").Value;
+            switch (abilityKey)
+            {
+                case AbilityKey.SummonElemental:
+                case AbilityKey.SummonBossMinions:
+                case AbilityKey.NaturesCall:
+                case AbilityKey.Tornado:
+                case AbilityKey.MonsterBait:
+                case AbilityKey.ProximityMine:
+                case AbilityKey.EyeOfAvalon:
+                case AbilityKey.SwordOfAvalon:
+                case AbilityKey.BeaconOfSmite:
+                case AbilityKey.BeaconOfHealing:
+                case AbilityKey.RaiseRoots:
+                case AbilityKey.CallCompanion:
+                    return true;
+            }
+
+            var abilityName = abilityKey.ToString();
+            var isSpawnAbility = abilityName.Contains("Spawn");
+            var isLampAbility = abilityName.Contains("Lamp");
+
+            return isSpawnAbility || isLampAbility;
+        }
+
+        private static bool DoesPieceDiedEventRepresentNewSpawn(SerializableEventPieceDied pieceDiedEvent)
+        {
+            foreach (var pieceId in pieceDiedEvent.deadPieces)
+            {
+                if (!_gameContext.pieceAndTurnController.TryGetPiece(pieceId, out Piece piece))
+                {
+                    continue;
+                }
+
+                if (piece.boardPieceId == BoardPieceId.SpiderEgg)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
Related to https://github.com/orendain/DemeoMods/issues/149.

Force board state resync in cases where a client may register a new spawn.

Existing rules that affect the stats of a piece are mostly resolved client-side. For the host's overridden piece stats to propagate to clients, the host needs to somehow sync its state with each client.

It is important to trigger this sync as close to the spawn event as possible, else the client may interact with the piece given non-actual stats, potentially causing desync issues.

Due to how heavy the resync is, it is undesirable to naively sync periodically (e.g., at the end of each action). However, because Demeo has only fine-grained and super-heavy-grained sync events, some overhead is to be expected.