### PR TITLE
Added 'The Swirl' ruleset.

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -49,6 +49,7 @@
             HR.Rulebook.Register(DifficultyEasyRuleset.Create());
             HR.Rulebook.Register(DifficultyHardRuleset.Create());
             HR.Rulebook.Register(DifficultyLegendaryRuleset.Create());
+            HR.Rulebook.Register(TheSwirlRuleset.Create());
             HR.Rulebook.Register(QuickandDeadRuleset.Create());
         }
     }

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -41,6 +41,7 @@
     <Compile Include="Rulesets\QuickAndDeadRuleset.cs" />
     <Compile Include="Rulesets\SampleRuleset.cs" />
     <Compile Include="Rulesets\NoSurprisesRuleset.cs" />
+    <Compile Include="Rulesets\TheSwirlRuleset.cs" />
     <Compile Include="Rules\AbilityActionCostAdjustedRule.cs" />
     <Compile Include="Rules\AbilityRandomPieceListRule.cs" />
     <Compile Include="Rules\AbilityDamageAdjustedRule.cs" />

--- a/HouseRules_Essentials/Rules/LevelExitLockedUntilAllEnemiesDefeatedRule.cs
+++ b/HouseRules_Essentials/Rules/LevelExitLockedUntilAllEnemiesDefeatedRule.cs
@@ -35,7 +35,7 @@
             harmony.Patch(
                 original: AccessTools.Constructor(
                     typeof(BoardgameActionPieceDied),
-                    new[] {typeof(GameContext), typeof(int[]), typeof(int)}),
+                    new[] { typeof(GameContext), typeof(int[]), typeof(int) }),
                 postfix: new HarmonyMethod(
                     typeof(LevelExitLockedUntilAllEnemiesDefeatedRule),
                     nameof(BoardgameActionPieceDied_Constructor_Postfix)));

--- a/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
@@ -1,0 +1,71 @@
+﻿namespace HouseRules.Essentials.Rulesets
+{
+    using System.Collections.Generic;
+    using DataKeys;
+    using HouseRules.Essentials.Rules;
+    using HouseRules.Types;
+
+    internal static class TheSwirlRuleset
+    {
+        internal static Ruleset Create()
+        {
+            const string name = "The Swirl";
+            const string description = "Ultra health. Ultra card recycling. Only 15 rounds to escape...";
+
+            var startingCards = new List<StartCardsModifiedRule.CardConfig>
+            {
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Implosion, IsReplenishable = true },
+            };
+            var startingCardsRule = new StartCardsModifiedRule(new Dictionary<BoardPieceId, List<StartCardsModifiedRule.CardConfig>>
+            {
+                { BoardPieceId.HeroBard, startingCards },
+                { BoardPieceId.HeroGuardian, startingCards },
+                { BoardPieceId.HeroHunter, startingCards },
+                { BoardPieceId.HeroRouge, startingCards },
+                { BoardPieceId.HeroSorcerer, startingCards },
+            });
+
+            var allowedCards = new List<AbilityKey> { AbilityKey.PoisonGasGrenade, AbilityKey.Fireball };
+            var allowedCardsRule = new CardAdditionOverriddenRule(new Dictionary<BoardPieceId, List<AbilityKey>>
+            {
+                { BoardPieceId.HeroBard, allowedCards },
+                { BoardPieceId.HeroGuardian, allowedCards },
+                { BoardPieceId.HeroHunter, allowedCards },
+                { BoardPieceId.HeroRouge, allowedCards },
+                { BoardPieceId.HeroSorcerer, allowedCards },
+            });
+
+            var piecesAdjustedRule = new PieceConfigAdjustedRule(new List<List<string>>
+            {
+                new List<string> { "HeroBard", "StartHealth", "50" },
+                new List<string> { "HeroGuardian", "StartHealth", "50" },
+                new List<string> { "HeroHunter", "StartHealth", "50" },
+                new List<string> { "HeroRouge", "StartHealth", "50" },
+                new List<string> { "HeroSorcerer", "StartHealth", "50" },
+            });
+
+            var levelPropertiesRule = new LevelPropertiesModifiedRule(new Dictionary<string, int>
+            {
+                { "FloorOneHealingFountains", 9 },
+                { "FloorOneLootChests", 9 },
+                { "FloorTwoHealingFountains", 9 },
+                { "FloorTwoLootChests", 9 },
+                { "FloorThreeHealingFountains", 9 },
+                { "FloorThreeLootChests", 9 },
+            });
+
+            var respawnsDisabledRule = new EnemyRespawnDisabledRule(true);
+            var levelExitLockedRule = new LevelExitLockedUntilAllEnemiesDefeatedRule(true);
+
+            return Ruleset.NewInstance(
+                name,
+                description,
+                startingCardsRule,
+                allowedCardsRule,
+                piecesAdjustedRule,
+                levelPropertiesRule,
+                respawnsDisabledRule,
+                levelExitLockedRule);
+        }
+    }
+}

--- a/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
@@ -10,7 +10,7 @@
         internal static Ruleset Create()
         {
             const string name = "The Swirl";
-            const string description = "Ultra health. Ultra card recycling. Only 15 rounds to escape...";
+            const string description = "Only poison, fireballs and vortexes. Health and POIs aplenty, but must defeat all enemies to escape.";
 
             var startingCards = new List<StartCardsModifiedRule.CardConfig>
             {


### PR DESCRIPTION
Only poison, fireballs and vortexes. Health and POIs aplenty, but must defeat all enemies to escape.

**Rules:**
- Starting cards: Replenishable Vortex.
- New cards overridden: Poison Bomb and Fireball
- Hero starting health: 50
- Level 1 POIs:  2 healing, 8 chests
- Level 2 POIs:  4 healing, 12 chests
- Level 3 POIs:  4 healing, 12 chests
- Respawns disabled.
- Level exit locked until all enemies defeated.