### PR TITLE
Perform some maintenance on rules.

### DIFF
--- a/HouseRules_Essentials/Rules/AbilityActionCostAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityActionCostAdjustedRule.cs
@@ -12,11 +12,12 @@
         public override string Description => "Ability AP costs are adjusted";
 
         private readonly Dictionary<string, bool> _adjustments;
+        private Dictionary<string, bool> _originals;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AbilityActionCostAdjustedRule"/> class.
         /// </summary>
-        /// <param name="adjustments">Key-value pairs of abilitykey and bool that controls 
+        /// <param name="adjustments">Key-value pairs of abilitykey and bool that controls
         /// the costActionPoint setting.</param>
         public AbilityActionCostAdjustedRule(Dictionary<string, bool> adjustments)
         {
@@ -27,22 +28,26 @@
 
         protected override void OnPostGameCreated(GameContext gameContext)
         {
-            var abilities = Resources.FindObjectsOfTypeAll<Ability>();
-            foreach (var item in _adjustments)
-            {
-                var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
-                ability.costActionPoint = item.Value;
-            }
+            _originals = UpdateActionPoints(_adjustments);
         }
 
         protected override void OnDeactivate(GameContext gameContext)
         {
+            UpdateActionPoints(_originals);
+        }
+
+        private static Dictionary<string, bool> UpdateActionPoints(Dictionary<string, bool> adjustments)
+        {
             var abilities = Resources.FindObjectsOfTypeAll<Ability>();
-            foreach (var item in _adjustments)
+            var previousValues = new Dictionary<string, bool>();
+            foreach (var item in adjustments)
             {
                 var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
-                ability.costActionPoint = !item.Value;
+                previousValues.Add(item.Key, ability.costActionPoint);
+                ability.costActionPoint = item.Value;
             }
+
+            return previousValues;
         }
     }
 }

--- a/HouseRules_Essentials/Rules/AbilityBackstabAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityBackstabAdjustedRule.cs
@@ -9,9 +9,10 @@
 
     public sealed class AbilityBackstabAdjustedRule : Rule, IConfigWritable<Dictionary<string, bool>>, IMultiplayerSafe
     {
-        public override string Description => "Ability AP costs are adjusted";
+        public override string Description => "Ability backstab enablement is adjusted";
 
         private readonly Dictionary<string, bool> _adjustments;
+        private Dictionary<string, bool> _originals;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AbilityBackstabAdjustedRule"/> class.
@@ -27,22 +28,26 @@
 
         protected override void OnPostGameCreated(GameContext gameContext)
         {
-            var abilities = Resources.FindObjectsOfTypeAll<Ability>();
-            foreach (var item in _adjustments)
-            {
-                var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
-                ability.enableBackstabBonus = item.Value;
-            }
+            _originals = UpdateAbilities(_adjustments);
         }
 
         protected override void OnDeactivate(GameContext gameContext)
         {
+            UpdateAbilities(_originals);
+        }
+
+        private static Dictionary<string, bool> UpdateAbilities(Dictionary<string, bool> adjustments)
+        {
             var abilities = Resources.FindObjectsOfTypeAll<Ability>();
-            foreach (var item in _adjustments)
+            var previousValues = new Dictionary<string, bool>();
+            foreach (var item in adjustments)
             {
                 var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
-                ability.enableBackstabBonus = !item.Value;
+                previousValues.Add(item.Key, ability.enableBackstabBonus);
+                ability.enableBackstabBonus = item.Value;
             }
+
+            return previousValues;
         }
     }
 }

--- a/HouseRules_Essentials/Rules/BackstabConfigOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/BackstabConfigOverriddenRule.cs
@@ -48,14 +48,7 @@
                 return true;
             }
 
-            if (_globalAdjustments.Contains(__instance.boardPieceId))
-            {
-                __result = true;
-            } else
-            {
-                __result = false;
-            }
-
+            __result = _globalAdjustments.Contains(__instance.boardPieceId);
             return false; // We returned an user-adjusted config.
         }
     }

--- a/HouseRules_Essentials/Rules/BackstabConfigOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/BackstabConfigOverriddenRule.cs
@@ -14,8 +14,8 @@
 
         private static List<BoardPieceId> _globalAdjustments;
         private static bool _isActivated;
-        
-        private static List<BoardPieceId> _adjustments;
+
+        private readonly List<BoardPieceId> _adjustments;
 
         public BackstabConfigOverriddenRule(List<BoardPieceId> adjustments)
         {
@@ -49,7 +49,7 @@
             }
 
             if (_globalAdjustments.Contains(__instance.boardPieceId))
-                {
+            {
                 __result = true;
             } else
             {

--- a/HouseRules_Essentials/Rules/BackstabConfigOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/BackstabConfigOverriddenRule.cs
@@ -6,7 +6,6 @@
     using DataKeys;
     using HarmonyLib;
     using HouseRules.Types;
-    using StatusEffectData = global::Types.StatusEffectData;
 
     public sealed class BackstabConfigOverriddenRule : Rule, IConfigWritable<List<BoardPieceId>>, IPatchable, IMultiplayerSafe
     {

--- a/HouseRules_Essentials/Rules/StatusEffectConfigRule.cs
+++ b/HouseRules_Essentials/Rules/StatusEffectConfigRule.cs
@@ -2,7 +2,6 @@
 {
     using System.Collections.Generic;
     using Boardgame;
-    using DataKeys;
     using global::Types;
     using HarmonyLib;
     using HouseRules.Types;
@@ -18,7 +17,7 @@
         /// Initializes a new instance of the <see cref="StatusEffectConfigRule"/> class.
         /// </summary>
         /// <param name="adjustments">Accepts a List of replacement StatusEffectsData
-        /// which will replace exsting values</param>
+        /// which will replace existing values.</param>
         public StatusEffectConfigRule(List<StatusEffectData> adjustments)
         {
             _adjustments = adjustments;
@@ -39,27 +38,18 @@
 
         private static List<StatusEffectData> UpdateStatusEffectConfig(List<StatusEffectData> adjustments)
         {
-            var effectsConfig = Traverse.Create(typeof(StatusEffectsConfig)).Field<StatusEffectData[]>("effectsConfig").Value;
+            var effectsConfigs = Traverse.Create(typeof(StatusEffectsConfig)).Field<StatusEffectData[]>("effectsConfig").Value;
             var previousConfigs = new List<StatusEffectData>();
-            var changedEffectStateTypes = new List<EffectStateType>();
-            foreach (var statusEffect in adjustments)
+            for (var i = 0; i < effectsConfigs.Length; i++)
             {
-                changedEffectStateTypes.Add(statusEffect.effectStateType);
-            }
-
-            for (int i = 0; i < effectsConfig.Length; i++)
-            {
-                if (changedEffectStateTypes.Contains(effectsConfig[i].effectStateType))
+                var matchingIndex = adjustments.FindIndex(a => a.effectStateType == effectsConfigs[i].effectStateType);
+                if (matchingIndex < 0)
                 {
-                    previousConfigs.Add(effectsConfig[i]);
-                    for (int j = 0; j < adjustments.Count; j++)
-                    {
-                        if (adjustments[j].effectStateType == effectsConfig[i].effectStateType)
-                        {
-                            effectsConfig[i] = adjustments[j];
-                        }
-                    }
+                    continue;
                 }
+
+                previousConfigs.Add(effectsConfigs[i]);
+                effectsConfigs[i] = adjustments[matchingIndex];
             }
 
             return previousConfigs;


### PR DESCRIPTION
Was going to continue but started running out of fuel.  If a change is more confusing than helpful, happy to revert.

**Changes:**
- Make _adjustments a non-static variable.
  - Otherwise, it is changed by all instantiations of this rule.  By making it non-static, a copy a new `_adjustments` is created for each instance of the rule.  And only after `OnActivate()` is called is that rule-specific `_adjustments` value copied to the global `_globalAdjustments` field.
- Simplify expression.
- Use method which can be reused on both OnPostGameCreated and OnDeactive.
- Shorted code in StatusEffectConfigRule that handled updating.
  - Reduced the number of loops used.
  - Used a guard class to reduce nesting by one level.
- Use method for AbilityBackstabAdjustedRule which can be reused on both OnPostGameCreated and OnDeactive, and saves exact previous value.