### PR TITLE
Use item's key when intepolating strings.

### DIFF
--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -146,7 +146,7 @@
             });
 
             EffectStateType[] effs = { EffectStateType.Diseased, EffectStateType.Stunned, EffectStateType.MarkOfAvalon, EffectStateType.Weaken, EffectStateType.Frozen, EffectStateType.Tangled, EffectStateType.Petrified };
-            var pila = new Essentials.Rules.PieceImmunityListAdjustedRule(new Dictionary<string, EffectStateType[]> { { "Sorcerer", effs } } );
+            var pila = new Essentials.Rules.PieceImmunityListAdjustedRule(new Dictionary<BoardPieceId, EffectStateType[]> { { BoardPieceId.HeroSorcerer, effs } } );
 
             var sec = new List<StatusEffectData>
             {

--- a/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
@@ -8,25 +8,25 @@
     using HouseRules.Types;
     using UnityEngine;
 
-    public sealed class PieceImmunityListAdjustedRule : Rule, IConfigWritable<Dictionary<string, EffectStateType[]>>, IMultiplayerSafe
+    public sealed class PieceImmunityListAdjustedRule : Rule, IConfigWritable<Dictionary<BoardPieceId, EffectStateType[]>>, IMultiplayerSafe
     {
         public override string Description => "Piece immunities are adjusted";
 
-        private readonly Dictionary<string, EffectStateType[]> _adjustments;
-        private readonly Dictionary<string, EffectStateType[]> _originals;
+        private readonly Dictionary<BoardPieceId, EffectStateType[]> _adjustments;
+        private readonly Dictionary<BoardPieceId, EffectStateType[]> _originals;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PieceImmunityListAdjustedRule"/> class.
         /// </summary>
         /// <param name="adjustments">Dict of piece name and EffectStateType[]
         /// Replaces original settings with new list.</param>
-        public PieceImmunityListAdjustedRule(Dictionary<string, EffectStateType[]> adjustments)
+        public PieceImmunityListAdjustedRule(Dictionary<BoardPieceId, EffectStateType[]> adjustments)
         {
             _adjustments = adjustments;
-            _originals = new Dictionary<string, EffectStateType[]>();
+            _originals = new Dictionary<BoardPieceId, EffectStateType[]>();
         }
 
-        public Dictionary<string, EffectStateType[]> GetConfigObject() => _adjustments;
+        public Dictionary<BoardPieceId, EffectStateType[]> GetConfigObject() => _adjustments;
 
         protected override void OnPostGameCreated(GameContext gameContext)
         {

--- a/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
@@ -45,7 +45,7 @@
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _originals)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
                 var property = Traverse.Create(pieceConfig).Property<EffectStateType[]>("ImmuneToStatusEffects");
                 property.Value = item.Value;
             }


### PR DESCRIPTION
PR was originally for:
2b577e5 Use item's key when intepolating strings.

But in the process, I figured I'd boyscout:
fddec51 Use BoardPieceId type instead of string for static type checking.

Using the static type `BoardPieceId` in place of a string allows us better compile-time checking, and will fail-fast when reading in a ruleset from JSON, where the string the user provided does not map to a boardpieceId (instead of allowing the rule to continue, and then only failing during rule activation).