### PR TITLE
Add rule to adjust PieceConfig ImmuneToStatusEffects lists.

### DIFF
--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -144,9 +144,12 @@
                 { "NaturesCall", bps },
             });
 
+            EffectStateType[] effs = { EffectStateType.Diseased, EffectStateType.Stunned, EffectStateType.MarkOfAvalon, EffectStateType.Weaken, EffectStateType.Frozen, EffectStateType.Tangled, EffectStateType.Petrified };
+            var pila = new Essentials.Rules.PieceImmunityListAdjustedRule(new Dictionary<string, EffectStateType[]> { { "Sorcerer", effs } } );
+
             var customRuleset = Ruleset.NewInstance("DemoConfigurableRuleset", "Just a random description.", new List<Rule>
             {
-                aaca, aaa, ada, apa, cefam1, cefam2, cefam3, cefam4, cefrm, csvm, eas, edod, ehs, erd, gpus, pca, rnsg, sscm, sha, arpl,
+                aaca, aaa, ada, apa, cefam1, cefam2, cefam3, cefam4, cefrm, csvm, eas, edod, ehs, erd, gpus, pca, rnsg, sscm, sha, arpl, pila,
             });
 
             ConfigManager.ExportRuleset(customRuleset);

--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -33,6 +33,7 @@
             HR.Rulebook.Register(typeof(GoldPickedUpMultipliedRule));
             HR.Rulebook.Register(typeof(LevelPropertiesModifiedRule));
             HR.Rulebook.Register(typeof(PieceConfigAdjustedRule));
+            HR.Rulebook.Register(typeof(PieceImmunityListAdjustedRule));
             HR.Rulebook.Register(typeof(RatNestsSpawnGoldRule));
             HR.Rulebook.Register(typeof(RoundCountLimitedRule));
             HR.Rulebook.Register(typeof(StartCardsModifiedRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Rules\EnemyRespawnDisabledRule.cs" />
     <Compile Include="Rules\GoldPickedUpMultipliedRule.cs" />
     <Compile Include="Rules\LevelPropertiesModifiedRule.cs" />
+    <Compile Include="Rules\PieceImmunityListAdjustedRule.cs" />
     <Compile Include="Rules\PieceConfigAdjustedRule.cs" />
     <Compile Include="Rules\RatNestsSpawnGoldRule.cs" />
     <Compile Include="Rules\RoundCountLimitedRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -249,6 +249,22 @@ An example [Ruleset for rapid play](../docs/TestingRuleSet.json) is provided to 
     ]
   },
   ```
+  
+- __PieceImmunityListAdjustedRule__: Piece ImmuneToStatusEffects list is adjusted
+  - Allows customization of many the list of immunities for each game Piece. Diseased, Stunned, Weakened, Frozen, Tangled, Petrified , etc
+  - Config accepts Dictionary e.g. `{ "HeroSorcerer", EventState[], "RatKing", EventState[], ... }`  
+
+  ###### _Example JSON config for PieceImmunityListAdjustedRule_
+
+  ```json
+  {
+    "Rule": "PieceImmunityListAdjusted",
+    "Config": {
+      "HeroSorcerer": [ "Diseased", "MarkOfAvalon", "Weaken", "Frozen", "Tangled", "Petrified" ],
+      "HeroGuardian": [ "Frozen" ]
+    }
+  },
+  ```
 
 - __RatNestsSpawnGoldRule__: Rat nests spawn gold
   - Config accepts bool e.g `true`  

--- a/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
@@ -1,0 +1,54 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Boardgame;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Types;
+    using UnityEngine;
+
+            public sealed class PieceImmunityListAdjustedRule : Rule, IConfigWritable<Dictionary<string, EffectStateType[]>>, IMultiplayerSafe
+    {
+        public override string Description => "Piece immunities are adjusted";
+
+        private readonly Dictionary<string, EffectStateType[]> _adjustments;
+        private readonly Dictionary<string, EffectStateType[]> _originals;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="PieceImmunityListAdjustedRule"/> class.
+            /// </summary>
+            /// <param name="adjustments">Dict of piece name and EffectStateType[]
+            /// Replaces original settings with new list.</param>
+            public PieceImmunityListAdjustedRule(Dictionary<string, EffectStateType[]> adjustments)
+        {
+            _adjustments = adjustments;
+            _originals = new Dictionary<string, EffectStateType[]>();
+            }
+
+        public Dictionary<string, EffectStateType[]> GetConfigObject() => _adjustments;
+
+        protected override void OnPostGameCreated(GameContext gameContext)
+        {
+            var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            foreach (var item in _adjustments)
+            {
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                _originals[item.Key] = pieceConfig.ImmuneToStatusEffects;
+                var property = Traverse.Create(pieceConfig).Property<EffectStateType[]>("ImmuneToStatusEffects");
+                property.Value = item.Value;
+            }
+        }
+
+        protected override void OnDeactivate(GameContext gameContext)
+        {
+            var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            foreach (var item in _originals)
+            {
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item}"));
+                var property = Traverse.Create(pieceConfig).Property<EffectStateType[]>("ImmuneToStatusEffects");
+                property.Value = item.Value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# A rule for editing the list of immunities for any given piece. 

Can add immunities to friendly pieces, or strip them away from the baddies. The list specified replaces the default list.

## How to review?

I tried this rule quickly in a skirmish and it seemed to work fine - My Sorcered could not be frozen.

This rule has not been tested in multiplayer yet - It currently has `IMultiplayerSafe` set so it should not be merged until it has been tested.


### Sample config for testing:
```
      {
      "Rule": "PieceImmunityListAdjusted",
      "Config": {
        "HeroSorcerer": [
          "Diseased",
          "Stunned",
          "MarkOfAvalon",
          "Weaken",
          "Frozen",
          "Tangled",
          "Petrified"
        ]
      }
    }

```