### PR TITLE
Cleanup - remove unused 'lookupstring' var

### DIFF
--- a/HouseRules_Essentials/Rules/PieceAbilityListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceAbilityListOverriddenRule.cs
@@ -31,7 +31,6 @@
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
-            string lookupstring = string.Empty;
             foreach (var item in _adjustments)
             {
                 var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));

--- a/HouseRules_Essentials/Rules/PieceBehavioursListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceBehavioursListOverriddenRule.cs
@@ -29,14 +29,11 @@
 
         public Dictionary<BoardPieceId, Behaviour[]> GetConfigObject() => _adjustments;
 
-
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
-            string lookupstring = string.Empty;
             foreach (var item in _adjustments)
             {
-         
                 var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
                 _originals[item.Key] = pieceConfig.Behaviours;
                 var property = Traverse.Create(pieceConfig).Property<Behaviour[]>("Behaviours");

--- a/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -53,7 +53,6 @@
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
             var previousProperties = new List<PieceProperty>();
-            string lookupstring = string.Empty;
             foreach (var item in pieceProperties)
             {
                 var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Piece)}"));

--- a/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
@@ -31,7 +31,6 @@
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
-            string lookupstring = string.Empty;
             foreach (var item in _adjustments)
             {
                 var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));

--- a/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
@@ -32,7 +32,6 @@
         protected override void OnPostGameCreated(GameContext gameContext)
         {
             var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
-            string lookupstring = string.Empty;
             foreach (var item in _adjustments)
             {
                 var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));


### PR DESCRIPTION
Variable was added as part of work to add underscores into boss names before the method got moved to a central location. These vars were missed in the cleanup.