### PR TITLE
Tweak BeatTheClock ruleset.

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -43,7 +43,6 @@
 
         private static void RegisterRulesets()
         {
-            HR.Rulebook.Register(SampleRuleset.Create());
             HR.Rulebook.Register(NoSurprisesRuleset.Create());
             HR.Rulebook.Register(BeatTheClockRuleset.Create());
             HR.Rulebook.Register(DifficultyEasyRuleset.Create());

--- a/HouseRules_Essentials/Rules/RoundCountLimitedRule.cs
+++ b/HouseRules_Essentials/Rules/RoundCountLimitedRule.cs
@@ -88,7 +88,7 @@
         private static void ShowRoundsLeft()
         {
             var roundsLeft = _globalRoundLimit - _globalRoundsPlayed;
-            GameUI.ShowCameraMessage($"You have {roundsLeft} left to escape...", RoundsLeftMessageDurationSeconds);
+            GameUI.ShowCameraMessage($"You have {roundsLeft} rounds left to escape...", RoundsLeftMessageDurationSeconds);
         }
 
         private static void DownAllPlayers(PieceAndTurnController pieceAndTurnController)

--- a/HouseRules_Essentials/Rulesets/BeatTheClockRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/BeatTheClockRuleset.cs
@@ -9,25 +9,31 @@
         internal static Ruleset Create()
         {
             const string name = "Beat The Clock!";
-            const string description = "Godmode. Ultra recycling. 40 rounds to beat the game.";
+            const string description = "Ultra health. Ultra card recycling. Only 15 rounds to escape...";
 
             var healthRule = new StartHealthAdjustedRule(new Dictionary<string, int>
             {
-                { "HeroGuardian", 990 },
-                { "HeroSorcerer", 990 },
-                { "HeroRouge", 990 },
-                { "HeroHunter", 990 },
-                { "HeroBard", 990 },
+                { "HeroGuardian", 190 },
+                { "HeroSorcerer", 190 },
+                { "HeroRouge", 190 },
+                { "HeroHunter", 190 },
+                { "HeroBard", 190 },
             });
-            var recyclingRule = new CardEnergyFromRecyclingMultipliedRule(6);
-            var roundLimitRule = new RoundCountLimitedRule(40);
+            var recyclingRule = new CardEnergyFromRecyclingMultipliedRule(5);
+            var roundLimitRule = new RoundCountLimitedRule(15);
+            var levelRule = new LevelPropertiesModifiedRule(new Dictionary<string, int>
+            {
+                { "FloorOneLootChests", 15 },
+                { "FloorTwoLootChests", 15 },
+            });
 
             return Ruleset.NewInstance(
                 name,
                 description,
                 healthRule,
                 recyclingRule,
-                roundLimitRule);
+                roundLimitRule,
+                levelRule);
         }
     }
 }


### PR DESCRIPTION
- Reduced HP to 200 to make health depletion at least somewhat more interesting.
- Reduced round count to 15 to increase difficulty.
- Decreased card recycling to reduce spam.
- Added POIs to increase difficulty by way of hiding the exit.