### PR TITLE
Update The Swirl ruleset.

### DIFF
--- a/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
@@ -74,6 +74,12 @@
                 { "FloorThreeLootChests", 12 },
             });
 
+            var aoePotions = new AbilityAoeAdjustedRule(new Dictionary<string, int>
+            {
+                { "Strength", 1 },
+                { "Speed", 1 },
+            });
+
             var respawnsDisabledRule = new EnemyRespawnDisabledRule(true);
             var levelExitLockedRule = new LevelExitLockedUntilAllEnemiesDefeatedRule(true);
 
@@ -84,6 +90,7 @@
                 allowedCardsRule,
                 piecesAdjustedRule,
                 levelPropertiesRule,
+                aoePotions,
                 respawnsDisabledRule,
                 levelExitLockedRule);
         }

--- a/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
@@ -75,7 +75,6 @@
                 { "FloorThreeLootChests", 12 },
             });
 
-            var cardEnergyRule = new CardEnergyFromAttackMultipliedRule(1f);
             var respawnsDisabledRule = new EnemyRespawnDisabledRule(true);
             var levelExitLockedRule = new LevelExitLockedUntilAllEnemiesDefeatedRule(true);
 
@@ -86,7 +85,6 @@
                 allowedCardsRule,
                 piecesAdjustedRule,
                 levelPropertiesRule,
-                cardEnergyRule,
                 respawnsDisabledRule,
                 levelExitLockedRule);
         }

--- a/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
@@ -39,21 +39,20 @@
             };
             var startingCardsRule = new StartCardsModifiedRule(new Dictionary<BoardPieceId, List<StartCardsModifiedRule.CardConfig>>
             {
-                { BoardPieceId.HeroBard, bardCards }, // tordnater
-                { BoardPieceId.HeroGuardian, guardianCards }, /// charge
-                { BoardPieceId.HeroHunter, hunterCards }, // naturescall
-                { BoardPieceId.HeroRouge, assassinCards }, //blink
-                { BoardPieceId.HeroSorcerer, sorcererCards }, // spawn elemtnal
+                { BoardPieceId.HeroBard, bardCards },
+                { BoardPieceId.HeroGuardian, guardianCards },
+                { BoardPieceId.HeroHunter, hunterCards },
+                { BoardPieceId.HeroRouge, assassinCards },
+                { BoardPieceId.HeroSorcerer, sorcererCards },
             });
 
-            var allowedCards = new List<AbilityKey> { AbilityKey.PoisonGasGrenade, AbilityKey.Fireball };
             var allowedCardsRule = new CardAdditionOverriddenRule(new Dictionary<BoardPieceId, List<AbilityKey>>
             {
-                { BoardPieceId.HeroBard, allowedCards },
-                { BoardPieceId.HeroGuardian, allowedCards },
-                { BoardPieceId.HeroHunter, allowedCards },
-                { BoardPieceId.HeroRouge, allowedCards },
-                { BoardPieceId.HeroSorcerer, allowedCards },
+                { BoardPieceId.HeroBard, new List<AbilityKey> { AbilityKey.PoisonGasGrenade, AbilityKey.Fireball, AbilityKey.Tornado } },
+                { BoardPieceId.HeroGuardian, new List<AbilityKey> { AbilityKey.PoisonGasGrenade, AbilityKey.Fireball, AbilityKey.Charge } },
+                { BoardPieceId.HeroHunter, new List<AbilityKey> { AbilityKey.PoisonGasGrenade, AbilityKey.Fireball, AbilityKey.PoisonedTip } },
+                { BoardPieceId.HeroRouge, new List<AbilityKey> { AbilityKey.PoisonGasGrenade, AbilityKey.Fireball, AbilityKey.Blink } },
+                { BoardPieceId.HeroSorcerer, new List<AbilityKey> { AbilityKey.PoisonGasGrenade, AbilityKey.Fireball, AbilityKey.SummonElemental } },
             });
 
             var piecesAdjustedRule = new PieceConfigAdjustedRule(new List<PieceConfigAdjustedRule.PieceProperty>

--- a/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
@@ -39,11 +39,11 @@
             };
             var startingCardsRule = new StartCardsModifiedRule(new Dictionary<BoardPieceId, List<StartCardsModifiedRule.CardConfig>>
             {
-                { BoardPieceId.HeroBard, bardCards },
-                { BoardPieceId.HeroGuardian, guardianCards },
-                { BoardPieceId.HeroHunter, hunterCards },
-                { BoardPieceId.HeroRouge, assassinCards },
-                { BoardPieceId.HeroSorcerer, sorcererCards },
+                { BoardPieceId.HeroBard, bardCards }, // tordnater
+                { BoardPieceId.HeroGuardian, guardianCards }, /// charge
+                { BoardPieceId.HeroHunter, hunterCards }, // naturescall
+                { BoardPieceId.HeroRouge, assassinCards }, //blink
+                { BoardPieceId.HeroSorcerer, sorcererCards }, // spawn elemtnal
             });
 
             var allowedCards = new List<AbilityKey> { AbilityKey.PoisonGasGrenade, AbilityKey.Fireball };
@@ -68,14 +68,14 @@
             var levelPropertiesRule = new LevelPropertiesModifiedRule(new Dictionary<string, int>
             {
                 { "FloorOneHealingFountains", 2 },
-                { "FloorOneLootChests", 8 },
+                { "FloorOneLootChests", 11 },
                 { "FloorTwoHealingFountains", 4 },
-                { "FloorTwoLootChests", 12 },
+                { "FloorTwoLootChests", 14 },
                 { "FloorThreeHealingFountains", 4 },
                 { "FloorThreeLootChests", 12 },
             });
 
-            var cardEnergyRule = new CardEnergyFromAttackMultipliedRule(0.8f);
+            var cardEnergyRule = new CardEnergyFromAttackMultipliedRule(1f);
             var respawnsDisabledRule = new EnemyRespawnDisabledRule(true);
             var levelExitLockedRule = new LevelExitLockedUntilAllEnemiesDefeatedRule(true);
 


### PR DESCRIPTION
**Changes:**
- Increase the number of look chests in the first two floors.
- Remove the card energy modification.
- Heroes have one additional card added to the possible card pool.
- Strength and speed potions have a 3x3 AoE effect. 