### PR TITLE
Introduce RoomCode mod.

### DIFF
--- a/DemeoMods.sln
+++ b/DemeoMods.sln
@@ -31,6 +31,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{8C7F69F7-5
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HouseRules_Configuration", "HouseRules_Configuration\HouseRules_Configuration.csproj", "{ED5D884D-FC02-4095-886E-C18369F4051D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoomCode", "RoomCode\RoomCode.csproj", "{B2A6BA28-0902-4271-94AB-C91F5F2A2B30}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -61,6 +63,10 @@ Global
 		{ED5D884D-FC02-4095-886E-C18369F4051D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED5D884D-FC02-4095-886E-C18369F4051D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ED5D884D-FC02-4095-886E-C18369F4051D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2A6BA28-0902-4271-94AB-C91F5F2A2B30}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2A6BA28-0902-4271-94AB-C91F5F2A2B30}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2A6BA28-0902-4271-94AB-C91F5F2A2B30}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2A6BA28-0902-4271-94AB-C91F5F2A2B30}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RoomCode/ModPatcher.cs
+++ b/RoomCode/ModPatcher.cs
@@ -1,0 +1,54 @@
+﻿namespace RoomCode
+{
+    using System.Linq;
+    using System.Reflection;
+    using HarmonyLib;
+
+    internal static class ModPatcher
+    {
+        private static int _roomCodeAttempts;
+
+        internal static void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(GameStateMachine), "GetRandomRoomCode"),
+                prefix: new HarmonyMethod(typeof(ModPatcher), nameof(GameStateMachine_GetRandomRoomCode_Prefix)));
+
+            harmony.Patch(
+                original: AccessTools
+                    .Inner(typeof(GameStateMachine), "CreatingGameState").GetTypeInfo()
+                    .GetDeclaredMethod("OnJoinedRoom"),
+                prefix: new HarmonyMethod(typeof(ModPatcher), nameof(CreatingGameState_OnJoinedRoom_Prefix)));
+        }
+
+        private static bool GameStateMachine_GetRandomRoomCode_Prefix(ref string __result)
+        {
+            if (!RoomCodeMod.Enabled)
+            {
+                return true;
+            }
+
+            if (!RoomCodeMod.RoomCodes.Any())
+            {
+                return true;
+            }
+
+            if (_roomCodeAttempts >= RoomCodeMod.RoomCodes.Count)
+            {
+                RoomCodeMod.Logger.Msg("All proposed room codes unavailable.");
+                return true;
+            }
+
+            __result = RoomCodeMod.RoomCodes.ElementAt(_roomCodeAttempts);
+            ++_roomCodeAttempts;
+
+            RoomCodeMod.Logger.Msg($"Proposing room code: {__result}");
+            return false;
+        }
+
+        private static void CreatingGameState_OnJoinedRoom_Prefix()
+        {
+            _roomCodeAttempts = 0;
+        }
+    }
+}

--- a/RoomCode/Properties/AssemblyInfo.cs
+++ b/RoomCode/Properties/AssemblyInfo.cs
@@ -1,0 +1,43 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+using MelonLoader;
+using RoomCode;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("RoomCode")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Orendain")]
+[assembly: AssemblyProduct("RoomCode")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("B2A6BA28-0902-4271-94AB-C91F5F2A2B30")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+
+// Melon Loader.
+[assembly: MelonInfo(typeof(RoomCodeMod), "RoomCode", "1.0.0", "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonGame("Resolution Games", "Demeo")]
+[assembly: MelonID("581308")]
+[assembly: VerifyLoaderVersion("0.5.3", true)]

--- a/RoomCode/README.md
+++ b/RoomCode/README.md
@@ -1,0 +1,28 @@
+# RoomCode
+
+Set your own room code.
+
+After installing the mod, run the game once. A configuration file will be
+created in your Demeo game directory. Specifically, at:
+`<Demeo_Game_Directory>/UserData/MelonPreferences.cfg`
+
+You should see something like the following in that file.
+
+```toml
+[RoomCode]
+enabled = true
+codes = [ ]
+```
+
+`enabled`: Set to `true` to enable the mod, or `false` to disable it.
+`codes`: List all room codes you'd like to use, in order of preference.
+
+If none of the room codes are available, the mod will fall back to Demeo's
+random room code generation.
+
+**Example configuration:**
+```toml
+[RoomCode]
+enabled = true
+codes = ["8888", "7777", "1234"]
+```

--- a/RoomCode/RoomCode.csproj
+++ b/RoomCode/RoomCode.csproj
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <ProjectGuid>{B2A6BA28-0902-4271-94AB-C91F5F2A2B30}</ProjectGuid>
+        <OutputType>Library</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <RootNamespace>RoomCode</RootNamespace>
+        <AssemblyName>RoomCode</AssemblyName>
+        <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+        <FileAlignment>512</FileAlignment>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <OutputPath>bin\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugType>pdbonly</DebugType>
+        <Optimize>true</Optimize>
+        <OutputPath>bin\Release\</OutputPath>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="Assembly-CSharp">
+            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
+        </Reference>
+        <Reference Include="MelonLoader">
+            <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
+        </Reference>
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="ModPatcher.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs" />
+        <Compile Include="RoomCodeMod.cs" />
+    </ItemGroup>
+    <ItemGroup>
+      <Content Include="README.md" />
+    </ItemGroup>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+    <Target Name="CopyToModsDir" AfterTargets="Build">
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(SteamDemeoDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(OculusDemeoDir)\Mods" />
+    </Target>
+</Project>

--- a/RoomCode/RoomCodeMod.cs
+++ b/RoomCode/RoomCodeMod.cs
@@ -1,0 +1,32 @@
+﻿namespace RoomCode
+{
+    using System.Collections.Generic;
+    using MelonLoader;
+
+    internal class RoomCodeMod : MelonMod
+    {
+        internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("RoomCode");
+
+        internal static bool Enabled { get; private set; }
+
+        internal static List<string> RoomCodes { get; private set; }
+
+        public override void OnApplicationStart()
+        {
+            var harmony = new HarmonyLib.Harmony("com.orendain.demeomods.roomcode");
+            ModPatcher.Patch(harmony);
+
+            InitializeConfiguration();
+        }
+
+        private static void InitializeConfiguration()
+        {
+            var configCategory = MelonPreferences.CreateCategory("RoomCode");
+            var enabledEntry = configCategory.CreateEntry("enabled", true);
+            var roomCodesEntry = configCategory.CreateEntry("codes", new List<string>());
+
+            Enabled = enabledEntry.Value;
+            RoomCodes = roomCodesEntry.Value;
+        }
+    }
+}


### PR DESCRIPTION
Directly from the committed README:

---

Set your own room code.

After installing the mod, run the game once. A configuration file will be
created in your Demeo game directory. Specifically, at:
`<Demeo_Game_Directory>/UserData/MelonPreferences.cfg`

You should see something like the following in that file.

```toml
[RoomCode]
enabled = true
codes = [ ]
```

`enabled`: Set to `true` to enable the mod, or `false` to disable it.
`codes`: List all room codes you'd like to use, in order of preference.

If none of the room codes are available, the mod will fall back to Demeo's
random room code generation.

**Example configuration:**
```toml
[RoomCode]
enabled = true
codes = ["8888", "7777", "1234"]
```