### PR TITLE
Add support for PieceConfigAdjustedRule to set float properties.

### DIFF
--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using DataKeys;
+    using HouseRules.Essentials.Rules;
     using HouseRules.Types;
     using MelonLoader;
     using UnityEngine;
@@ -96,23 +97,23 @@
             var ehs = new Essentials.Rules.EnemyHealthScaledRule(2);
             var erd = new Essentials.Rules.EnemyRespawnDisabledRule(true);
             var gpus = new Essentials.Rules.GoldPickedUpMultipliedRule(2f);
-            var pca = new Essentials.Rules.PieceConfigAdjustedRule(new List<List<string>>
+            var pca = new Essentials.Rules.PieceConfigAdjustedRule(new List<PieceConfigAdjustedRule.PieceProperty>
             {
-                new List<string> { "HeroSorcerer", "MoveRange", "6" }, // Increased from the default of 4
-                new List<string> { "HeroSorcerer", "StartHealth", "20" }, // 10 extra HP
-                new List<string> { "HeroGuardian", "MoveRange", "5" },
-                new List<string> { "HeroGuardian", "StartHealth", "15" },
-                new List<string> { "HeroHunter", "MoveRange", "6" },
-                new List<string> { "HeroHunter", "StartHealth", "18" },
-                new List<string> { "HeroBard", "MoveRange", "8" },
-                new List<string> { "HeroBard", "StartHealth", "12" },
-                new List<string> { "HeroRouge", "MoveRange", "5" },
-                new List<string> { "HeroRouge", "StartHealth", "20" },
-                new List<string> { "WolfCompanion", "StartHealth", "20" }, // Wolf lots of HP wandering through gas
-                new List<string> { "SwordOfAvalon", "StartHealth", "20" },
-                new List<string> { "BeaconOfSmite", "StartHealth", "25" },
-                new List<string> { "BeaconOfSmite", "ActionPoint", "2" }, // Behemoth gets to fire two rounds
-                new List<string> { "MonsterBait", "StartHealth", "25" }, // Lure needs to last a little longer
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroSorcerer, Property = "MoveRange", Value = 6 }, // Increased from the default of 4
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroSorcerer, Property = "StartHealth", Value = 20 }, // 10 extra HP
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroGuardian, Property = "MoveRange", Value = 5 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroGuardian, Property = "StartHealth", Value = 15 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroHunter, Property = "MoveRange", Value = 6 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroHunter, Property = "StartHealth", Value = 18 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroBard, Property = "MoveRange", Value = 8 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroBard, Property = "StartHealth", Value = 12 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroRouge, Property = "MoveRange", Value = 5 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroRouge, Property = "StartHealth", Value = 20 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.WolfCompanion, Property = "StartHealth", Value = 20 }, // Wolf lots of HP wandering through gas
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.SwordOfAvalon, Property = "StartHealth", Value = 20 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.BeaconOfSmite, Property = "StartHealth", Value = 25 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.BeaconOfSmite, Property = "ActionPoint", Value = 2 }, // Behemoth gets to fire two rounds
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.MonsterBait, Property = "StartHealth", Value = 25 }, // Lure needs to last a little longer
             });
             var rnsg = new Essentials.Rules.RatNestsSpawnGoldRule(8);
             var cards = new List<Essentials.Rules.StartCardsModifiedRule.CardConfig>

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -279,8 +279,8 @@ An example [LuckyDip Ruleset](../docs/LuckyDip.json) which uses many differnt ru
 - __PieceConfigAdjustedRule__: Piece configuration is adjusted
   - See [PieceConfig.md](../docs/PieceConfig.md) for information about modifiable fields.
   - Allows customization of many of the properties for each game Piece. 🩺Health, 🎲ActionPoints, 🏃Movement, ⚔️MeleeDamage, etc
-  - Config accepts List of Lists e.g. `[ [ "PieceName1", "ParamName1", int ], [ "PieceName1", "ParamName1", int ], ... ]`
-  - Only works for Integer fields. The configured value replaces the default.  
+  - Config accepts List of Dicts e.g. `[ {}, {}, ]`
+  - Only works for integer and float fields. The configured value replaces the default.
 
   ###### _Example JSON config for PieceConfigAdjustedRule_
 
@@ -288,14 +288,12 @@ An example [LuckyDip Ruleset](../docs/LuckyDip.json) which uses many differnt ru
   {
     "Rule": "PieceConfigAdjustedRule",
     "Config": [
-      [ "HeroSorcerer", "StartHealth", "20" ],
-      [ "HeroSorcerer", "MoveRange", "5" ],
-      [ "HeroSorcerer", "ActionPoint", "3" ],
-      [ "WolfCompanion", "StartHealth", "30" ],
-      [ "SwordOfAvalon", "StartHealth", "20" ],
-      [ "BeaconOfSmite", "StartHealth", "20" ],
-      [ "BeaconOfSmite", "ActionPoint", "2" ],
-      [ "MonsterBait", "StartHealth", "30" ],
+      { "Piece": "HeroSorcerer", "Property": "StartHealth", "Value": 20 },
+      { "Piece": "HeroSorcerer", "Property": "MoveRange", "Value": 5 },
+      { "Piece": "HeroSorcerer", "Property": "ActionPoint", "Value": 3 },
+      { "Piece": "MonsterBait", "Property": "StartHealth", "Value": 30 },
+      { "Piece": "BeaconOfSmite", "Property": "ActionPoint", "Value": 2 },
+      { "Piece": "HeroSorcerer", "Property": "BerserkBelowHealth", "Value": 0.8 }
     ]
   },
   ```

--- a/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -1,5 +1,6 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Boardgame;
@@ -8,47 +9,82 @@
     using HouseRules.Types;
     using UnityEngine;
 
-    public sealed class PieceConfigAdjustedRule : Rule, IConfigWritable<List<List<string>>>, IMultiplayerSafe
+    public sealed class PieceConfigAdjustedRule : Rule, IConfigWritable<List<PieceConfigAdjustedRule.PieceProperty>>, IMultiplayerSafe
     {
         public override string Description => "Piece configuration is adjusted";
 
-        private readonly List<List<string>> _adjustments;
-        private readonly List<List<string>> _originals;
+        private readonly List<PieceProperty> _adjustments;
+        private List<PieceProperty> _originals;
+
+        public struct PieceProperty
+        {
+            public BoardPieceId Piece;
+            public string Property;
+            public float Value;
+        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PieceConfigAdjustedRule"/> class.
         /// </summary>
-        /// <param name="adjustments">String lists of PieceNames, PropertyNames and integer values
-        /// replacing defaults.</param>
-        public PieceConfigAdjustedRule(List<List<string>> adjustments)
+        /// <param name="adjustments">List of <see cref="PieceProperty"/> that represent PieceConfig properties to replace.</param>
+        public PieceConfigAdjustedRule(List<PieceProperty> adjustments)
         {
             _adjustments = adjustments;
-            _originals = new List<List<string>>();
+            _originals = new List<PieceProperty>();
         }
 
-        public List<List<string>> GetConfigObject() => _adjustments;
+        public List<PieceProperty> GetConfigObject() => _adjustments;
 
         protected override void OnPostGameCreated(GameContext gameContext)
         {
-            var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
-            foreach (var item in _adjustments)
-            {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item[0]}"));
-                var property = Traverse.Create(pieceConfig).Property<int>(item[1]);
-                _originals.Add(new List<string> { item[0], item[1], property.Value.ToString() });
-                property.Value = int.Parse(item[2]);
-            }
+            _originals = ReplaceExistingProperties(_adjustments);
         }
 
         protected override void OnDeactivate(GameContext gameContext)
         {
+            ReplaceExistingProperties(_originals);
+        }
+
+        /// <summary>
+        /// Replaces existing PieceConfig properties with those specified.
+        /// </summary>
+        /// <returns>The list of previous PieceConfig properties that are now replaced.</returns>
+        private static List<PieceProperty> ReplaceExistingProperties(List<PieceProperty> pieceProperties)
+        {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
-            foreach (var item in _originals)
+            var previousProperties = new List<PieceProperty>();
+            foreach (var item in pieceProperties)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item[0]}"));
-                var property = Traverse.Create(pieceConfig).Property<int>(item[1]);
-                property.Value = int.Parse(item[2]);
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Piece}"));
+                var propertyTraverse = Traverse.Create(pieceConfig).Property(item.Property);
+                var castedNewValue = CastPropertyValue(item.Value, propertyTraverse.GetValueType());
+
+                previousProperties.Add(new PieceProperty
+                {
+                    Piece = item.Piece,
+                    Property = item.Property,
+                    Value = Convert.ToSingle(propertyTraverse.GetValue()),
+                });
+
+                propertyTraverse.SetValue(castedNewValue);
             }
+
+            return previousProperties;
+        }
+
+        private static object CastPropertyValue(float value, Type propertyValueType)
+        {
+            if (propertyValueType == typeof(int))
+            {
+                return (int)value;
+            }
+
+            if (propertyValueType == typeof(float))
+            {
+                return value;
+            }
+
+            throw new ArgumentException($"Can not support a piece property of type: {propertyValueType}");
         }
     }
 }

--- a/HouseRules_Essentials/Rulesets/BeatTheClockRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/BeatTheClockRuleset.cs
@@ -1,6 +1,7 @@
 ﻿namespace HouseRules.Essentials.Rulesets
 {
     using System.Collections.Generic;
+    using DataKeys;
     using HouseRules.Essentials.Rules;
     using HouseRules.Types;
 
@@ -11,13 +12,13 @@
             const string name = "Beat The Clock!";
             const string description = "Ultra health. Ultra card recycling. Only 15 rounds to escape...";
 
-            var healthRule = new Essentials.Rules.PieceConfigAdjustedRule(new List<List<string>>
+            var healthRule = new PieceConfigAdjustedRule(new List<PieceConfigAdjustedRule.PieceProperty>
             {
-                new List<string> { "HeroGuardian", "StartHealth", "200" },
-                new List<string> { "HeroSorcerer", "StartHealth", "200" },
-                new List<string> { "HeroRouge", "StartHealth", "200" },
-                new List<string> { "HeroHunter", "StartHealth", "200" },
-                new List<string> { "HeroBard", "StartHealth", "200" },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroBard, Property = "StartHealth", Value = 200 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroGuardian, Property = "StartHealth", Value = 200 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroHunter, Property = "StartHealth", Value = 200 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroRouge, Property = "StartHealth", Value = 200 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroSorcerer, Property = "StartHealth", Value = 200 },
             });
             var recyclingRule = new CardEnergyFromRecyclingMultipliedRule(5);
             var roundLimitRule = new RoundCountLimitedRule(15);

--- a/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
@@ -56,13 +56,13 @@
                 { BoardPieceId.HeroSorcerer, allowedCards },
             });
 
-            var piecesAdjustedRule = new PieceConfigAdjustedRule(new List<List<string>>
+            var piecesAdjustedRule = new PieceConfigAdjustedRule(new List<PieceConfigAdjustedRule.PieceProperty>
             {
-                new List<string> { "HeroBard", "StartHealth", "50" },
-                new List<string> { "HeroGuardian", "StartHealth", "50" },
-                new List<string> { "HeroHunter", "StartHealth", "50" },
-                new List<string> { "HeroRouge", "StartHealth", "50" },
-                new List<string> { "HeroSorcerer", "StartHealth", "50" },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroBard, Property = "StartHealth", Value = 50 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroGuardian, Property = "StartHealth", Value = 50 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroHunter, Property = "StartHealth", Value = 50 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroRouge, Property = "StartHealth", Value = 50 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroSorcerer, Property = "StartHealth", Value = 50 },
             });
 
             var levelPropertiesRule = new LevelPropertiesModifiedRule(new Dictionary<string, int>


### PR DESCRIPTION
**Changes:**
- Add support for PieceConfigAdjustedRule to set float properties.
- Changed the parameter type of List<List<string>> to List<PieceProperty>, where PieceProperty is a statically-typed structure.
- Updated rules to the new parameter type.

Additionally resolves https://github.com/orendain/DemeoMods/issues/5.

Example JSON ruleset for testing _(self-fireballing as a Sorcerer will trigger Berserk)_:
```json
{
  "Name": "TestingGrounds",
  "Description": "Testing Grounds.",
  "Rules": [
    {
      "Rule": "PieceConfigAdjustedRule",
      "Config": [
          { "Piece": "HeroSorcerer", "Property": "StartHealth", "Value": 20 },
          { "Piece": "HeroSorcerer", "Property": "BerserkBelowHealth", "Value": 0.8 }
      ]
    }
  ]
}
```
