### PR TITLE
Add QuickAndDeadRuleset to csproj.

### DIFF
--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -34,11 +34,12 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="EssentialsMod.cs" />
+    <Compile Include="Rulesets\BeatTheClockRuleset.cs" />
     <Compile Include="Rulesets\DifficultyEasyRuleset.cs" />
     <Compile Include="Rulesets\DifficultyHardRuleset.cs" />
     <Compile Include="Rulesets\DifficultyLegendaryRuleset.cs" />
+    <Compile Include="Rulesets\QuickAndDeadRuleset.cs" />
     <Compile Include="Rulesets\SampleRuleset.cs" />
-    <Compile Include="Rulesets\BeatTheClockRuleset.cs" />
     <Compile Include="Rules\AbilityActionCostAdjustedRule.cs" />
     <Compile Include="Rules\AbilityRandomPieceListRule.cs" />
     <Compile Include="Rules\AbilityDamageAdjustedRule.cs" />

--- a/HouseRules_Essentials/Rulesets/DifficultyHardRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/DifficultyHardRuleset.cs
@@ -14,7 +14,7 @@
                 name,
                 description,
                 new CardEnergyFromAttackMultipliedRule(0.8f),
-                new CardEnergyFromRecylcingMultipliedRule(0.8f),
+                new CardEnergyFromRecyclingMultipliedRule(0.8f),
                 new EnemyHealthScaledRule(1.2f),
                 new EnemyAttackScaledRule(1.2f));
         }


### PR DESCRIPTION
Just a heads up @Buruko that I'm adding `QuickAndDeadRuleset` to the `.csproj` folder (so that it gets recognized as part of the project when building the project into a DLL).

And fixing a small typo in `DifficultyHardRuleset.cs`.  It's really easy to miss - only reason I noticed it is because my development environment (IDE) performs these types of checks.