### PR TITLE
A rule for adjusting the StatModifiers

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -38,6 +38,7 @@
             HR.Rulebook.Register(typeof(RatNestsSpawnGoldRule));
             HR.Rulebook.Register(typeof(RoundCountLimitedRule));
             HR.Rulebook.Register(typeof(StartCardsModifiedRule));
+            HR.Rulebook.Register(typeof(StatModifiersOverridenRule));
             HR.Rulebook.Register(typeof(StatusEffectConfigRule));
         }
 

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Rulesets\NoSurprisesRuleset.cs" />
     <Compile Include="Rulesets\TheSwirlRuleset.cs" />
     <Compile Include="Rules\AbilityActionCostAdjustedRule.cs" />
+    <Compile Include="Rules\StatModifiersOverridenRule.cs" />
     <Compile Include="Rules\AbilityRandomPieceListRule.cs" />
     <Compile Include="Rules\AbilityDamageAdjustedRule.cs" />
     <Compile Include="Rules\CardAdditionOverriddenRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -382,10 +382,35 @@ An example [LuckyDip Ruleset](../docs/LuckyDip.json) which uses many differnt ru
      }
    },
    ```
-- __StatusEffectConfigRule__: The parameters of different StatusEffects (🔥Torch, 🤢Poison, 🥶Frozen) can be overridden
-- Accepts a list of overrides which take the place of the default config. 
+
+  - __StatModifiersOverriden__: The additiveBonus parameters of StatModifiers are overridden.
+  - There are only six different StatModifiers in the game. They are used by 💪Strength, 🦶Speed, 🛡️ReplenishArmor, HuntersMark, etc
+  - Accepts a list of overrides which take the place of the default config.
   - If no override is specified, the default is used instead.
-  - Default values can be found in `StatusEffectsConfig.effectsConfig` 
+  - Config accepts list of dict of StatModifier names, integer values. `{"Statmodifier": int}, {}, }`
+
+  ###### _Example JSON config for StatModifiersOverriden_
+
+  ```json
+    {
+      "Rule": "StatModifiersOverriden",
+      "Config": {
+        "Strength": 2,
+        "Speed": 2,
+        "MarkOfAvalon": -4,
+        "ReplenishBarkArmor": 4,
+        "SongOfResilience": 6,
+        "ReplenishArmor": 4,
+        
+        
+      }
+    },
+   ```
+
+  - __StatusEffectConfigRule__: The parameters of different StatusEffects (🔥Torch, 🤢Poison, 🥶Frozen) can be overridden
+  - Accepts a list of overrides which take the place of the default config.
+  - If no override is specified, the default is used instead.
+  - Default values can be found in `StatusEffectsConfig.effectsConfig`
   - Config accepts list of dicts e.g. `[ {}, {}, ]`
 
   ###### _Example JSON config for StatusEffectConfigRule_

--- a/HouseRules_Essentials/Rules/StatModifiersOverridenRule.cs
+++ b/HouseRules_Essentials/Rules/StatModifiersOverridenRule.cs
@@ -1,0 +1,54 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Boardgame;
+    using HarmonyLib;
+    using HouseRules.Types;
+    using UnityEngine;
+
+    public sealed class StatModifiersOverridenRule : Rule, IConfigWritable<Dictionary<string, int>>, IMultiplayerSafe
+    {
+        public override string Description => "StatModifiersOverridenRule are overridden";
+
+        private readonly Dictionary<string, int> _adjustments;
+        private readonly Dictionary<string, int> _originals;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StatModifiersOverridenRule"/> class.
+        /// </summary>
+        /// <param name="adjustments">Key-value pairs mapping the name of a StatModifier and the new additiveBonus setting.
+        /// Overwrites existing settings. Some StatModifiers require negative values.</param>
+        public StatModifiersOverridenRule(Dictionary<string, int> adjustments)
+        {
+            _adjustments = adjustments;
+            _originals = new Dictionary<string, int>();
+        }
+
+        public Dictionary<string, int> GetConfigObject() => _adjustments;
+
+        protected override void OnPostGameCreated(GameContext gameContext)
+        {
+            var typeByName = AccessTools.TypeByName("Boardgame.GameplayEffects.StatModifier");
+            var statModifiers = Resources.FindObjectsOfTypeAll(typeByName);
+            foreach (var item in _adjustments)
+            {
+                var statModifier = statModifiers.First(c => c.name.Equals($"{item.Key}(Clone)"));
+                _originals[item.Key] = Traverse.Create(statModifier).Field<int>("additiveBonus").Value;
+                Traverse.Create(statModifier).Field<int>("additiveBonus").Value = item.Value;
+            }
+        }
+
+        protected override void OnDeactivate(GameContext gameContext)
+        {
+            var typeByName = AccessTools.TypeByName("Boardgame.GameplayEffects.StatModifier");
+            var statModifiers = Resources.FindObjectsOfTypeAll(typeByName);
+            foreach (var item in _originals)
+            {
+                var statModifier = statModifiers.First(c => c.name.Equals($"{item.Key}(Clone)"));
+                _originals[item.Key] = Traverse.Create(statModifier).Field<int>("additiveBonus").Value;
+                Traverse.Create(statModifier).Field<int>("additiveBonus").Value = item.Value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# A rule for adjusting the StatModifiers
StatModifiers are only used by just six abilities.

Adjusting the additiveBonus can allow you to make StrenghtPotions that give you +3 strength etc.

## JSON for testing
Increments or decrements all of the possible different StatModifiers by one point.

```
    {
      "Rule": "StatModifiersOverriden",
      "Config": {
        "Strength": 2,
        "Speed": 2,
        "MarkOfAvalon": -4,
        "ReplenishBarkArmor": 4,
        "SongOfResilience": 6,
        "ReplenishArmor": 4,  
      }
    },
```

Resolves #90 