### PR TITLE
Add rule to override StatusEffectConfig 

### DIFF
--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -147,9 +147,28 @@
             EffectStateType[] effs = { EffectStateType.Diseased, EffectStateType.Stunned, EffectStateType.MarkOfAvalon, EffectStateType.Weaken, EffectStateType.Frozen, EffectStateType.Tangled, EffectStateType.Petrified };
             var pila = new Essentials.Rules.PieceImmunityListAdjustedRule(new Dictionary<string, EffectStateType[]> { { "Sorcerer", effs } } );
 
+            var sec = new global::Types.StatusEffectData[]
+            {
+                new global::Types.StatusEffectData {
+                    effectStateType = EffectStateType.TorchPlayer,
+                    durationTurns = 15,
+                    damagePerTurn = 0,
+                    stacks = true,
+                    clearOnNewLevel = false,
+                    tickWhen = StatusEffectsConfig.TickWhen.StartTurn,
+                },
+                new global::Types.StatusEffectData {
+                    effectStateType = EffectStateType.HealingSong,
+                    durationTurns = 4,
+                    healPerTurn = 3,
+                    stacks = false,
+                    tickWhen = StatusEffectsConfig.TickWhen.StartTurn,
+                },
+            };
+            var seca = new Essentials.Rules.StatusEffectConfigRule(sec);
             var customRuleset = Ruleset.NewInstance("DemoConfigurableRuleset", "Just a random description.", new List<Rule>
             {
-                aaca, aaa, ada, apa, cefam1, cefam2, cefam3, cefam4, cefrm, csvm, eas, edod, ehs, erd, gpus, pca, rnsg, sscm, sha, arpl, pila,
+                aaca, aaa, ada, apa, cefam1, cefam2, cefam3, cefam4, cefrm, csvm, eas, edod, ehs, erd, gpus, pca, rnsg, sscm, sha, arpl, pila, seca,
             });
 
             ConfigManager.ExportRuleset(customRuleset);

--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -6,6 +6,7 @@
     using HouseRules.Types;
     using MelonLoader;
     using UnityEngine;
+    using StatusEffectData = global::Types.StatusEffectData;
 
     internal class ConfigurationMod : MelonMod
     {
@@ -147,9 +148,9 @@
             EffectStateType[] effs = { EffectStateType.Diseased, EffectStateType.Stunned, EffectStateType.MarkOfAvalon, EffectStateType.Weaken, EffectStateType.Frozen, EffectStateType.Tangled, EffectStateType.Petrified };
             var pila = new Essentials.Rules.PieceImmunityListAdjustedRule(new Dictionary<string, EffectStateType[]> { { "Sorcerer", effs } } );
 
-            var sec = new global::Types.StatusEffectData[]
+            var sec = new List<StatusEffectData>
             {
-                new global::Types.StatusEffectData {
+                new StatusEffectData {
                     effectStateType = EffectStateType.TorchPlayer,
                     durationTurns = 15,
                     damagePerTurn = 0,
@@ -157,7 +158,7 @@
                     clearOnNewLevel = false,
                     tickWhen = StatusEffectsConfig.TickWhen.StartTurn,
                 },
-                new global::Types.StatusEffectData {
+                new StatusEffectData {
                     effectStateType = EffectStateType.HealingSong,
                     durationTurns = 4,
                     healPerTurn = 3,

--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -38,6 +38,7 @@
             HR.Rulebook.Register(typeof(RoundCountLimitedRule));
             HR.Rulebook.Register(typeof(StartCardsModifiedRule));
             HR.Rulebook.Register(typeof(StartHealthAdjustedRule));
+            HR.Rulebook.Register(typeof(StatusEffectConfigRule));
         }
 
         private static void RegisterRulesets()

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -45,6 +45,7 @@
     <Compile Include="Rules\ActionPointsAdjustedRule.cs" />
     <Compile Include="Rules\CardAdditionOverriddenRule.cs" />
     <Compile Include="Rules\CardEnergyFromAttackMultipliedRule.cs" />
+    <Compile Include="Rules\StatusEffectConfigRule.cs" />
     <Compile Include="Rules\CardEnergyFromRecyclingMultipliedRule.cs" />
     <Compile Include="Rules\CardLimitModifiedRule.cs" />
     <Compile Include="Rules\CardSellValueMultipliedRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -317,6 +317,41 @@ An example [Ruleset for rapid play](../docs/TestingRuleSet.json) is provided to 
      }
    },
    ```
+- __StatusEffectConfigRule__: The parameters of different StatusEffects (Torch, Poison, Frozen) can be overridden
+  - Accepts a list of overrides which take the place of the default config. 
+  - If no override is specified, the default is used instead.
+  - Default values can be found in `StatusEffectsConfig.effectsConfig` 
+  - Config accepts list of dicts e.g. `[ {}, {}, ]`
+
+  ###### _Example JSON config for StatusEffectConfigRule_
+
+  ```json
+    {
+      "Rule": "StatusEffectConfig",
+      "Config": [
+        {
+          "effectStateType": "TorchPlayer",
+          "durationTurns": 15,
+          "tickWhen": "StartTurn",
+          "stacks": true,
+          "damagePerTurn": 0,
+          "clearOnNewLevel": false,
+          "damageTags": null,
+          "healPerTurn": 0
+        },
+        {
+          "effectStateType": "HealingSong",
+          "durationTurns": 4,
+          "tickWhen": "StartTurn",
+          "stacks": false,
+          "damagePerTurn": 0,
+          "clearOnNewLevel": false,
+          "damageTags": null,
+          "healPerTurn": 3
+        }
+      ]
+   },
+   ```
 
 - ___StartHealthAdjustedRule__: Starting Health is adjusted_
   - Same settings handled by piececonfig. Rule not needed anymore?

--- a/HouseRules_Essentials/Rules/StatusEffectConfigRule.cs
+++ b/HouseRules_Essentials/Rules/StatusEffectConfigRule.cs
@@ -1,0 +1,69 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System;
+    using Boardgame;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Types;
+
+    public sealed class StatusEffectConfigRule : Rule, IConfigWritable<global::Types.StatusEffectData[]>, IPatchable, IMultiplayerSafe
+    {
+        public override string Description => "Status Effect Durations are modified";
+
+        private static bool _isActivated;
+        private static global::Types.StatusEffectData[] _adjustments;
+
+        public StatusEffectConfigRule(global::Types.StatusEffectData[] adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        public global::Types.StatusEffectData[] GetConfigObject() => _adjustments;
+
+        protected override void OnActivate(GameContext gameContext)
+        {
+            _isActivated = true;
+
+        }
+
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
+
+        private static void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(StatusEffectsConfig), "GetConfigFor"),
+                prefix: new HarmonyMethod(
+                    typeof(StatusEffectConfigRule),
+                    nameof(StatusEffects_GetConfigFor_Prefix)));
+        }
+
+        private static bool StatusEffects_GetConfigFor_Prefix(ref EffectStateType type, ref global::Types.StatusEffectData __result)
+        {
+            if (!_isActivated)
+            {
+                return true;
+            }
+
+            var effectsConfig = Traverse.Create(typeof(StatusEffectsConfig)).Field<global::Types.StatusEffectData[]>("effectsConfig").Value;
+
+            for (int i = 0; i < _adjustments.Length; i++)
+            {
+                if (_adjustments[i].effectStateType == type)
+                {
+                    __result = _adjustments[i];
+                    return false; // We returned an user-adjusted config.
+                }
+            }
+            for (int i = 0; i < effectsConfig.Length; i++)
+            {
+                if (effectsConfig[i].effectStateType == type)
+                {
+                    __result = effectsConfig[i];
+                    return false; // We returned original result.
+                }
+            }
+
+            throw new Exception("Could not find config for " + type);
+        }
+    }
+}

--- a/HouseRules_Essentials/Rules/StatusEffectConfigRule.cs
+++ b/HouseRules_Essentials/Rules/StatusEffectConfigRule.cs
@@ -1,24 +1,26 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
     using System;
+    using System.Collections.Generic;
     using Boardgame;
     using DataKeys;
     using HarmonyLib;
     using HouseRules.Types;
+    using StatusEffectData = global::Types.StatusEffectData;
 
-    public sealed class StatusEffectConfigRule : Rule, IConfigWritable<global::Types.StatusEffectData[]>, IPatchable, IMultiplayerSafe
+    public sealed class StatusEffectConfigRule : Rule, IConfigWritable<List<StatusEffectData>>, IPatchable, IMultiplayerSafe
     {
         public override string Description => "Status Effect Durations are modified";
 
         private static bool _isActivated;
-        private static global::Types.StatusEffectData[] _adjustments;
+        private static List<StatusEffectData> _adjustments;
 
-        public StatusEffectConfigRule(global::Types.StatusEffectData[] adjustments)
+        public StatusEffectConfigRule(List<StatusEffectData> adjustments)
         {
             _adjustments = adjustments;
         }
 
-        public global::Types.StatusEffectData[] GetConfigObject() => _adjustments;
+        public List<StatusEffectData> GetConfigObject() => _adjustments;
 
         protected override void OnActivate(GameContext gameContext)
         {
@@ -37,16 +39,14 @@
                     nameof(StatusEffects_GetConfigFor_Prefix)));
         }
 
-        private static bool StatusEffects_GetConfigFor_Prefix(ref EffectStateType type, ref global::Types.StatusEffectData __result)
+        private static bool StatusEffects_GetConfigFor_Prefix(ref EffectStateType type, ref StatusEffectData __result)
         {
             if (!_isActivated)
             {
                 return true;
             }
 
-            var effectsConfig = Traverse.Create(typeof(StatusEffectsConfig)).Field<global::Types.StatusEffectData[]>("effectsConfig").Value;
-
-            for (int i = 0; i < _adjustments.Length; i++)
+            for (int i = 0; i < _adjustments.Count; i++)
             {
                 if (_adjustments[i].effectStateType == type)
                 {
@@ -54,16 +54,8 @@
                     return false; // We returned an user-adjusted config.
                 }
             }
-            for (int i = 0; i < effectsConfig.Length; i++)
-            {
-                if (effectsConfig[i].effectStateType == type)
-                {
-                    __result = effectsConfig[i];
-                    return false; // We returned original result.
-                }
-            }
 
-            throw new Exception("Could not find config for " + type);
+            return true;
         }
     }
 }


### PR DESCRIPTION
# New Rule to override StatusEffectConfig

The behaviour of the status effects such as Torch, Poisoned, Weakened, SongOfHealing, etc are configured through a list of StatusEffectData. This PR implements a new rule which accepts a similar list of overriding StatusEffectData and patches the `GetConfigFor` function so that it will return any matching overrides if present. If not then default config will be used.

Please note that this has not been testing in multiplayer yet.

## Suggested JSON for testing.
```
{
  "Name": "LuckyDip",
  "Description": "Life is like a box of chocolates + AOE changes, so stay close to your allies",
  "Rules": [
      {
        "Rule": "AbilityDamageAdjusted",
        "Config": { "Zap": 1 }
      },
      {
        "Rule": "StartCardsModified",
        "Config": {
          "HeroSorcerer": [
            { "Card": "Heal", "IsReplenishable": false },
            { "Card": "Zap", "IsReplenishable": true },
            { "Card": "TorchLight", "IsReplenishable": true },
            { "Card": "DropChest", "IsReplenishable": false },
            { "Card": "DropChest", "IsReplenishable": false }
          ],
          "HeroBard": [
            { "Card": "Heal", "IsReplenishable": false },
            { "Card": "StrengthenCourage", "IsReplenishable": true },
            { "Card": "SongOfRecovery", "IsReplenishable": true },
            { "Card": "DropChest", "IsReplenishable": false },          
            { "Card": "DropChest", "IsReplenishable": false },
            { "Card": "ShatteringVoice", "IsReplenishable": false }
          ]
        }
      },
    {
      "Rule": "StatusEffectConfig",
      "Config": [
        {
          "effectStateType": "TorchPlayer",
          "durationTurns": 15,
          "tickWhen": "StartTurn",
          "stacks": true,
          "damagePerTurn": 0,
          "clearOnNewLevel": false,
          "damageTags": null,
          "healPerTurn": 0
        },
        {
          "effectStateType": "HealingSong",
          "durationTurns": 4,
          "tickWhen": "StartTurn",
          "stacks": false,
          "damagePerTurn": 0,
          "clearOnNewLevel": false,
          "damageTags": null,
          "healPerTurn": 3
        }
      ]
    }
  ]
}
```
