### PR TITLE
Provide visual feedback of selected ruleset on UI.

### DIFF
--- a/Common/UI/UiHelper.cs
+++ b/Common/UI/UiHelper.cs
@@ -11,7 +11,8 @@
         public const int DefaultButtonFontSize = 7;
         public const int DefaultLabelFontSize = 5;
         public const int DefaultMenuHeaderFontSize = 10;
-        public const float DefaultTextZShift = -0.3f;
+        public const float DefaultButtonZShift = -0.1f;
+        public const float DefaultTextZShift = -0.2f;
 
         private static UiHelper _instance;
 

--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -45,7 +45,7 @@
                 return;
             }
 
-            _ = new GameObject("RulesetSelectionUI", typeof(UI.RulesetSelectionUI));
+            _ = new GameObject("HouseRules_RulesetSelection", typeof(UI.RulesetSelectionUI));
         }
 
         private static void LoadRulesetsFromConfig()

--- a/HouseRules_Configuration/UI/RulesetSelectionPanel.cs
+++ b/HouseRules_Configuration/UI/RulesetSelectionPanel.cs
@@ -5,6 +5,7 @@
     using Common.UI;
     using DataKeys;
     using HouseRules.Types;
+    using TMPro;
     using UnityEngine;
 
     internal class RulesetSelectionPanel
@@ -12,6 +13,8 @@
         private readonly UiHelper _uiHelper;
 
         private readonly Rulebook _rulebook;
+
+        private TextMeshPro _selectedText;
 
         internal GameObject GameObject { get; }
 
@@ -31,35 +34,45 @@
 
         private void Render()
         {
-            var headerContainer = CreateHeader();
-            headerContainer.transform.SetParent(GameObject.transform, worldPositionStays: false);
+            var header = CreateHeader();
+            header.transform.SetParent(GameObject.transform, worldPositionStays: false);
+            header.transform.localPosition = new Vector3(0, 1.5f, 0);
 
-            var rulesetsContainer = new GameObject("Rulesets");
-            rulesetsContainer.transform.SetParent(GameObject.transform, worldPositionStays: false);
-            rulesetsContainer.transform.localPosition = new Vector3(0, -1.5f, 0);
+            var rulesets = new GameObject("Rulesets");
+            rulesets.transform.SetParent(GameObject.transform, worldPositionStays: false);
+            rulesets.transform.localPosition = new Vector3(0, -1.5f, 0);
 
             var rulesetRow = CreateRulesetRow(Ruleset.None);
-            rulesetRow.transform.SetParent(rulesetsContainer.transform, worldPositionStays: false);
+            rulesetRow.transform.SetParent(rulesets.transform, worldPositionStays: false);
             rulesetRow.transform.localPosition = new Vector3(0, 0, 0);
 
             for (var i = 0; i < _rulebook.Rulesets.Count; i++)
             {
-                var yOffset = (i + 1) * -1.75f;
+                var yOffset = (i + 1) * -1.5f;
                 rulesetRow = CreateRulesetRow(_rulebook.Rulesets.ElementAt(i));
-                rulesetRow.transform.SetParent(rulesetsContainer.transform, worldPositionStays: false);
+                rulesetRow.transform.SetParent(rulesets.transform, worldPositionStays: false);
                 rulesetRow.transform.localPosition = new Vector3(0, yOffset, 0);
             }
         }
 
         private GameObject CreateHeader()
         {
-            var headerContainer = new GameObject("RulesetsHeader");
+            var headerContainer = new GameObject("Header");
 
             var infoText = _uiHelper.CreateLabelText("Select a ruleset for your next private multiplayer game or skirmish.");
             var rectTransform = (RectTransform)infoText.transform;
             rectTransform.SetParent(headerContainer.transform, worldPositionStays: false);
             rectTransform.sizeDelta = new Vector2(10, 2);
-            rectTransform.localPosition = new Vector3(0f, 1f, UiHelper.DefaultTextZShift);
+            rectTransform.localPosition = new Vector3(0, 0, UiHelper.DefaultTextZShift);
+
+            var selectedText = _uiHelper.CreateLabelText("Selected ruleset: ");
+            rectTransform = (RectTransform)selectedText.transform;
+            rectTransform.SetParent(headerContainer.transform, worldPositionStays: false);
+            rectTransform.sizeDelta = new Vector2(10, 2);
+            rectTransform.localPosition = new Vector3(0, -1.5f, UiHelper.DefaultTextZShift);
+
+            _selectedText = selectedText.GetComponentInChildren<TextMeshPro>();
+            UpdateSelectedText();
 
             return headerContainer;
         }
@@ -70,12 +83,12 @@
 
             var button = _uiHelper.CreateButton(SelectRulesetAction(ruleset.Name));
             button.transform.SetParent(roomRowContainer.transform, worldPositionStays: false);
-            button.transform.localScale = new Vector3(1.5f, 1f, 1);
-            button.transform.localPosition = new Vector3(-4.5f, 0, 0);
+            button.transform.localScale = new Vector3(1f, 0.6f, 1f);
+            button.transform.localPosition = new Vector3(-4.5f, 0, UiHelper.DefaultButtonZShift);
 
             var buttonText = _uiHelper.CreateText(ruleset.Name, Color.white, UiHelper.DefaultLabelFontSize);
             buttonText.transform.SetParent(roomRowContainer.transform, worldPositionStays: false);
-            buttonText.transform.localPosition = new Vector3(-4.5f, 0, UiHelper.DefaultTextZShift);
+            buttonText.transform.localPosition = new Vector3(-4.5f, 0, UiHelper.DefaultButtonZShift + UiHelper.DefaultTextZShift);
 
             var description = _uiHelper.CreateLabelText(ruleset.Description);
             var rectTransform = (RectTransform)description.transform;
@@ -87,9 +100,18 @@
             return roomRowContainer;
         }
 
-        private static Action SelectRulesetAction(string rulesetName)
+        private Action SelectRulesetAction(string rulesetName)
         {
-            return () => HR.SelectRuleset(rulesetName);
+            return () =>
+            {
+                HR.SelectRuleset(rulesetName);
+                UpdateSelectedText();
+            };
+        }
+
+        private void UpdateSelectedText()
+        {
+            _selectedText.text = $"Selected ruleset: {HR.SelectedRuleset.Name}";
         }
     }
 }

--- a/HouseRules_Configuration/UI/RulesetSelectionUI.cs
+++ b/HouseRules_Configuration/UI/RulesetSelectionUI.cs
@@ -39,7 +39,7 @@
             this.transform.position = new Vector3(32.6f, 26.4f, -12.8f);
             this.transform.rotation = Quaternion.Euler(0, 70, 0);
 
-            _background = new GameObject("RulesetSelectionUIBackground");
+            _background = new GameObject("Background");
             _background.AddComponent<MeshFilter>().mesh = _uiHelper.DemeoResource.MenuBoxMesh;
             _background.AddComponent<MeshRenderer>().material = _uiHelper.DemeoResource.MenuBoxMaterial;
             _background.transform.SetParent(this.transform, worldPositionStays: false);


### PR DESCRIPTION
Resolves https://github.com/orendain/DemeoMods/issues/220.

**Changes:**

- Display selected ruleset on UI.
- Reduce gap between listed rulesets.
- Rename fields and labels slightly.
- Rename widgets.

**Notes:**

Originally, I wanted to save some space and give the UI that extra bit of pizzazz by having buttons alternate colors when selected.  While solved, implementation would have taken significantly longer than this approach of simply displaying the selected ruleset.  The original idea can still be implemented, but for the sake of saving some time this was the approach this time around.

**Screenshot to demonstrate new UI:**

![image](https://user-images.githubusercontent.com/1426304/157569731-a932b1d8-9549-4301-aab2-7421b9e85b50.png)
