### PR TITLE
Rule to control the enableBackstabBonus toggle on Abilities.

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -17,6 +17,7 @@
         private static void RegisterRuleTypes()
         {
             HR.Rulebook.Register(typeof(AbilityAoeAdjustedRule));
+            HR.Rulebook.Register(typeof(AbilityBackstabAdjustedRule));
             HR.Rulebook.Register(typeof(AbilityDamageAdjustedRule));
             HR.Rulebook.Register(typeof(AbilityActionCostAdjustedRule));
             HR.Rulebook.Register(typeof(AbilityRandomPieceListRule));

--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -20,6 +20,7 @@
             HR.Rulebook.Register(typeof(AbilityDamageAdjustedRule));
             HR.Rulebook.Register(typeof(AbilityActionCostAdjustedRule));
             HR.Rulebook.Register(typeof(AbilityRandomPieceListRule));
+            HR.Rulebook.Register(typeof(BackstabConfigOverriddenRule));
             HR.Rulebook.Register(typeof(CardAdditionOverriddenRule));
             HR.Rulebook.Register(typeof(CardClassRestrictionOverriddenRule));
             HR.Rulebook.Register(typeof(CardEnergyFromAttackMultipliedRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -42,6 +42,7 @@
     <Compile Include="Rulesets\QuickAndDeadRuleset.cs" />
     <Compile Include="Rulesets\NoSurprisesRuleset.cs" />
     <Compile Include="Rulesets\TheSwirlRuleset.cs" />
+    <Compile Include="Rules\AbilityBackstabAdjustedRule.cs" />
     <Compile Include="Rules\CardClassRestrictionOverriddenRule.cs" />
     <Compile Include="Rules\SpawnCategoryOverriddenRule.cs" />
     <Compile Include="Rules\AbilityActionCostAdjustedRule.cs" />

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Rules\CardEnergyFromAttackMultipliedRule.cs" />
     <Compile Include="Rules\LevelExitLockedUntilAllEnemiesDefeatedRule.cs" />
     <Compile Include="Rules\PetsFocusHunterMarkRule.cs" />
+    <Compile Include="Rules\BackstabConfigOverriddenRule.cs" />
     <Compile Include="Rules\StatusEffectConfigRule.cs" />
     <Compile Include="Rules\CardEnergyFromRecyclingMultipliedRule.cs" />
     <Compile Include="Rules\CardLimitModifiedRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -74,6 +74,26 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
   },
   ```
 
+- __AbilityBackstabAdjustedRule__: Adjusts the enableBackstabBonus setting for abilities.
+  - Does not work with all abilities.
+  - Config accepts Dictionary e.g. `{ "AbilityName1", bool, "AbilityName2", bool }`
+  
+  ###### _Example JSON config for AbilityBackstabAdjustedRule_
+
+  ```json
+  {
+    "Rule": "AbilityBackstabAdjustedRule",
+    "Config": {
+      "Zap": true,
+      "HunterArrow": true,
+      "PiercingArrow": true,
+      "PoisonTip": true,
+      "Fireball": true,
+      "Freeze": true,
+    }
+  },
+  ```
+
 - __AbilityDamageAdjustedRule__: Ability damage is adjusted
   - Only functions for abilities which do damage. (You can't make a Heal hurt).
   - CriticalHitDamage is adjusted to double normal damage.

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -112,6 +112,20 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
   },
   ```
 
+- __BackstabConfigOverriddenRule__: A list of Pieces may use 🔪Backstab🔪 instead of just the Assassin
+  - Replaces the hardcoded default of HeroRouge with a configurable list.
+  - Now everyone can benefit from Backstab bonus..
+  - Config accepts List of BoardPieceIDs e.g. `[ "HeroGuardian", "HeroSorcerer", ...]`  
+
+  ###### _Example JSON config for BackstabConfigOverriddenRule_
+
+  ```json
+    {
+      "Rule": "BackstabConfigOverridden",
+      "Config": [ "HeroGuardian", "HeroHunter", "HeroSorcerer", "HeroRouge", "HeroBard" ]
+    },
+  ```
+
 - __CardAdditionOverriddenRule__: Overrides the lists of cards which players receive from chests & karma
   - The default card allocation mechanism is intercepted changed to use a user-defined list of cards.
   - Config accepts Dictionary of PieceNames and lists of ability strings.. `{ "PieceName1": ["Ability1", "Ability2"], "PieceName2": ["Ability3", "Ability4"] }`  

--- a/HouseRules_Essentials/Rules/AbilityBackstabAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityBackstabAdjustedRule.cs
@@ -7,18 +7,18 @@
     using HouseRules.Types;
     using UnityEngine;
 
-    public sealed class AbilityActionCostAdjustedRule : Rule, IConfigWritable<Dictionary<string, bool>>, IMultiplayerSafe
+    public sealed class AbilityBackstabAdjustedRule : Rule, IConfigWritable<Dictionary<string, bool>>, IMultiplayerSafe
     {
         public override string Description => "Ability AP costs are adjusted";
 
         private readonly Dictionary<string, bool> _adjustments;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AbilityActionCostAdjustedRule"/> class.
+        /// Initializes a new instance of the <see cref="AbilityBackstabAdjustedRule"/> class.
         /// </summary>
-        /// <param name="adjustments">Key-value pairs of abilitykey and bool that controls 
-        /// the costActionPoint setting.</param>
-        public AbilityActionCostAdjustedRule(Dictionary<string, bool> adjustments)
+        /// <param name="adjustments">Key-value pairs of abilitykey and bool for whether backstab bonus
+        /// is enabled or not.</param>
+        public AbilityBackstabAdjustedRule(Dictionary<string, bool> adjustments)
         {
             _adjustments = adjustments;
         }
@@ -31,7 +31,7 @@
             foreach (var item in _adjustments)
             {
                 var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
-                ability.costActionPoint = item.Value;
+                ability.enableBackstabBonus = item.Value;
             }
         }
 
@@ -41,7 +41,7 @@
             foreach (var item in _adjustments)
             {
                 var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
-                ability.costActionPoint = !item.Value;
+                ability.enableBackstabBonus = !item.Value;
             }
         }
     }

--- a/HouseRules_Essentials/Rules/BackstabConfigOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/BackstabConfigOverriddenRule.cs
@@ -1,0 +1,62 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System.Collections.Generic;
+    using Boardgame;
+    using Boardgame.BoardEntities;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Types;
+    using StatusEffectData = global::Types.StatusEffectData;
+
+    public sealed class BackstabConfigOverriddenRule : Rule, IConfigWritable<List<BoardPieceId>>, IPatchable, IMultiplayerSafe
+    {
+        public override string Description => "Backstab is allocated to new BoardPieceIDs";
+
+        private static List<BoardPieceId> _globalAdjustments;
+        private static bool _isActivated;
+        
+        private static List<BoardPieceId> _adjustments;
+
+        public BackstabConfigOverriddenRule(List<BoardPieceId> adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        public List<BoardPieceId> GetConfigObject() => _adjustments;
+
+        protected override void OnActivate(GameContext gameContext)
+        {
+            _globalAdjustments = _adjustments;
+            _isActivated = true;
+        }
+
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
+
+        private static void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Piece), "IsRogue"),
+                prefix: new HarmonyMethod(
+                    typeof(BackstabConfigOverriddenRule),
+                    nameof(Piece_IsRogue_Prefix)));
+        }
+
+        private static bool Piece_IsRogue_Prefix(ref Piece __instance, ref bool __result)
+        {
+            if (!_isActivated)
+            {
+                return true;
+            }
+
+            if (_globalAdjustments.Contains(__instance.boardPieceId))
+                {
+                __result = true;
+            } else
+            {
+                __result = false;
+            }
+
+            return false; // We returned an user-adjusted config.
+        }
+    }
+}


### PR DESCRIPTION
In #219  I'd pondered whether the rule name chosen was suitable or whether it would clash with a rule for changing the backstab setting on abilities. At that time, I hadn't actually been successful in changing an ability's backstab through UnityExplorer. As there was already a near perfect rule to copy, I quickly put together a new one for adjusting an ability's backstab bonus setting.

During the process of putting this rule together, I realised that there would be no naming clash between different backstab rules, so merged the other PR.

Having put a new rule together, I figured I might as well PR it. 

This rule is very lazy... There are so many other bools that we could toggle, it is probably worthwhile putting together a more generic rule along the lines of PieceConfigAdjusted which can accept param names and values instad.


## Test JSON
```
    {
      "Rule": "AbilityBackstabAdjustedRule",
      "Config": {
        "Zap": true,
        "HunterArrow": true,
        "PiercingArrow": true,
        "PoisonTip": true,
        "Fireball": true,
        "Freeze": true,
      }
    },
```

