### PR TITLE
Keep sort order when room list is refreshed.

### DIFF
--- a/RoomFinder/UI/RoomFinderUI.cs
+++ b/RoomFinder/UI/RoomFinderUI.cs
@@ -76,7 +76,7 @@
                 Quaternion.Euler(-90, 0, 0); // Un-flip card from it's default face-up position.
             _background.transform.localScale = new Vector3(2, 1, 2.5f);
 
-            var menuTitle = _uiHelper.CreateMenuHeaderText("Public Rooms");
+            var menuTitle = _uiHelper.CreateMenuHeaderText("RoomFinder");
             menuTitle.transform.SetParent(this.transform, worldPositionStays: false);
             menuTitle.transform.localPosition = new Vector3(0, 2.375f, 0);
 

--- a/RoomFinder/UI/RoomListPanel.cs
+++ b/RoomFinder/UI/RoomListPanel.cs
@@ -28,8 +28,8 @@
         {
             this._uiHelper = uiHelper;
             this.GameObject = panel;
-            this._sortOrder = r => r;
-            this._isDescendingOrder = false;
+            this._sortOrder = r => r.CurrentPlayers;
+            this._isDescendingOrder = true;
 
             this._rooms = new List<RoomListEntry>();
         }
@@ -49,7 +49,6 @@
             }
 
             RenderHeader();
-
             for (var i = 0; i < _rooms.Count; i++)
             {
                 RenderRoomRow(_rooms[i], i);

--- a/RoomFinder/UI/RoomListPanel.cs
+++ b/RoomFinder/UI/RoomListPanel.cs
@@ -15,7 +15,6 @@
         private readonly UiHelper _uiHelper;
         private Func<RoomListEntry, object> _sortOrder;
         private bool _isDescendingOrder;
-        private List<RoomListEntry> _originalRooms;
         private List<RoomListEntry> _rooms;
 
         internal GameObject GameObject { get; }
@@ -32,16 +31,13 @@
             this._sortOrder = r => r;
             this._isDescendingOrder = false;
 
-            this._originalRooms = new List<RoomListEntry>();
-            this._rooms = this._originalRooms;
+            this._rooms = new List<RoomListEntry>();
         }
 
         internal void SetRooms(IEnumerable<RoomInfo> rooms)
         {
-            _originalRooms = rooms.Select(RoomListEntry.Parse).ToList();
-            _rooms = _originalRooms;
-
-            Render();
+            _rooms = rooms.Select(RoomListEntry.Parse).ToList();
+            SortRooms();
         }
 
         private void Render()
@@ -107,10 +103,10 @@
             }
 
             _sortOrder = sortOrder;
-            ResortRooms();
+            SortRooms();
         }
 
-        private void ResortRooms()
+        private void SortRooms()
         {
             _rooms = _isDescendingOrder
                 ? _rooms.OrderByDescending(_sortOrder).ToList()

--- a/RoomFinder/UI/RoomListPanel.cs
+++ b/RoomFinder/UI/RoomListPanel.cs
@@ -38,6 +38,7 @@
         {
             _rooms = rooms.Select(RoomListEntry.Parse).ToList();
             SortRooms();
+            Render();
         }
 
         private void Render()
@@ -64,17 +65,17 @@
             sortLabel.transform.SetParent(headerContainer.transform, worldPositionStays: false);
             sortLabel.transform.localPosition = new Vector3(-3f, 0, 0);
 
-            var gameButton = CreateSortButton("Game", () => SortListBy(r => r.GameType));
+            var gameButton = CreateSortButton("Game", () => SetSortOrderAndApply(r => r.GameType));
             gameButton.transform.SetParent(headerContainer.transform, worldPositionStays: false);
             gameButton.transform.localScale = new Vector3(0.5f, 0.5f, 0.5f);
             gameButton.transform.localPosition = new Vector3(-0.5f, 0, 0);
 
-            var floorButton = CreateSortButton("Floor", () => SortListBy(r => r.Floor));
+            var floorButton = CreateSortButton("Floor", () => SetSortOrderAndApply(r => r.Floor));
             floorButton.transform.SetParent(headerContainer.transform, worldPositionStays: false);
             floorButton.transform.localScale = new Vector3(0.5f, 0.5f, 0.5f);
             floorButton.transform.localPosition = new Vector3(1.5f, 0, 0);
 
-            var playersButton = CreateSortButton("Players", () => SortListBy(r => r.CurrentPlayers));
+            var playersButton = CreateSortButton("Players", () => SetSortOrderAndApply(r => r.CurrentPlayers));
             playersButton.transform.SetParent(headerContainer.transform, worldPositionStays: false);
             playersButton.transform.localScale = new Vector3(0.5f, 0.5f, 0.5f);
             playersButton.transform.localPosition = new Vector3(3.5f, 0, 0);
@@ -95,7 +96,7 @@
             return container;
         }
 
-        private void SortListBy(Func<RoomListEntry, object> sortOrder)
+        private void SetSortOrderAndApply(Func<RoomListEntry, object> sortOrder)
         {
             if (_sortOrder == sortOrder)
             {
@@ -104,6 +105,7 @@
 
             _sortOrder = sortOrder;
             SortRooms();
+            Render();
         }
 
         private void SortRooms()
@@ -111,8 +113,6 @@
             _rooms = _isDescendingOrder
                 ? _rooms.OrderByDescending(_sortOrder).ToList()
                 : _rooms.OrderBy(_sortOrder).ToList();
-
-            Render();
         }
 
         private void RenderRoomRow(RoomListEntry room, int row)


### PR DESCRIPTION
- Keep sort order when room list is refreshed.
- Slightly renamed methods and how they're called, to improve encapsulation.
- Set default sorting to be descending by current players.
- Change header of UI element to 'RoomFinder'.