### PR TITLE
Add Hangouts table anchor to DemeoResources helper.

### DIFF
--- a/Common/UI/DemeoResource.cs
+++ b/Common/UI/DemeoResource.cs
@@ -13,7 +13,9 @@
 
         public Color ColorBeige { get; } = new Color(0.878f, 0.752f, 0.384f, 1);
 
-        public Component LobbyAnchor { get; private set; }
+        public Component LobbyTableAnchor { get; private set; }
+
+        public GameObject HangoutsTableAnchor { get; private set; }
 
         public TMP_FontAsset Font { get; private set; }
 
@@ -62,8 +64,13 @@
                    && Resources.FindObjectsOfTypeAll<Material>().Any(x => x.name == "MainMenuHover")
                    && Resources.FindObjectsOfTypeAll<Mesh>().Any(x => x.name == "MenuBox_SettingsButton")
                    && Resources.FindObjectsOfTypeAll<Material>().Any(x => x.name == "MainMenuMat (Instance)")
-                   && Resources.FindObjectsOfTypeAll<charactersoundlistener>()
-                       .Count(x => x.name == "MenuBox_BindPose") > 1;
+                   && IsAnchorReady();
+        }
+
+        private static bool IsAnchorReady()
+        {
+            return Resources.FindObjectsOfTypeAll<charactersoundlistener>().Count(x => x.name == "MenuBox_BindPose") > 1
+                   || Resources.FindObjectsOfTypeAll<GameObject>().Any(x => x.name == "GroupLaunchTable");
         }
 
         /// <summary>
@@ -71,7 +78,7 @@
         /// </summary>
         public void EnsureResourcesExists()
         {
-            if (LobbyAnchor == null
+            if (!DoesAnchorExist()
                 || Font == null
                 || FontColorGradient == null
                 || ButtonMesh == null
@@ -85,10 +92,14 @@
             }
         }
 
+        private bool DoesAnchorExist()
+        {
+            return LobbyTableAnchor != null
+                   || HangoutsTableAnchor != null;
+        }
+
         private void Initialize()
         {
-            LobbyAnchor = Resources.FindObjectsOfTypeAll<charactersoundlistener>()
-                .First(x => x.name == "MenuBox_BindPose");
             Font = Resources.FindObjectsOfTypeAll<TMP_FontAsset>().First(x => x.name == "Demeo SDF");
             FontColorGradient = Resources
                 .FindObjectsOfTypeAll<TMP_ColorGradient>()
@@ -98,6 +109,16 @@
             ButtonHoverMaterial = Resources.FindObjectsOfTypeAll<Material>().First(x => x.name == "MainMenuHover");
             MenuBoxMesh = Resources.FindObjectsOfTypeAll<Mesh>().First(x => x.name == "MenuBox_SettingsButton");
             MenuBoxMaterial = Resources.FindObjectsOfTypeAll<Material>().First(x => x.name == "MainMenuMat (Instance)");
+
+            InitializeAnchors();
+        }
+
+        private void InitializeAnchors()
+        {
+            LobbyTableAnchor = Resources.FindObjectsOfTypeAll<charactersoundlistener>()
+                .FirstOrDefault(x => x.name == "MenuBox_BindPose");
+            HangoutsTableAnchor = Resources.FindObjectsOfTypeAll<GameObject>()
+                .FirstOrDefault(x => x.name == "GroupLaunchTable");
         }
     }
 }

--- a/HouseRules_Configuration/UI/RulesetSelectionUI.cs
+++ b/HouseRules_Configuration/UI/RulesetSelectionUI.cs
@@ -34,7 +34,8 @@
 
         private void Initialize()
         {
-            this.transform.SetParent(_uiHelper.DemeoResource.LobbyAnchor.transform, worldPositionStays: true);
+            this.transform.SetParent(_uiHelper.DemeoResource.LobbyTableAnchor.transform, worldPositionStays: true);
+
             this.transform.position = new Vector3(32.6f, 26.4f, -12.8f);
             this.transform.rotation = Quaternion.Euler(0, 70, 0);
 

--- a/RoomFinder/UI/RoomFinderUI.cs
+++ b/RoomFinder/UI/RoomFinderUI.cs
@@ -62,7 +62,7 @@
 
         private void Initialize()
         {
-            this.transform.SetParent(_uiHelper.DemeoResource.LobbyAnchor.transform, worldPositionStays: true);
+            this.transform.SetParent(_uiHelper.DemeoResource.LobbyTableAnchor.transform, worldPositionStays: true);
             this.transform.position = new Vector3(25, 30, 0);
             this.transform.rotation = Quaternion.Euler(0, 40, 0);
 


### PR DESCRIPTION
Part of #222.

- Rename `LobbyAnchor` to `LobbyTableAnchor`
- Add `HangoutsTableAnchor` as a potential anchor to capture in the DemeoResources helper.
- Modify DemeoResources helper to only need to capture a single anchor (i.e., `LobbyTableAnchor` or `HangoutsTableAnchor`).