### PR TITLE
Control whether cards are returned to players hand when cast on someone already at max.

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -40,6 +40,7 @@
             HR.Rulebook.Register(typeof(PieceBehavioursListOverriddenRule));
             HR.Rulebook.Register(typeof(PiecePieceTypeListOverriddenRule));
             HR.Rulebook.Register(typeof(RatNestsSpawnGoldRule));
+            HR.Rulebook.Register(typeof(RegainAbilityIfMaxxedOutOverriddenRule));
             HR.Rulebook.Register(typeof(RoundCountLimitedRule));
             HR.Rulebook.Register(typeof(SpawnCategoryOverriddenRule));
             HR.Rulebook.Register(typeof(StartCardsModifiedRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Rules\PiecePieceTypeListOverriddenRule.cs" />
     <Compile Include="Rules\PieceBehavioursListOverriddenRule.cs" />
     <Compile Include="Rules\PieceAbilityListOverriddenRule.cs" />
+    <Compile Include="Rules\RegainAbilityIfMaxxedOutOverriddenRule.cs" />
     <Compile Include="Rules\StatModifiersOverridenRule.cs" />
     <Compile Include="Rules\AbilityRandomPieceListRule.cs" />
     <Compile Include="Rules\AbilityDamageAdjustedRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -410,6 +410,23 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
   },
   ```
 
+- __RegainAbilityIfMaxxedOutOverriddenRule__: Controls whether you get a potion back when you cast it on someone who is already at max.
+  - This rule is to overcome a mana-farming 'feature' that occurs if you apply an AOE range onto Strength/Speed potions. By default when you cast a strength or speed potion on someone who is already maxxed out, you get it returned to your hand. If you cast a potion on a group who are maxxed, you get one-potion-per-player returned back to your hand. This is effectively free-mana whenever you want it.
+  - This rule exists to control that behaviour. By setting Abilities to `false` you can prevent the card being returned to the player's hand.
+  - Config accepts dictionary of ability name and bool.  
+
+  ###### _Example JSON config for RegainAbilityIfMaxxedOutOverriddenRule_
+
+  ```json
+    {
+      "Rule": "RegainAbilityIfMaxxedOutOverridden",
+      "Config": {
+        "Speed": false,
+        "Strength": false
+      }
+    },
+  ```
+
 - __RoundCountLimitedRule__:  Sets a limit for the maximum number of rounds a game may take.
   - For ⏳ beat-the-clock ⏳ type gameplay.
   - Config accepts integer of number of rounds e.g 50  

--- a/HouseRules_Essentials/Rules/RegainAbilityIfMaxxedOutOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/RegainAbilityIfMaxxedOutOverriddenRule.cs
@@ -1,0 +1,54 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Boardgame;
+    using HarmonyLib;
+    using HouseRules.Types;
+    using UnityEngine;
+
+    public sealed class RegainAbilityIfMaxxedOutOverriddenRule : Rule, IConfigWritable<Dictionary<string, bool>>, IMultiplayerSafe
+    {
+        public override string Description => "RegainAbilityIfMaxxedOut settings are overridden";
+
+        private readonly Dictionary<string, bool> _adjustments;
+        private readonly Dictionary<string, bool> _originals;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegainAbilityIfMaxxedOutOverriddenRule"/> class.
+        /// </summary>
+        /// <param name="adjustments">Key-value pairs mapping the name of a StatModifier and the new additiveBonus setting.
+        /// Overwrites existing settings. Some StatModifiers require negative values.</param>
+        public RegainAbilityIfMaxxedOutOverriddenRule(Dictionary<string, bool> adjustments)
+        {
+            _adjustments = adjustments;
+            _originals = new Dictionary<string, bool>();
+        }
+
+        public Dictionary<string, bool> GetConfigObject() => _adjustments;
+
+        protected override void OnPostGameCreated(GameContext gameContext)
+        {
+            var typeByName = AccessTools.TypeByName("Boardgame.GameplayEffects.StatModifier");
+            var statModifiers = Resources.FindObjectsOfTypeAll(typeByName);
+            foreach (var item in _adjustments)
+            {
+                var statModifier = statModifiers.First(c => c.name.Equals($"{item.Key}(Clone)"));
+                _originals[item.Key] = Traverse.Create(statModifier).Field<bool>("regainAbilityIfMaxxedOut").Value;
+                Traverse.Create(statModifier).Field<bool>("regainAbilityIfMaxxedOut").Value = item.Value;
+            }
+        }
+
+        protected override void OnDeactivate(GameContext gameContext)
+        {
+            var typeByName = AccessTools.TypeByName("Boardgame.GameplayEffects.StatModifier");
+            var statModifiers = Resources.FindObjectsOfTypeAll(typeByName);
+            foreach (var item in _originals)
+            {
+                var statModifier = statModifiers.First(c => c.name.Equals($"{item.Key}(Clone)"));
+                _originals[item.Key] = Traverse.Create(statModifier).Field<bool>("regainAbilityIfMaxxedOut").Value;
+                Traverse.Create(statModifier).Field<bool>("regainAbilityIfMaxxedOut").Value = item.Value;
+            }
+        }
+    }
+}

--- a/docs/Arachnophobia.json
+++ b/docs/Arachnophobia.json
@@ -64,6 +64,13 @@
       }
     },
     {
+      "Rule": "RegainAbilityIfMaxxedOutOverridden",
+      "Config": {
+        "Speed": false,
+        "Strength": false
+      }
+    },
+    {
       "Rule": "PieceConfigAdjusted",
       "Config": [
         { "Piece": "HeroSorcerer", "Property": "StartHealth", "Value": 15 },


### PR DESCRIPTION
A new rule to control whether strenght/speed ability cards are returned to the player's hand when they are cast on something that is already at Max.

I gave this a quick test by assigning the sorcerer 4x speed cards in his starting hand. All appears to work as expected.