### PR TITLE
Trigger board sync only if active ruleset requires it.

### DIFF
--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -61,6 +61,11 @@
                 return;
             }
 
+            if (HR.SelectedRuleset.ModifiedData == SpecialSyncData.None)
+            {
+                return;
+            }
+
             UpdateSyncTriggers(serializableEvent);
 
             if (!IsSyncNeeded())
@@ -162,7 +167,25 @@
 
         private static bool IsSyncNeeded()
         {
-            return _isNewSpawnPossible || _isStatusImmunitiesTouched || _isStatusEffectsTouched;
+            var hasSyncType = (HR.SelectedRuleset.ModifiedData & SpecialSyncData.PieceData) > 0;
+            if (hasSyncType && _isNewSpawnPossible)
+            {
+                return true;
+            }
+
+            hasSyncType = (HR.SelectedRuleset.ModifiedData & SpecialSyncData.StatusEffectImmunity) > 0;
+            if (hasSyncType && _isStatusImmunitiesTouched)
+            {
+                return true;
+            }
+
+            hasSyncType = (HR.SelectedRuleset.ModifiedData & SpecialSyncData.StatusEffectData) > 0;
+            if (hasSyncType && _isStatusEffectsTouched)
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private static bool IsSyncOpportunity(SerializableEvent serializableEvent)

--- a/HouseRules_Core/Types/Ruleset.cs
+++ b/HouseRules_Core/Types/Ruleset.cs
@@ -21,12 +21,17 @@
         public List<Rule> Rules { get; }
 
         /// <summary>
-        /// Gets a value indicating whether this ruleset is safe to use in multiplayer environments.
+        /// Gets a value indicating whether the ruleset is safe to use in multiplayer environments.
         /// </summary>
         public bool IsSafeForMultiplayer { get; }
 
         /// <summary>
-        /// Represents the default/empty/null ruleset.
+        /// Gets the type of data that the rule makes modifications to.
+        /// </summary>
+        public SpecialSyncData ModifiedData { get; }
+
+        /// <summary>
+        /// Represents the empty/missing ruleset.
         /// </summary>
         public static readonly Ruleset None = NewInstance("None", "No custom ruleset.");
 
@@ -38,15 +43,17 @@
         public static Ruleset NewInstance(string name, string description, List<Rule> rules)
         {
             var safeForMultiplayer = rules.All(r => r is IMultiplayerSafe);
-            return new Ruleset(name, description, rules, safeForMultiplayer);
+            var modifiedData = rules.Aggregate(SpecialSyncData.None, (data, rule) => data | rule.ModifiedData);
+            return new Ruleset(name, description, rules, safeForMultiplayer, modifiedData);
         }
 
-        private Ruleset(string name, string description, List<Rule> rules, bool isSafeForMultiplayer)
+        private Ruleset(string name, string description, List<Rule> rules, bool isSafeForMultiplayer, SpecialSyncData modifiedData)
         {
             Name = name;
             Description = description;
             Rules = rules;
             IsSafeForMultiplayer = isSafeForMultiplayer;
+            ModifiedData = modifiedData;
         }
     }
 }

--- a/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
@@ -7,7 +7,6 @@
     using HarmonyLib;
     using HouseRules.Types;
     using UnityEngine;
-    using Behaviour = DataKeys.Behaviour;
 
     public sealed class PiecePieceTypeListOverriddenRule : Rule, IConfigWritable<Dictionary<BoardPieceId, PieceType[]>>, IMultiplayerSafe
     {


### PR DESCRIPTION
Ruleset class now exposes the aggregate data type that it makes modifications to.

Board will only sync if there is overlap between what the ruleset needs and what was changed.