### PR TITLE
Mark more rules as being multiplayer safe.

### DIFF
--- a/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
@@ -8,7 +8,7 @@
     using HouseRules.Types;
     using UnityEngine;
 
-    public sealed class AbilityAoeAdjustedRule : Rule, IConfigWritable<Dictionary<string, int>>
+    public sealed class AbilityAoeAdjustedRule : Rule, IConfigWritable<Dictionary<string, int>>, IMultiplayerSafe
     {
         public override string Description => "Ability AOE Ranges are adjusted";
 

--- a/HouseRules_Essentials/Rules/AbilityDamageAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityDamageAdjustedRule.cs
@@ -7,7 +7,7 @@
     using HouseRules.Types;
     using UnityEngine;
 
-    public sealed class AbilityDamageAdjustedRule : Rule, IConfigWritable<Dictionary<string, int>>
+    public sealed class AbilityDamageAdjustedRule : Rule, IConfigWritable<Dictionary<string, int>>, IMultiplayerSafe
     {
         public override string Description => "Ability damage is adjusted";
 

--- a/HouseRules_Essentials/Rules/EnemyAttackScaledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyAttackScaledRule.cs
@@ -5,7 +5,7 @@
     using HarmonyLib;
     using HouseRules.Types;
 
-    public sealed class EnemyAttackScaledRule : Rule, IConfigWritable<float>, IPatchable
+    public sealed class EnemyAttackScaledRule : Rule, IConfigWritable<float>, IPatchable, IMultiplayerSafe
     {
         public override string Description => "Enemy attack damage is scaled";
 

--- a/HouseRules_Essentials/Rules/EnemyHealthScaledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyHealthScaledRule.cs
@@ -5,7 +5,7 @@
     using HarmonyLib;
     using HouseRules.Types;
 
-    public sealed class EnemyHealthScaledRule : Rule, IConfigWritable<float>, IPatchable
+    public sealed class EnemyHealthScaledRule : Rule, IConfigWritable<float>, IPatchable, IMultiplayerSafe
     {
         public override string Description => "Enemy health is scaled";
 

--- a/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -7,7 +7,7 @@
     using HouseRules.Types;
     using UnityEngine;
 
-    public sealed class PieceConfigAdjustedRule : Rule, IConfigWritable<List<List<string>>>
+    public sealed class PieceConfigAdjustedRule : Rule, IConfigWritable<List<List<string>>>, IMultiplayerSafe
     {
         public override string Description => "Piece configuration is adjusted";
 

--- a/HouseRules_Essentials/Rules/StartHealthAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/StartHealthAdjustedRule.cs
@@ -7,7 +7,7 @@
     using HouseRules.Types;
     using UnityEngine;
 
-    public sealed class StartHealthAdjustedRule : Rule, IConfigWritable<Dictionary<string, int>>
+    public sealed class StartHealthAdjustedRule : Rule, IConfigWritable<Dictionary<string, int>>, IMultiplayerSafe
     {
         public override string Description => "Start Health is adjusted";
 


### PR DESCRIPTION
Enabled because HouseRules now performs board and piece syncing, as introduced in #151.

Related to https://github.com/orendain/DemeoMods/issues/149.