### PR TITLE
Two more example JSON rulesets to help with documentation etc.

### DIFF
--- a/docs/rulesets/3x3 Potions and Buffs.json
+++ b/docs/rulesets/3x3 Potions and Buffs.json
@@ -1,0 +1,25 @@
+{
+  "Name": "3x3 Potions and Buffs",
+  "Description": "Heal, Strength, Speed, Adamant, Antitoxin, RepairArmor and Bard buffs are 3x3 AOE",
+  "Rules": [
+    {
+      "Rule": "AbilityAoeAdjusted",
+      "Config": {
+        "StrengthenCourage": 1,
+        "ReplenishArmor": 1,
+        "Strength": 1,
+        "Speed": 1,
+        "Antidote": 1,
+        "Invulnerability": 1,
+        "Heal": 1,
+      }
+    },
+    {
+      "Rule": "RegainAbilityIfMaxxedOutOverridden",
+      "Config": {
+        "Speed": false,
+        "Strength": false
+      }
+    },
+  ]
+}

--- a/docs/rulesets/Better Sorcerer.json
+++ b/docs/rulesets/Better Sorcerer.json
@@ -1,0 +1,12 @@
+{
+    "Name": "Better Sorcerer",
+    "Description": "0 Action Cost for Sorcerer's Zap - No other changes. #STS",
+    "Rules": [
+        {
+            "Rule": "AbilityActionCostAdjusted",
+            "Config": {
+              "Zap": false,
+            }
+          },
+    ]
+  }


### PR DESCRIPTION
# Two more example rulesets to help people get started writing their own.

## Better Sorcerer ( #STS Save the Sorcerer🪄 )
Applies 0 action cost for the ⚡Zap ability. This very small change 'fixes' the Sorcerer character and makes it much more enjoyable to play in the early stages of the game. Normally the Sorcerer is a bit weak until the card energy meter starts to fill up more rapidly from the 2nd floor down, but having a free zap per round leaves him free to add in a 2hp Melee attack giving an equivalent 3HP attack plus a move like all of the other characters can do.

## 3x3 Potions and Buffs 💪
Applies 3x3 Area of Effect on most buffs. Players near the bard when he sings will all benefit from his songs. If your friends are nearby and thirsty then of course you'd share your drink. Applies to Courage, RepairArmor, Strength, Speed, AntiToxin, Adamant and Heal.

 