### PR TITLE
SpawnCategoryOverridden,  CardClassRestrictionOverridden & Arachnophobia Ruleset.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+

--- a/DemeoMods.sln
+++ b/DemeoMods.sln
@@ -22,6 +22,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{8C7F69F7-5EF5-4AED-8B59-43EB164F7EC5}"
 	ProjectSection(SolutionItems) = preProject
+		docs\Arachnophobia.json = docs\Arachnophobia.json
 		docs\house-rules-logo1.png = docs\house-rules-logo1.png
 		docs\house-rules-logo2.png = docs\house-rules-logo2.png
 		docs\houserules_menu_screenshot.jpg = docs\houserules_menu_screenshot.jpg

--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -4,6 +4,7 @@ namespace HouseRules
     using System.Linq;
     using System.Text;
     using Boardgame;
+    using DataKeys;
     using HouseRules.Types;
     using MelonLoader;
 
@@ -17,6 +18,16 @@ namespace HouseRules
         public static Ruleset SelectedRuleset { get; private set; } = Ruleset.None;
 
         internal static bool IsRulesetActive { get; private set; }
+
+        public static string FixBossNames(BoardPieceId piece)
+        {
+            if (piece == BoardPieceId.DarkElfGoddessBoss || piece == BoardPieceId.CavetrollBoss)
+            {
+                return piece.ToString().Replace("Boss", "_Boss");
+            }
+
+            return piece.ToString();
+        }
 
         public static void SelectRuleset(string ruleset)
         {

--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -21,6 +21,7 @@
             HR.Rulebook.Register(typeof(AbilityActionCostAdjustedRule));
             HR.Rulebook.Register(typeof(AbilityRandomPieceListRule));
             HR.Rulebook.Register(typeof(CardAdditionOverriddenRule));
+            HR.Rulebook.Register(typeof(CardClassRestrictionOverriddenRule));
             HR.Rulebook.Register(typeof(CardEnergyFromAttackMultipliedRule));
             HR.Rulebook.Register(typeof(CardEnergyFromRecyclingMultipliedRule));
             HR.Rulebook.Register(typeof(CardLimitModifiedRule));

--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -40,6 +40,7 @@
             HR.Rulebook.Register(typeof(PiecePieceTypeListOverriddenRule));
             HR.Rulebook.Register(typeof(RatNestsSpawnGoldRule));
             HR.Rulebook.Register(typeof(RoundCountLimitedRule));
+            HR.Rulebook.Register(typeof(SpawnCategoryOverriddenRule));
             HR.Rulebook.Register(typeof(StartCardsModifiedRule));
             HR.Rulebook.Register(typeof(StatModifiersOverridenRule));
             HR.Rulebook.Register(typeof(StatusEffectConfigRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -42,6 +42,7 @@
     <Compile Include="Rulesets\QuickAndDeadRuleset.cs" />
     <Compile Include="Rulesets\NoSurprisesRuleset.cs" />
     <Compile Include="Rulesets\TheSwirlRuleset.cs" />
+    <Compile Include="Rules\SpawnCategoryOverriddenRule.cs" />
     <Compile Include="Rules\AbilityActionCostAdjustedRule.cs" />
     <Compile Include="Rules\PiecePieceTypeListOverriddenRule.cs" />
     <Compile Include="Rules\PieceBehavioursListOverriddenRule.cs" />

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -42,6 +42,7 @@
     <Compile Include="Rulesets\QuickAndDeadRuleset.cs" />
     <Compile Include="Rulesets\NoSurprisesRuleset.cs" />
     <Compile Include="Rulesets\TheSwirlRuleset.cs" />
+    <Compile Include="Rules\CardClassRestrictionOverriddenRule.cs" />
     <Compile Include="Rules\SpawnCategoryOverriddenRule.cs" />
     <Compile Include="Rules\AbilityActionCostAdjustedRule.cs" />
     <Compile Include="Rules\PiecePieceTypeListOverriddenRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -23,7 +23,11 @@ HouseRules API.
 ### JSON Rulesets
 
 Rulesets may also be configured as JSON files and stored within the game directory `<GAME_DIR>/UserData/HouseRules/<rulesetname>.json`
-An example [LuckyDip Ruleset](../docs/LuckyDip.json) which uses many different rules for rapid gameplay is provided as a guide to help you get started.
+
+A selection are available within this repository. These are intended to be fun to play alternative games, and as a good examples for others wanting to create their own rulesets.
+
+- __[LuckyDip Ruleset](../docs/LuckyDip.json)__ : Players each start with two 'Drop Chest' cards instead of their normal starting cards, meaning that no two games start the same. Many potions have AOE effect, because it's rude not to share. Many other changes included for faster gameplay with an aim of around 90 minutes per game.
+- __[Arachnophobia Ruleset](../docs/Arachnophobia.json)__ offers a fresh adventure to be played on the RootsofEvil Map. Chased by violent thugs from their ancestral homes in Sunderhaven, the King and Queen flee into the woods. Befriended by money spiders, they hatch a plan to rebuild their fallen empires by mugging tourists.
 
 The [Settings Reference](../docs/SettingsReference.md) contains lists of all different BehaviourIDs, AbilityKeys and other data types used by the Rules.
 
@@ -169,6 +173,24 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
     "Rule": "CardSellValueMultipliedRule",
     "Config": 2.0
   },
+  ```
+
+- __CardClassRestrictionOverriddenRule__: Overrides Character Class assignments for cards.
+  - Cards with a character class of `None` are usable by all players.
+  - Cards may be disbled from play by assigning to a non-player Character
+  - Cards may be reassigned to other player characters  
+
+  ###### _Example JSON config for CardClassRestrictionOverriddenRule_
+
+  ```json
+    {
+      "Rule": "CardClassRestrictionOverridden",
+      "Config": {
+        "NaturesCall": "Mushroom",
+        "Stealth": "Guardian",
+        "Zap": "Hunter",
+      }
+    },
   ```
 
 - __EnemyAttackScaledRule__: Enemy ⚔️attack⚔️ damage is scaled
@@ -400,11 +422,34 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
 - __SampleRule__: A [sample rule](Rules/SampleRule.cs) documenting the anatomy
   of a HouseRule rule.
 
+- __SpawnCategoryOverriddenRule__:  Overrides the Spawn Categories which control distribution of pieces in each map.
+  - Each dungeon has a list of pieces which may appear, and controlling properties.
+  - This rule replaces the list (for all dungeons) with a new one.
+  - Per-Piece properties for `MaxPerDeck`, `PreFill` and `FirstAllowedLevelIndex` must be specified.
+  - Pieces which are not listed in the config will have `IsSpawningEnabled` set to `false` to disable pieces from auto-populating a map.
+  - Does not have absolute control over what monsters will appear. Bosses bring support chars etc.
+  - Config accepts list of dicts { "BoardPieceID": [ MaxPerDeck, PreFill, FirstAllowedLevelIndex ], ... }
+
+  ###### _Example JSON config for SpawnCategoryOverriddenRule_
+
+  ```json
+    {
+      "Rule": "SpawnCategoryOverridden",
+      "Config": {
+        "Spiderling": [ 200, 50, 1 ],
+        "SpiderEgg": [ 20, 10, 1 ] ,
+        "LargeSpider": [ 30, 10, 1 ],
+        "RatKing": [ 1, 1, 1 ],
+        "DarkElfGoddessBoss": [ 1, 1, 2 ],
+      }
+    },
+  ```
+
 - __StartCardsModifiedRule__: Player 🎴 starting cards 🎴 are modified
   - Removes all default cards from Player's hand and replaces them with custom ones.
   - Replenishable cards do not leave a players hand once cast (e.g. RepairArmor, HunterArrow or Zap)
   - Max of two replenishable cards per player.
-  - Config accepts Dictionary of list of dicts e.g. `{ "<HeroName1": [ { "Card" : "<CardName>","isReplenishable": bool }, ... ], ...  }`
+  - Config accepts Dictionary of list of dicts e.g. `{ "HeroName1": [ { "Card" : "CardName","isReplenishable": bool }, ... ], ...  }`
 
   ###### _Example JSON config for StartCardsModifiedRule_
 

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -26,8 +26,12 @@ Rulesets may also be configured as JSON files and stored within the game directo
 
 A selection are available within this repository. These are intended to be fun to play alternative games, and as a good examples for others wanting to create their own rulesets.
 
-- __[LuckyDip Ruleset](../docs/LuckyDip.json)__ : Players each start with two 'Drop Chest' cards instead of their normal starting cards, meaning that no two games start the same. Many potions have AOE effect, because it's rude not to share. Many other changes included for faster gameplay with an aim of around 90 minutes per game.
-- __[Arachnophobia Ruleset](../docs/Arachnophobia.json)__ offers a fresh adventure to be played on the RootsofEvil Map. Chased by violent thugs from their ancestral homes in Sunderhaven, the King and Queen flee into the woods. Befriended by money spiders, they hatch a plan to rebuild their fallen empires by mugging tourists.
+- __[🎲LuckyDip🎲 Ruleset](../docs/LuckyDip.json)__ : Players each start with two 'Drop Chest' cards instead of their normal
+starting cards, meaning that no two games start the same. Many potions have AOE effect, because it's rude not to share. 
+Many other changes included for faster gameplay with an aim of around 90 minutes per game.
+- __[🕷️Arachnophobia🕷️ Ruleset](../docs/Arachnophobia.json)__ offers a fresh adventure to be played on the RootsOfEvil Map.
+Chased by violent thugs from their ancestral homes in Sunderhaven, the King and Queen flee into the woods. 
+Befriended by money spiders, they hatch a plan to rebuild their fallen empires, but first they're going to need some cash.
 
 The [Settings Reference](../docs/SettingsReference.md) contains lists of all different BehaviourIDs, AbilityKeys and other data types used by the Rules.
 

--- a/HouseRules_Essentials/Rules/CardClassRestrictionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardClassRestrictionOverriddenRule.cs
@@ -1,0 +1,77 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System.Collections.Generic;
+    using Boardgame;
+    using Data.GameData;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Types;
+
+    public sealed class CardClassRestrictionOverriddenRule : Rule, IConfigWritable<Dictionary<AbilityKey, BoardPieceId>>, IMultiplayerSafe
+    {
+        public override string Description => "Card class restrictions are overridden";
+
+        private readonly Dictionary<AbilityKey, BoardPieceId> _adjustments;
+        private Dictionary<AbilityKey, BoardPieceId> _originals;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CardClassRestrictionOverriddenRule"/> class.
+        /// </summary>
+        /// <param name="adjustments">Accepts list of AbilityKeys for cards which should not be dealt.</param>
+        public CardClassRestrictionOverriddenRule(Dictionary<AbilityKey, BoardPieceId> adjustments)
+        {
+            _adjustments = adjustments;
+            _originals = new Dictionary<AbilityKey, BoardPieceId>();
+        }
+
+        public Dictionary<AbilityKey, BoardPieceId> GetConfigObject() => _adjustments;
+
+        protected override void OnPostGameCreated(GameContext gameContext)
+        {
+            _originals = UpdateExistingCardConfigs(_adjustments);
+        }
+
+        protected override void OnDeactivate(GameContext gameContext)
+        {
+            UpdateExistingCardConfigs(_originals);
+        }
+
+        private static Dictionary<AbilityKey, BoardPieceId> UpdateExistingCardConfigs(Dictionary<AbilityKey, BoardPieceId> cardProperties)
+        {
+            var gameConfigCardConfigs = Traverse.Create(typeof(GameDataAPI)).Field<Dictionary<GameConfigType, List<CardConfigDTO>>>("CardConfigDTOlist").Value;
+            var cardConfigs = gameConfigCardConfigs[MotherbrainGlobalVars.CurrentConfig];
+            var previousConfigs = new Dictionary<AbilityKey, BoardPieceId>();
+            var aks = new List<AbilityKey>();
+            foreach (var ak in cardProperties)
+            {
+                aks.Add(ak.Key);
+            }
+
+            for (int i = 0; i < cardConfigs.Count; i++)
+            {
+                if (aks.Contains(cardConfigs[i].Card))
+                {
+                    previousConfigs[cardConfigs[i].Card] = cardConfigs[i].ClassRestriction;
+                    EssentialsMod.Logger.Warning($"Changing ClassRestriction on {cardConfigs[i].Card} from " +
+                        $"{cardConfigs[i].ClassRestriction} to " +
+                        $"{cardProperties[cardConfigs[i].Card]} ");
+                    cardConfigs[i] = new CardConfigDTO
+                    {
+                        Card = cardConfigs[i].Card,
+                        ClassRestriction = cardProperties[cardConfigs[i].Card],
+                        Tags = cardConfigs[i].Tags,
+                        CostInShop = cardConfigs[i].CostInShop,
+                        SellValue = cardConfigs[i].SellValue,
+                        TestValue = cardConfigs[i].TestValue,
+                        ShopRarity = cardConfigs[i].ShopRarity,
+                        ChestRarity = cardConfigs[i].ChestRarity,
+                        ClassRarity = cardConfigs[i].ClassRarity,
+                        CardEnergy = cardConfigs[i].CardEnergy,
+                    };
+                }
+            }
+
+            return previousConfigs;
+        }
+    }
+}

--- a/HouseRules_Essentials/Rules/PieceAbilityListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceAbilityListOverriddenRule.cs
@@ -31,9 +31,10 @@
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            string lookupstring = string.Empty;
             foreach (var item in _adjustments)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 _originals[item.Key] = pieceConfig.Abilities;
                 var property = Traverse.Create(pieceConfig).Property<List<AbilityKey>>("Abilities");
                 property.Value = item.Value;
@@ -45,7 +46,7 @@
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _originals)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 var property = Traverse.Create(pieceConfig).Property<List<AbilityKey>>("Abilities");
                 property.Value = item.Value;
             }

--- a/HouseRules_Essentials/Rules/PieceBehavioursListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceBehavioursListOverriddenRule.cs
@@ -29,12 +29,15 @@
 
         public Dictionary<BoardPieceId, Behaviour[]> GetConfigObject() => _adjustments;
 
+
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            string lookupstring = string.Empty;
             foreach (var item in _adjustments)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+         
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 _originals[item.Key] = pieceConfig.Behaviours;
                 var property = Traverse.Create(pieceConfig).Property<Behaviour[]>("Behaviours");
                 property.Value = item.Value;
@@ -46,7 +49,7 @@
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _originals)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 var property = Traverse.Create(pieceConfig).Property<Behaviour[]>("Behaviours");
                 property.Value = item.Value;
             }

--- a/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -35,8 +35,6 @@
 
         public List<PieceProperty> GetConfigObject() => _adjustments;
 
-
-
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             _originals = ReplaceExistingProperties(_adjustments);

--- a/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -35,6 +35,8 @@
 
         public List<PieceProperty> GetConfigObject() => _adjustments;
 
+
+
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             _originals = ReplaceExistingProperties(_adjustments);
@@ -53,9 +55,10 @@
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             var previousProperties = new List<PieceProperty>();
+            string lookupstring = string.Empty;
             foreach (var item in pieceProperties)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Piece}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Piece)}"));
                 var propertyTraverse = Traverse.Create(pieceConfig).Property(item.Property);
                 var castedNewValue = CastPropertyValue(item.Value, propertyTraverse.GetValueType());
 

--- a/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
@@ -31,9 +31,10 @@
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            string lookupstring = string.Empty;
             foreach (var item in _adjustments)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 _originals[item.Key] = pieceConfig.ImmuneToStatusEffects;
                 var property = Traverse.Create(pieceConfig).Property<EffectStateType[]>("ImmuneToStatusEffects");
                 property.Value = item.Value;
@@ -45,7 +46,7 @@
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _originals)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 var property = Traverse.Create(pieceConfig).Property<EffectStateType[]>("ImmuneToStatusEffects");
                 property.Value = item.Value;
             }

--- a/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
@@ -32,9 +32,10 @@
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            string lookupstring = string.Empty;
             foreach (var item in _adjustments)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 _originals[item.Key] = pieceConfig.PieceType;
                 var property = Traverse.Create(pieceConfig).Property<PieceType[]>("PieceType");
                 property.Value = item.Value;
@@ -46,7 +47,7 @@
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             foreach (var item in _originals)
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{item.Key}"));
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 var property = Traverse.Create(pieceConfig).Property<PieceType[]>("PieceType");
                 property.Value = item.Value;
             }

--- a/HouseRules_Essentials/Rules/SpawnCategoryOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/SpawnCategoryOverriddenRule.cs
@@ -1,0 +1,93 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System.Collections.Generic;
+    using Boardgame;
+    using Data.GameData;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Types;
+
+    public sealed class SpawnCategoryOverriddenRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<int>>>, IMultiplayerSafe
+    {
+        public override string Description => "Spawn Category definitions are Overridden";
+
+        private readonly Dictionary<BoardPieceId, List<int>> _adjustments;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpawnCategoryOverriddenRule"/> class.
+        /// </summary>
+        /// <param name="adjustments">Accepts a Dictionary of BoardPieceIDs and Int settings
+        /// for MaxPerDe</param>
+        public SpawnCategoryOverriddenRule(Dictionary<BoardPieceId, List<int>> adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        public Dictionary<BoardPieceId, List<int>> GetConfigObject() => _adjustments;
+
+        protected override void OnPostGameCreated(GameContext gameContext)
+        {
+            var spawnCategories = Traverse.Create(typeof(GameDataAPI)).Field<Dictionary<GameConfigType, List<SpawnCategoryDTO>>>("SpawnCategoryDTOlist").Value;
+            var bpis = new List<BoardPieceId>();
+            foreach (var nap in _adjustments)
+            {
+                bpis.Add(nap.Key);
+            }
+
+            foreach (var gameConfigType in spawnCategories)
+            {
+                for (int i = 0; i < spawnCategories[gameConfigType.Key].Count; i++)
+                {
+                    if (bpis.Contains(spawnCategories[gameConfigType.Key][i].BoardPieceId))
+                    {
+                        spawnCategories[gameConfigType.Key][i] = new SpawnCategoryDTO
+                        {
+                            BoardPieceId = spawnCategories[gameConfigType.Key][i].BoardPieceId,
+                            EnemyWeight = spawnCategories[gameConfigType.Key][i].EnemyWeight,
+                            IsSpawningEnabled = true,
+                            IsAllowedKeyholder = spawnCategories[gameConfigType.Key][i].IsAllowedKeyholder,
+                            IsBossSynergyUnit = spawnCategories[gameConfigType.Key][i].IsBossSynergyUnit,
+                            OverrideDefaultMaxPerDeckBehaviour = true,
+                            MaxPerDeck = _adjustments[spawnCategories[gameConfigType.Key][i].BoardPieceId][0],
+                            PreFill = _adjustments[spawnCategories[gameConfigType.Key][i].BoardPieceId][1],
+                            FirstAllowedLevelIndex = _adjustments[spawnCategories[gameConfigType.Key][i].BoardPieceId][2],
+                            IsRedrawEnabled = spawnCategories[gameConfigType.Key][i].IsRedrawEnabled,
+                            IsPriorityUnit = true,
+                        };
+                        EssentialsMod.Logger.Warning($"We have enabled {gameConfigType.Key} {spawnCategories[gameConfigType.Key][i].BoardPieceId}");
+                    }
+                    else
+                    {
+                        spawnCategories[gameConfigType.Key][i] = new SpawnCategoryDTO
+                        {
+                            BoardPieceId = spawnCategories[gameConfigType.Key][i].BoardPieceId,
+                            EnemyWeight = spawnCategories[gameConfigType.Key][i].EnemyWeight,
+                            IsSpawningEnabled = false,
+                            IsAllowedKeyholder = false,
+                            IsBossSynergyUnit = false,
+                            OverrideDefaultMaxPerDeckBehaviour = true,
+                            MaxPerDeck = 0,
+                            PreFill = 0,
+                            FirstAllowedLevelIndex = 4,
+                            IsRedrawEnabled = true,
+                            IsPriorityUnit = false,
+                        };
+                        EssentialsMod.Logger.Warning($"We disabled spawning for {gameConfigType.Key} {spawnCategories[gameConfigType.Key][i].BoardPieceId}");
+                    }
+                }
+            }
+        }
+
+        protected override void OnDeactivate(GameContext gameContext)
+        {
+            var spawnCategories = Traverse.Create(typeof(GameDataAPI)).Field<Dictionary<GameConfigType, List<SpawnCategoryDTO>>>("SpawnCategoryDTOlist").Value;
+            foreach (var item in spawnCategories)
+            {
+                EssentialsMod.Logger.Warning($"We removed a thing {item.Key}");
+            }
+        }
+    }
+}
+
+
+

--- a/HouseRules_Essentials/Rules/SpawnCategoryOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/SpawnCategoryOverriddenRule.cs
@@ -12,6 +12,7 @@
         public override string Description => "Spawn Category definitions are Overridden";
 
         private readonly Dictionary<BoardPieceId, List<int>> _adjustments;
+        private readonly Dictionary<GameConfigType, List<SpawnCategoryDTO>> _originals;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SpawnCategoryOverriddenRule"/> class.
@@ -36,6 +37,7 @@
 
             foreach (var gameConfigType in spawnCategories)
             {
+                _originals[gameConfigType.Key] = new List<SpawnCategoryDTO>(spawnCategories[gameConfigType.Key]);
                 for (int i = 0; i < spawnCategories[gameConfigType.Key].Count; i++)
                 {
                     if (bpis.Contains(spawnCategories[gameConfigType.Key][i].BoardPieceId))
@@ -81,9 +83,10 @@
         protected override void OnDeactivate(GameContext gameContext)
         {
             var spawnCategories = Traverse.Create(typeof(GameDataAPI)).Field<Dictionary<GameConfigType, List<SpawnCategoryDTO>>>("SpawnCategoryDTOlist").Value;
-            foreach (var item in spawnCategories)
+            foreach (var gameConfigType in spawnCategories)
             {
-                EssentialsMod.Logger.Warning($"We removed a thing {item.Key}");
+                spawnCategories[gameConfigType.Key] = new List<SpawnCategoryDTO>(_originals[gameConfigType.Key]);
+                EssentialsMod.Logger.Warning($"Restored Spawn configs for {gameConfigType.Key}");
             }
         }
     }

--- a/docs/Arachnophobia.json
+++ b/docs/Arachnophobia.json
@@ -157,7 +157,7 @@
       }
     },
     {
-      "Rule": "CardClassRestrictionOverriddenRule",
+      "Rule": "CardClassRestrictionOverridden",
       "Config": {
         "NaturesCall": "Mushroom",
       }

--- a/docs/Arachnophobia.json
+++ b/docs/Arachnophobia.json
@@ -66,9 +66,7 @@
     {
       "Rule": "PieceConfigAdjusted",
       "Config": [
-        { "Piece": "HeroSorcerer", "Property": "StartHealth", "Value": 50 },
-        { "Piece": "HeroSorcerer", "Property": "MoveRange", "Value": 40 },
-        { "Piece": "HeroSorcerer", "Property": "ActionPoint", "Value": 20 },
+        { "Piece": "HeroSorcerer", "Property": "StartHealth", "Value": 15 },
         { "Piece": "HeroGuardian", "Property": "StartHealth", "Value": 20 },
         { "Piece": "HeroHunter", "Property": "StartHealth", "Value": 15 },
         { "Piece": "HeroBard", "Property": "StartHealth", "Value": 15 },
@@ -79,7 +77,7 @@
         { "Piece": "BeaconOfSmite", "Property": "StartHealth", "Value": 20 },
         { "Piece": "BeaconOfSmite", "Property": "ActionPoint", "Value": 2 },
         { "Piece": "WolfCompanion", "Property": "ActionPoint", "Value": 3 },
-        { "Piece": "WolfCompanion", "Property": "MoveRange", "Value": 8 },
+        { "Piece": "WolfCompanion", "Property": "MoveRange", "Value": 6 },
         { "Piece": "WolfCompanion", "Property": "VisionRange", "Value": 40 },
         { "Piece": "MonsterBait", "Property": "StartHealth", "Value": 30 },
         { "Piece": "Spiderling", "Property": "StartHealth", "Value": 1 },

--- a/docs/Arachnophobia.json
+++ b/docs/Arachnophobia.json
@@ -1,0 +1,217 @@
+{
+  "Name": "Arachnophobia",
+  "Description": "Money Spiders everywhere. On the walls and in my hair.",
+  "Rules": [
+    {
+      "Rule": "AbilityDamageAdjusted",
+      "Config": { "Zap": 1 }
+    },
+    {
+      "Rule": "StartCardsModified",
+      "Config": {
+        "HeroGuardian": [
+          { "Card": "Heal", "IsReplenishable": false },
+          { "Card": "ReplenishArmor", "IsReplenishable": true },
+          { "Card": "Bone", "IsReplenishable": true },
+          { "Card": "Whirlwind", "IsReplenishable": false },
+          { "Card": "PiercingSpear", "IsReplenishable": false },
+          { "Card": "Stealth", "IsReplenishable": false },
+
+        ],
+        "HeroHunter": [
+          { "Card": "Heal", "IsReplenishable": false },
+          { "Card": "HunterArrow", "IsReplenishable": true },
+          { "Card": "PoisonedTip", "IsReplenishable": true },
+          { "Card": "Exterminate", "IsReplenishable": false },
+          { "Card": "CallCompanion", "IsReplenishable": false },
+          { "Card": "Stealth", "IsReplenishable": false },
+        ],
+        "HeroSorcerer": [
+          { "Card": "Heal", "IsReplenishable": false },
+          { "Card": "Zap", "IsReplenishable": true },
+          { "Card": "OilLamp", "IsReplenishable": true },
+          { "Card": "GodsFury", "IsReplenishable": false },
+          { "Card": "EyeOfAvalon", "IsReplenishable": false },
+        ],
+        "HeroRouge": [
+          { "Card": "Heal", "IsReplenishable": false },
+          { "Card": "Stealth", "IsReplenishable": true },
+          { "Card": "ScarePowder", "IsReplenishable": true },
+          { "Card": "ProximityMine", "IsReplenishable": false },
+          { "Card": "PoisonGasGrenade", "IsReplenishable": false },
+        ],
+        "HeroBard": [
+          { "Card": "Heal", "IsReplenishable": false },
+          { "Card": "StrengthenCourage", "IsReplenishable": true },
+          { "Card": "IceLamp", "IsReplenishable": true },
+          { "Card": "SongOfRecovery", "IsReplenishable": false },
+          { "Card": "Stealth", "IsReplenishable": false },
+          { "Card": "Tornado", "IsReplenishable": false },
+          { "Card": "ShatteringVoice", "IsReplenishable": false },
+        ]
+      }
+    },
+    {
+      "Rule": "AbilityAoeAdjusted",
+      "Config": {
+        "StrengthenCourage": 1,
+        "ReplenishArmor": 1,
+        "Strength": 1,
+        "Speed": 1,
+        "Antidote": 1,
+        "Invulnerability": 1,
+        "Heal": 1,
+      }
+    },
+    {
+      "Rule": "PieceConfigAdjusted",
+      "Config": [
+        { "Piece": "HeroSorcerer", "Property": "StartHealth", "Value": 50 },
+        { "Piece": "HeroSorcerer", "Property": "MoveRange", "Value": 40 },
+        { "Piece": "HeroSorcerer", "Property": "ActionPoint", "Value": 20 },
+        { "Piece": "HeroGuardian", "Property": "StartHealth", "Value": 20 },
+        { "Piece": "HeroHunter", "Property": "StartHealth", "Value": 15 },
+        { "Piece": "HeroBard", "Property": "StartHealth", "Value": 15 },
+        { "Piece": "HeroRouge", "Property": "StartHealth", "Value": 15 },
+        { "Piece": "HeroHunter", "Property": "MoveRange", "Value": 5 },
+        { "Piece": "HeroBard", "Property": "MoveRange", "Value": 5 },
+        { "Piece": "SwordOfAvalon", "Property": "StartHealth", "Value": 20 },
+        { "Piece": "BeaconOfSmite", "Property": "StartHealth", "Value": 20 },
+        { "Piece": "BeaconOfSmite", "Property": "ActionPoint", "Value": 2 },
+        { "Piece": "WolfCompanion", "Property": "ActionPoint", "Value": 3 },
+        { "Piece": "WolfCompanion", "Property": "MoveRange", "Value": 8 },
+        { "Piece": "WolfCompanion", "Property": "VisionRange", "Value": 40 },
+        { "Piece": "MonsterBait", "Property": "StartHealth", "Value": 30 },
+        { "Piece": "Spiderling", "Property": "StartHealth", "Value": 1 },
+        { "Piece": "Spiderling", "Property": "ActionPoint", "Value": 3 },
+        { "Piece": "Spiderling", "Property": "MoveRange", "Value": 2 },
+        { "Piece": "RatKing", "Property": "StartHealth", "Value": 45 },
+        { "Piece": "RatKing", "Property": "MoveRange", "Value": 2 },
+        { "Piece": "DarkElfGoddessBoss", "Property": "StartHealth", "Value": 35 },
+      ]
+    },
+    {
+      "Rule": "AbilityActionCostAdjusted",
+      "Config": {
+        "Zap": false,
+        "StrengthenCourage": false,
+        "Stealth": false
+      }
+    },
+    {
+      "Rule": "LevelPropertiesModifiedRule",
+      "Config": {
+        "FloorOneHealingFountains": 4,
+        "FloorOneLootChests": 12,
+        "FloorOneClassCardChests": 8,
+        "FloorOneGoldMaxAmount": 1500,
+        "FloorTwoHealingFountains": 4,
+        "FloorTwoLootChests": 9,
+        "FloorTwoGoldMaxAmount": 2500,
+        "FloorThreeHealingFountains": 6,
+        "FloorThreeLootChests": 0,
+
+      }
+    },
+    {
+      "Rule": "PieceImmunityListAdjusted",
+      "Config": {
+        "HeroSorcerer": [ "Diseased", "Frozen" ],
+        "HeroGuardian": [ "Diseased", "Frozen" ],
+        "HeroBard": [ "Diseased", "Frozen" ],
+        "HeroHunter": [ "Diseased", "Frozen" ],
+        "HeroRouge": [ "Diseased", "Frozen" ],
+        "WolfCompanion": [ "Diseased" ],
+        "RatKing": ["Petrified"],
+        "DarkElfGoddessBoss": ["Petrified"],
+      }
+    },
+    {
+      "Rule": "SpawnCategoryOverridden",
+      "Config": {
+        "Spiderling": [ 200, 50, 1 ],
+        "SpiderEgg": [ 20, 10, 1 ] ,
+        "LargeSpider": [ 30, 10, 1 ],
+        "RatKing": [ 1, 1, 1 ],
+        "DarkElfGoddessBoss": [ 1, 1, 2 ],
+      }
+    },
+    {
+      "Rule": "PieceAbilityListOverridden",
+      "Config": {
+        "Spiderling": [ "SpiderWebshot", "AcidSpit", "EnemyStealCard", "EnemyStealGold" ],
+        "DarkElfGoddessBoss": ["EnemyKnockbackMelee", "EnemyFireball", "EarthShatter"],
+        "RatKing": ["DigRatsNest", "DiseasedBite", "VerminFrenzy"]
+     }
+    },
+    {
+      "Rule": "PieceBehavioursListOverridden",
+      "Config": {
+        "Spiderling": [ "AttackAndRetreat", "Patrol", "FleeToFOW", "ChargeMove" ],
+      }
+    },
+    {
+      "Rule": "PiecePieceTypeListOverridden",
+      "Config": {
+        "Spiderling": [ "Enemy", "Thief", "Canine" ],
+      }
+    },
+    {
+      "Rule": "CardClassRestrictionOverriddenRule",
+      "Config": {
+        "NaturesCall": "Mushroom",
+      }
+    },
+    {
+      "Rule": "EnemyRespawnDisabledRule",
+      "Config": true
+    },
+    {
+      "Rule": "StatusEffectConfig",
+      "Config": [
+        {
+          "effectStateType": "HealingSong",
+          "durationTurns": 5,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "healPerTurn": 3,
+          "clearOnNewLevel": false,
+          "damageTags": null
+        },       
+        {
+          "effectStateType": "Courageous",
+          "durationTurns": 2,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "clearOnNewLevel": false,
+          "damageTags": null
+        },
+        {
+          "effectStateType": "Heroic",
+          "durationTurns": 4,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "clearOnNewLevel": false,
+          "damageTags": null
+        },
+        {
+          "effectStateType": "Fearless",
+          "durationTurns": 6,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "clearOnNewLevel": false,
+          "damageTags": null
+        },
+        {
+          "effectStateType": "Recovery",
+          "durationTurns": 5,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "healPerTurn": 3,
+          "clearOnNewLevel": false,
+          "damageTags": null
+        },
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# A new Arachnophobia Ruleset, and two new rules required to support it.

- __SpawnCategoryOverridden__ - Replaces the list of SpawnCategories from which the MonsterDecks for each level are constructed. This makes it possible to control which types of monsters are allowed in which 🗺️levels.
- __CardClassRestrictionOverridden__ - Replaces the ClassRestriction property for any given 🃏card(s). This can be used to assign 🃏cards to different players, or disable them from assignment by changing the class restriction to a non-player item (e.g. mushroom).

## 🕷️Arachnophobia🕷️ Ruleset
_💰Money 🕷️spiders everywhere, on the walls and in my hair_ - This ruleset is intended for play on the RootsOfEvil 🗺️map. The Ruleset replaces the default enemies, changes some enemy abilities and behaviours and gives the ⚔️heros some new powers to help them in their struggle against the baddies.

Please note that this PR includes the same 'Two of the Boss characters are inconsistently named` commit that I PR'd earlier. Don't know if this will cause any kind of merge conflict.. I needed the commit in this branch to test my ruleset with.

## How to test.
Use the included `Arachnophobia.json` ruleset
