### PR TITLE
Two of the Boss characters are inconsistently named.

### DIFF
--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -4,6 +4,7 @@ namespace HouseRules
     using System.Linq;
     using System.Text;
     using Boardgame;
+    using DataKeys;
     using HouseRules.Types;
     using MelonLoader;
 
@@ -17,6 +18,16 @@ namespace HouseRules
         public static Ruleset SelectedRuleset { get; private set; } = Ruleset.None;
 
         internal static bool IsRulesetActive { get; private set; }
+
+        public static string FixBossNames(BoardPieceId piece)
+        {
+            if (piece == BoardPieceId.DarkElfGoddessBoss || piece == BoardPieceId.CavetrollBoss)
+            {
+                return piece.ToString().Replace("Boss", "_Boss");
+            }
+
+            return piece.ToString();
+        }
 
         public static void SelectRuleset(string ruleset)
         {

--- a/HouseRules_Essentials/Rules/PieceAbilityListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceAbilityListOverriddenRule.cs
@@ -31,9 +31,10 @@
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            string lookupstring = string.Empty;
             foreach (var item in _adjustments)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 _originals[item.Key] = pieceConfig.Abilities;
                 var property = Traverse.Create(pieceConfig).Property<List<AbilityKey>>("Abilities");
                 property.Value = item.Value;
@@ -45,7 +46,7 @@
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _originals)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 var property = Traverse.Create(pieceConfig).Property<List<AbilityKey>>("Abilities");
                 property.Value = item.Value;
             }

--- a/HouseRules_Essentials/Rules/PieceBehavioursListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceBehavioursListOverriddenRule.cs
@@ -29,12 +29,15 @@
 
         public Dictionary<BoardPieceId, Behaviour[]> GetConfigObject() => _adjustments;
 
+
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            string lookupstring = string.Empty;
             foreach (var item in _adjustments)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+         
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 _originals[item.Key] = pieceConfig.Behaviours;
                 var property = Traverse.Create(pieceConfig).Property<Behaviour[]>("Behaviours");
                 property.Value = item.Value;
@@ -46,7 +49,7 @@
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _originals)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 var property = Traverse.Create(pieceConfig).Property<Behaviour[]>("Behaviours");
                 property.Value = item.Value;
             }

--- a/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -35,6 +35,8 @@
 
         public List<PieceProperty> GetConfigObject() => _adjustments;
 
+
+
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             _originals = ReplaceExistingProperties(_adjustments);
@@ -53,9 +55,10 @@
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             var previousProperties = new List<PieceProperty>();
+            string lookupstring = string.Empty;
             foreach (var item in pieceProperties)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Piece}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Piece)}"));
                 var propertyTraverse = Traverse.Create(pieceConfig).Property(item.Property);
                 var castedNewValue = CastPropertyValue(item.Value, propertyTraverse.GetValueType());
 

--- a/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
@@ -31,9 +31,10 @@
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            string lookupstring = string.Empty;
             foreach (var item in _adjustments)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 _originals[item.Key] = pieceConfig.ImmuneToStatusEffects;
                 var property = Traverse.Create(pieceConfig).Property<EffectStateType[]>("ImmuneToStatusEffects");
                 property.Value = item.Value;
@@ -45,7 +46,7 @@
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _originals)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 var property = Traverse.Create(pieceConfig).Property<EffectStateType[]>("ImmuneToStatusEffects");
                 property.Value = item.Value;
             }

--- a/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
@@ -32,9 +32,10 @@
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            string lookupstring = string.Empty;
             foreach (var item in _adjustments)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 _originals[item.Key] = pieceConfig.PieceType;
                 var property = Traverse.Create(pieceConfig).Property<PieceType[]>("PieceType");
                 property.Value = item.Value;
@@ -46,7 +47,7 @@
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _originals)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 var property = Traverse.Create(pieceConfig).Property<PieceType[]>("PieceType");
                 property.Value = item.Value;
             }


### PR DESCRIPTION
Two of the pieces have PieceConfig names which differ from their BoardPieceID names.

DarkElfGoddessBoss is the BoardPieceID, but DarkElfGoddess_Boss is the pieceConfig name.
Similarly with CaveTrollBoss and CaveTroll_Boss

I tried switching things over to using the `PieceConfigDTOdict` instead, but either making modifications to that structure didn't have the desired effect, or I was doing it wrong.

This was the least-bad way I could find for fixing the boss names. 