### PR TITLE
Allow backstab to be configured for multiple pieces.

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -20,6 +20,7 @@
             HR.Rulebook.Register(typeof(AbilityDamageAdjustedRule));
             HR.Rulebook.Register(typeof(AbilityActionCostAdjustedRule));
             HR.Rulebook.Register(typeof(AbilityRandomPieceListRule));
+            HR.Rulebook.Register(typeof(BackstabConfigOverriddenRule));
             HR.Rulebook.Register(typeof(CardAdditionOverriddenRule));
             HR.Rulebook.Register(typeof(CardClassRestrictionOverriddenRule));
             HR.Rulebook.Register(typeof(CardEnergyFromAttackMultipliedRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Rules\CardEnergyFromAttackMultipliedRule.cs" />
     <Compile Include="Rules\LevelExitLockedUntilAllEnemiesDefeatedRule.cs" />
     <Compile Include="Rules\PetsFocusHunterMarkRule.cs" />
+    <Compile Include="Rules\BackstabConfigOverriddenRule.cs" />
     <Compile Include="Rules\StatusEffectConfigRule.cs" />
     <Compile Include="Rules\CardEnergyFromRecyclingMultipliedRule.cs" />
     <Compile Include="Rules\CardLimitModifiedRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -112,6 +112,20 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
   },
   ```
 
+- __BackstabConfigOverriddenRule__: A list of Pieces may use 🔪Backstab🔪 instead of just the Assassin
+  - Replaces the hardcoded default of HeroRouge with a configurable list.
+  - Now everyone can benefit from Backstab bonus..
+  - Config accepts List of BoardPieceIDs e.g. `[ "HeroGuardian", "HeroSorcerer", ...]`  
+
+  ###### _Example JSON config for BackstabConfigOverriddenRule_
+
+  ```json
+    {
+      "Rule": "BackstabConfigOverridden",
+      "Config": [ "HeroGuardian", "HeroHunter", "HeroSorcerer", "HeroRouge", "HeroBard" ]
+    },
+  ```
+
 - __CardAdditionOverriddenRule__: Overrides the lists of cards which players receive from chests & karma
   - The default card allocation mechanism is intercepted changed to use a user-defined list of cards.
   - Config accepts Dictionary of PieceNames and lists of ability strings.. `{ "PieceName1": ["Ability1", "Ability2"], "PieceName2": ["Ability3", "Ability4"] }`  

--- a/HouseRules_Essentials/Rules/BackstabConfigOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/BackstabConfigOverriddenRule.cs
@@ -1,0 +1,62 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System.Collections.Generic;
+    using Boardgame;
+    using Boardgame.BoardEntities;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Types;
+    using StatusEffectData = global::Types.StatusEffectData;
+
+    public sealed class BackstabConfigOverriddenRule : Rule, IConfigWritable<List<BoardPieceId>>, IPatchable, IMultiplayerSafe
+    {
+        public override string Description => "Backstab is allocated to new BoardPieceIDs";
+
+        private static List<BoardPieceId> _globalAdjustments;
+        private static bool _isActivated;
+        
+        private static List<BoardPieceId> _adjustments;
+
+        public BackstabConfigOverriddenRule(List<BoardPieceId> adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        public List<BoardPieceId> GetConfigObject() => _adjustments;
+
+        protected override void OnActivate(GameContext gameContext)
+        {
+            _globalAdjustments = _adjustments;
+            _isActivated = true;
+        }
+
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
+
+        private static void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Piece), "IsRogue"),
+                prefix: new HarmonyMethod(
+                    typeof(BackstabConfigOverriddenRule),
+                    nameof(Piece_IsRogue_Prefix)));
+        }
+
+        private static bool Piece_IsRogue_Prefix(ref Piece __instance, ref bool __result)
+        {
+            if (!_isActivated)
+            {
+                return true;
+            }
+
+            if (_globalAdjustments.Contains(__instance.boardPieceId))
+                {
+                __result = true;
+            } else
+            {
+                __result = false;
+            }
+
+            return false; // We returned an user-adjusted config.
+        }
+    }
+}


### PR DESCRIPTION
The backstab bonus is applied based on whether the `isRogue()` function within a `Piece` returns true or false. `IsRogue()` doesn't get used anywhere else apart from Backstab bonus, so shouldn't have any unexpected consequences.

Test JSON:
```
    {
      "Rule": "BackstabConfigOverridden",
      "Config": [ "HeroGuardian", "HeroHunter", "HeroSorcerer", "HeroRouge", "HeroBard"  ]
    },
```

I'm guessing that there is probably a better way of doign this so that rules don't overwrite each other's settings.... Possibly with the patch to make isRogue take a list of IDs being separate from the rule that configures the list... but that's beyond my ability to implement at the moment.