### PR TITLE
Set HouseRules version to 1.0.0, and update it's MelonID.

### DIFF
--- a/HouseRules_Configuration/Properties/AssemblyInfo.cs
+++ b/HouseRules_Configuration/Properties/AssemblyInfo.cs
@@ -37,8 +37,8 @@ using MelonLoader;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 // Melon Loader.
-[assembly: MelonInfo(typeof(ConfigurationMod), "HouseRules: Configuration", "0.1.0", "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonInfo(typeof(ConfigurationMod), "HouseRules: Configuration", "1.0.0", "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
-[assembly: MelonID("576572")]
+[assembly: MelonID("574512")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]
 [assembly: MelonAdditionalDependencies("HouseRules_Core")]

--- a/HouseRules_Core/Properties/AssemblyInfo.cs
+++ b/HouseRules_Core/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using MelonLoader;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 // Melon Loader.
-[assembly: MelonInfo(typeof(CoreMod), "HouseRules: Core", "0.1.0", "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonInfo(typeof(CoreMod), "HouseRules: Core", "1.0.0", "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonID("574512")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]

--- a/HouseRules_Essentials/Properties/AssemblyInfo.cs
+++ b/HouseRules_Essentials/Properties/AssemblyInfo.cs
@@ -37,8 +37,8 @@ using MelonLoader;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 // Melon Loader.
-[assembly: MelonInfo(typeof(EssentialsMod), "HouseRules: Essentials", "0.1.0", "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonInfo(typeof(EssentialsMod), "HouseRules: Essentials", "1.0.0", "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
-[assembly: MelonID("574514")]
+[assembly: MelonID("574512")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]
 [assembly: MelonAdditionalDependencies("HouseRules_Core")]


### PR DESCRIPTION
Set HouseRules version to 1.0.0, and update it's MelonID.

The MelonID is non-unique and represents the CurseForge project ID that the mods are grouped under.  For simplicity, the three mods/DLLs make sense to be shipped together, thus a single CurseForge project, and thus a unified MelonID.