### PR TITLE
Enable UiHelper to render buttons in Hangout spaces.

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -52,6 +52,7 @@
         </Reference>
     </ItemGroup>
     <ItemGroup>
+        <Compile Include="ModPatcher.cs" />
         <Compile Include="Properties\AssemblyInfo.cs" />
         <Compile Include="CommonModule.cs" />
         <Compile Include="UI\DemeoResource.cs" />

--- a/Common/CommonModule.cs
+++ b/Common/CommonModule.cs
@@ -1,9 +1,24 @@
 ﻿namespace Common
 {
+    using Bowser.Core;
     using MelonLoader;
 
-    internal class CommonModule
+    internal static class CommonModule
     {
         internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("Common");
+
+        internal static BowserButtonHandler HangoutsButtonHandler { get; set; }
+
+        internal static bool IsInitialized { get; private set; }
+
+        /// <summary>
+        /// Initialize the module. This should be called during the dependant module's OnApplicationStart().
+        /// </summary>
+        public static void Initialize()
+        {
+            var harmony = new HarmonyLib.Harmony("com.orendain.demeomods.common");
+            ModPatcher.Patch(harmony);
+            IsInitialized = true;
+        }
     }
 }

--- a/Common/ModPatcher.cs
+++ b/Common/ModPatcher.cs
@@ -1,0 +1,22 @@
+﻿namespace Common
+{
+    using Bowser.Core;
+    using Bowser.GameIntegration;
+    using HarmonyLib;
+
+    internal static class ModPatcher
+    {
+        internal static void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(GameStateHobbyShop), "Start"),
+                postfix: new HarmonyMethod(typeof(ModPatcher), nameof(GameStateHobbyShop_Start_Postfix)));
+        }
+
+        private static void GameStateHobbyShop_Start_Postfix(GameStateHobbyShop __instance)
+        {
+            var buttonHandler = Traverse.Create(__instance).Field<BowserButtonHandler>("buttonHandler").Value;
+            CommonModule.HangoutsButtonHandler = buttonHandler;
+        }
+    }
+}

--- a/Common/UI/DemeoResource.cs
+++ b/Common/UI/DemeoResource.cs
@@ -13,7 +13,7 @@
 
         public Color ColorBeige { get; } = new Color(0.878f, 0.752f, 0.384f, 1);
 
-        public Component LobbyTableAnchor { get; private set; }
+        public Component VrLobbyTableAnchor { get; private set; }
 
         public GameObject HangoutsTableAnchor { get; private set; }
 
@@ -77,33 +77,7 @@
                    || Resources.FindObjectsOfTypeAll<GameObject>().Any(x => x.name == "GroupLaunchTable");
         }
 
-        /// <summary>
-        /// Ensures all originally captured Demeo resources still exist, reinitializing otherwise.
-        /// </summary>
-        public void EnsureResourcesExists()
-        {
-            if (IsMissingAnchor()
-                || Font == null
-                || FontColorGradient == null
-                || ButtonMeshBlue == null
-                || ButtonMeshBrown == null
-                || ButtonMeshRed == null
-                || ButtonMaterial == null
-                || ButtonHoverMaterial == null
-                || MenuBoxMesh == null
-                || MenuBoxMaterial == null)
-            {
-                CommonModule.Logger.Msg("Discovered a required Demeo resource was removed. Reinitializing.");
-                Initialize();
-            }
-        }
-
-        private bool IsMissingAnchor()
-        {
-            return LobbyTableAnchor == null && HangoutsTableAnchor == null;
-        }
-
-        private void Initialize()
+        public void Initialize()
         {
             Font = Resources.FindObjectsOfTypeAll<TMP_FontAsset>().First(x => x.name == "Demeo SDF");
             FontColorGradient = Resources
@@ -122,7 +96,7 @@
 
         private void InitializeAnchors()
         {
-            LobbyTableAnchor = Resources.FindObjectsOfTypeAll<charactersoundlistener>()
+            VrLobbyTableAnchor = Resources.FindObjectsOfTypeAll<charactersoundlistener>()
                 .FirstOrDefault(x => x.name == "MenuBox_BindPose");
             HangoutsTableAnchor = Resources.FindObjectsOfTypeAll<GameObject>()
                 .FirstOrDefault(x => x.name == "GroupLaunchTable");

--- a/Common/UI/UiHelper.cs
+++ b/Common/UI/UiHelper.cs
@@ -1,8 +1,10 @@
 ﻿namespace Common.UI
 {
     using System;
+    using Bowser.Core;
     using TMPro;
     using UnityEngine;
+    using UnityEngine.SceneManagement;
 
     // Helpful discussion on transforms:
     // https://forum.unity.com/threads/whats-the-best-practice-for-moving-recttransforms-in-script.264495
@@ -14,16 +16,31 @@
         public const float DefaultButtonZShift = -0.1f;
         public const float DefaultTextZShift = -0.2f;
 
+        private const int VrUiCollisionLayer = 5;
+        private const int HangoutsPointerCollisionLayer = 30;
+        private const int HangoutsSceneIndex = 43;
+
         private static UiHelper _instance;
 
         public DemeoResource DemeoResource { get; }
+
+        internal enum UiType
+        {
+            Vr,
+            Hangouts,
+        }
 
         public static UiHelper Instance()
         {
             if (_instance != null)
             {
-                _instance.DemeoResource.EnsureResourcesExists();
+                _instance.DemeoResource.Initialize();
                 return _instance;
+            }
+
+            if (!CommonModule.IsInitialized)
+            {
+                throw new InvalidOperationException("Common module is not initialized.");
             }
 
             if (!IsReady())
@@ -45,7 +62,27 @@
         /// </summary>
         public static bool IsReady()
         {
-            return DemeoResource.IsReady();
+            return CommonModule.IsInitialized && DemeoResource.IsReady() && IsReadyForHangouts();
+        }
+
+        private static bool IsReadyForHangouts()
+        {
+            if (GetCurrentUiType() != UiType.Hangouts)
+            {
+                return true;
+            }
+
+            return CommonModule.HangoutsButtonHandler != null;
+        }
+
+        public static UiType GetCurrentUiType()
+        {
+            if (SceneManager.GetActiveScene().buildIndex == HangoutsSceneIndex)
+            {
+                return UiType.Hangouts;
+            }
+
+            return UiType.Vr;
         }
 
         public GameObject CreateButtonText(string text)
@@ -61,28 +98,6 @@
         public GameObject CreateMenuHeaderText(string text)
         {
             return CreateText(text, DemeoResource.ColorBeige, fontSize: DefaultMenuHeaderFontSize);
-        }
-
-        public GameObject CreateButton(Action callback)
-        {
-            var buttonObject = new GameObject("Button");
-            buttonObject.transform.localRotation = Quaternion.Euler(270, 0, 0); // Align object.
-            buttonObject.layer = 5; // UI layer.
-
-            buttonObject.AddComponent<MeshFilter>().mesh = DemeoResource.ButtonMeshBlue;
-            buttonObject.AddComponent<MeshRenderer>().material = DemeoResource.ButtonMaterial;
-
-            var menuButtonHoverEffect = buttonObject.AddComponent<MenuButtonHoverEffect>();
-            menuButtonHoverEffect.hoverMaterial = DemeoResource.ButtonHoverMaterial;
-            menuButtonHoverEffect.Init();
-
-            // Added after HoverMaterial to enable effect.
-            buttonObject.AddComponent<ClickableButton>().InitButton(0, string.Empty, callback, false);
-
-            // Added last to allow ray to hit full object.
-            buttonObject.AddComponent<BoxCollider>();
-
-            return WrapObject(buttonObject);
         }
 
         /// <summary>
@@ -118,6 +133,63 @@
             return textObject;
         }
 
+        public GameObject CreateButton(Action callback)
+        {
+            if (GetCurrentUiType() == UiType.Hangouts)
+            {
+                return WrapObject(CreateHangoutsButton(callback));
+            }
+
+            return WrapObject(CreateVrUiButton(callback));
+        }
+
+        /// <summary>
+        /// Creates a button to function in Demeo VR UI.
+        /// </summary>
+        private GameObject CreateVrUiButton(Action callback)
+        {
+            var buttonObject = new GameObject("Button");
+            buttonObject.transform.localRotation = Quaternion.Euler(270, 0, 0); // Align object.
+            buttonObject.layer = VrUiCollisionLayer;
+
+            buttonObject.AddComponent<MeshFilter>().mesh = DemeoResource.ButtonMeshBlue;
+            buttonObject.AddComponent<MeshRenderer>().material = DemeoResource.ButtonMaterial;
+
+            var menuButtonHoverEffect = buttonObject.AddComponent<MenuButtonHoverEffect>();
+            menuButtonHoverEffect.hoverMaterial = DemeoResource.ButtonHoverMaterial;
+            menuButtonHoverEffect.Init();
+
+            // Added after HoverMaterial to enable effect.
+            buttonObject.AddComponent<ClickableButton>().InitButton(0, string.Empty, callback, false);
+
+            // Added last to allow ray to hit full object.
+            buttonObject.AddComponent<BoxCollider>();
+
+            return buttonObject;
+        }
+
+        /// <summary>
+        /// Creates a button to function in Demeo Hangouts.
+        /// </summary>
+        private GameObject CreateHangoutsButton(Action callback)
+        {
+            var buttonObject = CreateVrUiButton(callback);
+            buttonObject.layer = HangoutsPointerCollisionLayer;
+
+            var buttonData = buttonObject.AddComponent<BowserButtonData>();
+            buttonData.buttonVisuals = buttonObject;
+            buttonData.hoverMat = DemeoResource.ButtonHoverMaterial;
+            buttonData.isLocalPress = true;
+            buttonData.pointerOnly = true;
+            buttonData.pressedPosition = buttonData.visualsIdlePosition;
+            buttonData.pressEffect = BowserButtonData.PressEffect.HoverSize;
+            buttonData.pressHaptic = BowserButtonData.HapticEffect.Mini;
+            buttonData.pressSound = BowserButtonData.SoundEffect.Generic2d;
+
+            CommonModule.HangoutsButtonHandler.RegisterBowserButton(buttonData, delegate { callback(); });
+            return buttonObject;
+        }
+
         /// <summary>
         /// Wraps the specified GameObject inside a new <see cref="GameObject"/>.
         /// </summary>
@@ -125,7 +197,7 @@
         /// Useful for preserving the composition and layout of the original GameObject.
         /// </remarks>
         /// <returns>The GameObject whose child is the specified GameObject.</returns>
-        public static GameObject WrapObject(GameObject child)
+        private static GameObject WrapObject(GameObject child)
         {
             var container = new GameObject($"{child.name}Wrapper");
             child.transform.SetParent(container.transform);

--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -11,6 +11,7 @@
         internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("HouseRules:Configuration");
         internal static readonly ConfigManager ConfigManager = ConfigManager.NewInstance();
         private const int LobbySceneIndex = 1;
+        private const int HangoutsSceneIndex = 43;
         private static readonly List<string> FailedRulesetFiles = new List<string>();
 
         public override void OnApplicationStart()
@@ -46,12 +47,10 @@
 
         public override void OnSceneWasInitialized(int buildIndex, string sceneName)
         {
-            if (buildIndex != LobbySceneIndex)
+            if (buildIndex == LobbySceneIndex || buildIndex == HangoutsSceneIndex)
             {
-                return;
+                _ = new GameObject("HouseRules_RulesetSelection", typeof(UI.RulesetSelectionUI));
             }
-
-            _ = new GameObject("HouseRules_RulesetSelection", typeof(UI.RulesetSelectionUI));
         }
 
         private static void LoadRulesetsFromConfig()

--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using Common;
     using MelonLoader;
     using UnityEngine;
 
@@ -11,6 +12,11 @@
         internal static readonly ConfigManager ConfigManager = ConfigManager.NewInstance();
         private const int LobbySceneIndex = 1;
         private static readonly List<string> FailedRulesetFiles = new List<string>();
+
+        public override void OnApplicationStart()
+        {
+            CommonModule.Initialize();
+        }
 
         public override void OnApplicationLateStart()
         {

--- a/HouseRules_Configuration/UI/RulesetSelectionPanel.cs
+++ b/HouseRules_Configuration/UI/RulesetSelectionPanel.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Linq;
     using Common.UI;
-    using DataKeys;
     using HouseRules.Types;
     using TMPro;
     using UnityEngine;

--- a/HouseRules_Configuration/UI/RulesetSelectionUI.cs
+++ b/HouseRules_Configuration/UI/RulesetSelectionUI.cs
@@ -1,5 +1,6 @@
 ﻿namespace HouseRules.Configuration.UI
 {
+    using System;
     using System.Collections;
     using Common.UI;
     using UnityEngine;
@@ -34,10 +35,17 @@
 
         private void Initialize()
         {
-            this.transform.SetParent(_uiHelper.DemeoResource.LobbyTableAnchor.transform, worldPositionStays: true);
-
-            this.transform.position = new Vector3(32.6f, 26.4f, -12.8f);
-            this.transform.rotation = Quaternion.Euler(0, 70, 0);
+            switch (UiHelper.GetCurrentUiType())
+            {
+                case UiHelper.UiType.Vr:
+                    PositionInVrLobby();
+                    break;
+                case UiHelper.UiType.Hangouts:
+                    PositionInHangouts();
+                    break;
+                default:
+                    throw new InvalidOperationException("Unsupported Demeo UI.");
+            }
 
             _background = new GameObject("Background");
             _background.AddComponent<MeshFilter>().mesh = _uiHelper.DemeoResource.MenuBoxMesh;
@@ -58,6 +66,21 @@
 
             // TODO(orendain): Fix so that ray interacts with entire object.
             this.gameObject.AddComponent<BoxCollider>();
+        }
+
+        private void PositionInVrLobby()
+        {
+            this.transform.SetParent(_uiHelper.DemeoResource.VrLobbyTableAnchor.transform, worldPositionStays: true);
+            this.transform.position = new Vector3(32.6f, 26.4f, -12.8f);
+            this.transform.rotation = Quaternion.Euler(0, 70, 0);
+        }
+
+        private void PositionInHangouts()
+        {
+            this.transform.SetParent(_uiHelper.DemeoResource.HangoutsTableAnchor.transform, worldPositionStays: true);
+            this.transform.position = new Vector3(0.88f, 2.1f, -3.8f);
+            this.transform.localScale = new Vector3(0.045f, 0.045f, 0.045f);
+            this.gameObject.AddComponent<FaceLocalPlayer>();
         }
     }
 }

--- a/RoomFinder/RoomFinderMod.cs
+++ b/RoomFinder/RoomFinderMod.cs
@@ -1,5 +1,6 @@
 ﻿namespace RoomFinder
 {
+    using Common;
     using HarmonyLib;
     using MelonLoader;
     using RoomFinder.UI;
@@ -18,6 +19,7 @@
         {
             var harmony = new Harmony("com.orendain.demeomods.roomfinder");
             ModPatcher.Patch(harmony);
+            CommonModule.Initialize();
         }
 
         public override void OnSceneWasInitialized(int buildIndex, string sceneName)

--- a/RoomFinder/UI/RoomFinderUI.cs
+++ b/RoomFinder/UI/RoomFinderUI.cs
@@ -62,7 +62,7 @@
 
         private void Initialize()
         {
-            this.transform.SetParent(_uiHelper.DemeoResource.LobbyTableAnchor.transform, worldPositionStays: true);
+            this.transform.SetParent(_uiHelper.DemeoResource.VrLobbyTableAnchor.transform, worldPositionStays: true);
             this.transform.position = new Vector3(25, 30, 0);
             this.transform.rotation = Quaternion.Euler(0, 40, 0);
 


### PR DESCRIPTION
Part of https://github.com/orendain/DemeoMods/issues/222.

There were non-trivial differences in how interactables are created in the Hangouts space.  For buttons, their behavior must be registered with a particular button handler.  Additionally, interactables in Hangouts and the typical VR space operate on two different Unity "layers" when it comes to collisions with the pointer (i.e., the player's hand beam).

**Changes:**
- The `Common` package now includes a patch allowing it to capture a Hangouts-related handler from Demeo.
- As a result of the above, the `Common` package must now be initialized (with `CommonModule.Initialize()`).  This should be called from a dependent mod's `OnApplicationStart()`.
- Added the appropriate `CommonModule.Initialize()` calls to both RoomFinder and HouseRules.
- Removed a complicated check (`UiHelper` checking `DemeoResource.EnsureResourceExists()` which sometimes re-initializes `DemeoResource` values).  This is replaced by dropping the check and always re-initializing `DemeoResource`.  A bit more computational overhead, but reduced complexity and more deterministic.
- Introduced `GetCurrentUiType()`, with corresponding `UiType` enum, which will for now return either `UiType.Vr` or `UiType.Hangouts`.
- Added logic for creating a functional button in Demeo Hangouts (`CreateHangoutsButton()`). This logic, however, is abstracted behind the single `UiHelper.CreateButton()` method.  The method will create a button for whichever UI type (e.g., hangouts or typical VR UI) is currently loaded.

**Known issues:**
- Buttons rendered in Hangouts do not properly get their hover effect applied with this change.

> Note: This change in and of itself does not add RoomFinder or HouseRules UIs to the Hangouts space.  It only enables that feature.  See https://github.com/orendain/DemeoMods/pull/224 for the PR that builds on this and adds HouseRules UI to Hangouts.