### PR TITLE
Add rule that allows to override cards that players receive.

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -23,6 +23,7 @@
             HR.Rulebook.Register(typeof(AbilityDamageAdjustedRule));
             HR.Rulebook.Register(typeof(AbilityActionCostAdjustedRule));
             HR.Rulebook.Register(typeof(ActionPointsAdjustedRule));
+            HR.Rulebook.Register(typeof(CardAdditionOverriddenRule));
             HR.Rulebook.Register(typeof(CardEnergyFromAttackMultipliedRule));
             HR.Rulebook.Register(typeof(CardEnergyFromRecyclingMultipliedRule));
             HR.Rulebook.Register(typeof(CardLimitModifiedRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -38,6 +38,7 @@
     <Compile Include="Rules\AbilityActionCostAdjustedRule.cs" />
     <Compile Include="Rules\AbilityDamageAdjustedRule.cs" />
     <Compile Include="Rules\ActionPointsAdjustedRule.cs" />
+    <Compile Include="Rules\CardAdditionOverriddenRule.cs" />
     <Compile Include="Rules\CardEnergyFromAttackMultipliedRule.cs" />
     <Compile Include="Rules\CardEnergyFromRecyclingMultipliedRule.cs" />
     <Compile Include="Rules\CardLimitModifiedRule.cs" />

--- a/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
@@ -1,0 +1,82 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Boardgame;
+    using Boardgame.BoardEntities;
+    using Boardgame.SerializableEvents;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Types;
+
+    public sealed class CardAdditionOverriddenRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<AbilityKey>>>, IPatchable, IMultiplayerSafe
+    {
+        public override string Description => "Card additions are overridden";
+
+        private static readonly Random Rnd = new Random();
+        private static Dictionary<BoardPieceId, List<AbilityKey>> _globalHeroCards;
+        private static bool _isActivated;
+
+        private readonly Dictionary<BoardPieceId, List<AbilityKey>> _heroCards;
+
+        public CardAdditionOverriddenRule(Dictionary<BoardPieceId, List<AbilityKey>> heroCards)
+        {
+            _heroCards = heroCards;
+        }
+
+        public Dictionary<BoardPieceId, List<AbilityKey>> GetConfigObject() => _heroCards;
+
+        protected override void OnActivate(GameContext gameContext)
+        {
+            _globalHeroCards = _heroCards;
+            _isActivated = true;
+        }
+
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
+
+        private static void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(SerializableEventQueue), "RespondToRequest"),
+                prefix: new HarmonyMethod(
+                    typeof(CardAdditionOverriddenRule),
+                    nameof(SerializableEventQueue_RespondToRequest_Prefix)));
+        }
+
+        private static void SerializableEventQueue_RespondToRequest_Prefix(SerializableEventQueue __instance, ref SerializableEvent request)
+        {
+            if (!_isActivated)
+            {
+                return;
+            }
+
+            if (request.type != SerializableEvent.Type.AddCardToPiece)
+            {
+                return;
+            }
+
+            var addCardToPieceEvent = (SerializableEventAddCardToPiece)request;
+            var gameContext = Traverse.Create(__instance).Property<GameContext>("gameContext").Value;
+
+            var targetPieceId = Traverse.Create(addCardToPieceEvent).Field<int>("targetPieceId").Value;
+            if (!gameContext.pieceAndTurnController.TryGetPiece(targetPieceId, out Piece piece))
+            {
+                return;
+            }
+
+            if (!piece.IsPlayer())
+            {
+                return;
+            }
+
+            if (!_globalHeroCards.TryGetValue(piece.boardPieceId, out List<AbilityKey> replacementAbilityKeys))
+            {
+                return;
+            }
+
+            var replacementAbilityKey = replacementAbilityKeys.ElementAt(Rnd.Next(replacementAbilityKeys.Count));
+            Traverse.Create(addCardToPieceEvent).Field<AbilityKey>("card").Value = replacementAbilityKey;
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/orendain/DemeoMods/issues/110

I was not creative with the name of the rule.  As always, anyone is welcome to change the name or description.

The config looks like:
```json
{
    "Rule": "CardAdditionOverridden",
    "Config": {
        "HeroSorcerer": ["FreeAP", "Bone"],
        "HeroRouge": ["Fireball", "RatBomb"]
    }
}
```

Missing documentation, but being tired got to me 🙂 .