### PR TITLE
Modify PieceConfigDTOdict directly, and new PieceUseWhenKilled rule

### DIFF
--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -19,16 +19,6 @@ namespace HouseRules
 
         internal static bool IsRulesetActive { get; private set; }
 
-        public static string FixBossNames(BoardPieceId piece)
-        {
-            if (piece == BoardPieceId.DarkElfGoddessBoss || piece == BoardPieceId.CavetrollBoss)
-            {
-                return piece.ToString().Replace("Boss", "_Boss");
-            }
-
-            return piece.ToString();
-        }
-
         public static void SelectRuleset(string ruleset)
         {
             if (IsRulesetActive)

--- a/HouseRules_Core/ModPatcher.cs
+++ b/HouseRules_Core/ModPatcher.cs
@@ -65,13 +65,13 @@
 
             var createGameMode = Traverse.Create(_gameContext.gameStateMachine)
                 .Field<CreateGameMode>("createGameMode").Value;
-            var levelSequence = Traverse.Create(_gameContext.gameStateMachine).Field<LevelSequence>("levelSequence").Value;
-            MotherbrainGlobalVars.CurrentConfig = levelSequence.gameConfig;
             if (createGameMode != CreateGameMode.Private)
             {
                 return;
             }
 
+            var levelSequence = Traverse.Create(_gameContext.gameStateMachine).Field<LevelSequence>("levelSequence").Value;
+            MotherbrainGlobalVars.CurrentConfig = levelSequence.gameConfig;
             HR.TriggerActivateRuleset(_gameContext, GameHub.GetGameMode);
             _isStartingGame = true;
             HR.TriggerPreGameCreated(_gameContext);

--- a/HouseRules_Core/ModPatcher.cs
+++ b/HouseRules_Core/ModPatcher.cs
@@ -65,6 +65,8 @@
 
             var createGameMode = Traverse.Create(_gameContext.gameStateMachine)
                 .Field<CreateGameMode>("createGameMode").Value;
+            var levelSequence = Traverse.Create(_gameContext.gameStateMachine).Field<LevelSequence>("levelSequence").Value;
+            MotherbrainGlobalVars.CurrentConfig = levelSequence.gameConfig;
             if (createGameMode != CreateGameMode.Private)
             {
                 return;

--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -41,6 +41,7 @@
             HR.Rulebook.Register(typeof(PieceAbilityListOverriddenRule));
             HR.Rulebook.Register(typeof(PieceBehavioursListOverriddenRule));
             HR.Rulebook.Register(typeof(PiecePieceTypeListOverriddenRule));
+            HR.Rulebook.Register(typeof(PieceUseWhenKilledOverriddenRule));
             HR.Rulebook.Register(typeof(RatNestsSpawnGoldRule));
             HR.Rulebook.Register(typeof(RegainAbilityIfMaxxedOutOverriddenRule));
             HR.Rulebook.Register(typeof(RoundCountLimitedRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Rulesets\TheSwirlRuleset.cs" />
     <Compile Include="Rules\AbilityBackstabAdjustedRule.cs" />
     <Compile Include="Rules\CardClassRestrictionOverriddenRule.cs" />
+    <Compile Include="Rules\PieceUseWhenKilledOverriddenRule.cs" />
     <Compile Include="Rules\SpawnCategoryOverriddenRule.cs" />
     <Compile Include="Rules\AbilityActionCostAdjustedRule.cs" />
     <Compile Include="Rules\PiecePieceTypeListOverriddenRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -431,6 +431,22 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
     }
   },
   ```
+  
+- __PieceUseWhenKilledOverriddenRule__: Allows the list of UseWhenKilled abilities for any ♟️BoardPiece to be overridden
+  - Abilities are trigged at the a piece dies. 
+  - Config accepts Dictionary of boardpieceIDs and Lists of AbilityKeys e.g. ` "BoardPieceID": [ "AbilityKey1", "AbilityKey2" ] }`  
+
+  ###### _Example JSON config for PieceUseWhenKilledOverriddenRule_
+
+  ```json
+  {
+    "Rule": "PieceUseWhenKilledOverridden",
+    "Config": {
+      "Spiderling": [ "Heal" ],
+      "CaveTroll": [ "Rejuvenation" ],
+    }
+  },
+  ```
 
 - __RatNestsSpawnGoldRule__: Rat nests spawn 💰gold💰
   - 🚧 _Skirmish-only - Does not work properly in multiplayer games._ 🚧

--- a/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -59,10 +59,11 @@
                 [GameConfigType.Sewers] = new List<PieceProperty>(),
                 [GameConfigType.Forest] = new List<PieceProperty>(),
             };
-            foreach (var item in pieceConfigChanges)
+
+            GameConfigType[] gct = { GameConfigType.Elven, GameConfigType.Sewers, GameConfigType.Forest };
+            foreach (var gameConfigType in gct)
             {
-                GameConfigType[] gct = { GameConfigType.Elven, GameConfigType.Sewers, GameConfigType.Forest };
-                foreach (var gameConfigType in gct)
+                foreach (var item in pieceConfigChanges)
                 {
                     var pieceConfigDto = gameConfigPieceConfigs[gameConfigType][item.Piece];
                     var propertyTraverse = Traverse.Create(pieceConfigDto).Field(item.Property);

--- a/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -2,21 +2,18 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using Boardgame;
+    using Data.GameData;
     using DataKeys;
     using HarmonyLib;
     using HouseRules.Types;
-    using UnityEngine;
 
     public sealed class PieceConfigAdjustedRule : Rule, IConfigWritable<List<PieceConfigAdjustedRule.PieceProperty>>, IMultiplayerSafe
     {
         public override string Description => "Piece configuration is adjusted";
 
-        protected override SpecialSyncData ModifiedData => SpecialSyncData.PieceData;
-
         private readonly List<PieceProperty> _adjustments;
-        private List<PieceProperty> _originals;
+        private Dictionary<GameConfigType, List<PieceProperty>> _originals;
 
         public struct PieceProperty
         {
@@ -32,61 +29,75 @@
         public PieceConfigAdjustedRule(List<PieceProperty> adjustments)
         {
             _adjustments = adjustments;
-            _originals = new List<PieceProperty>();
+            _originals = new Dictionary<GameConfigType, List<PieceProperty>>();
         }
 
         public List<PieceProperty> GetConfigObject() => _adjustments;
 
-        protected override void OnPostGameCreated(GameContext gameContext)
+        protected override void OnPreGameCreated(GameContext gameContext)
         {
             _originals = ReplaceExistingProperties(_adjustments);
         }
 
         protected override void OnDeactivate(GameContext gameContext)
         {
-            ReplaceExistingProperties(_originals);
+            ReplaceExistingProperties(_originals[GameConfigType.Elven]);
+            ReplaceExistingProperties(_originals[GameConfigType.Sewers]);
+            ReplaceExistingProperties(_originals[GameConfigType.Forest]);
         }
 
         /// <summary>
         /// Replaces existing PieceConfig properties with those specified.
         /// </summary>
-        /// <returns>The list of previous PieceConfig properties that are now replaced.</returns>
-        private static List<PieceProperty> ReplaceExistingProperties(List<PieceProperty> pieceProperties)
+        /// <returns>Dictionary of GameConfigYypes and lists of previous PieceConfig properties that are now replaced.</returns>
+        private static Dictionary<GameConfigType, List<PieceProperty>> ReplaceExistingProperties(List<PieceProperty> pieceConfigChanges)
         {
-            var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
-            var previousProperties = new List<PieceProperty>();
-            foreach (var item in pieceProperties)
+            var gameConfigPieceConfigs = Traverse.Create(typeof(GameDataAPI)).Field<Dictionary<GameConfigType, Dictionary<BoardPieceId, PieceConfigDTO>>>("PieceConfigDTOdict").Value;
+            var previousProperties = new Dictionary<GameConfigType, List<PieceProperty>>
             {
-                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Piece)}"));
-                var propertyTraverse = Traverse.Create(pieceConfig).Property(item.Property);
-                var castedNewValue = CastPropertyValue(item.Value, propertyTraverse.GetValueType());
-
-                previousProperties.Add(new PieceProperty
+                [GameConfigType.Elven] = new List<PieceProperty>(),
+                [GameConfigType.Sewers] = new List<PieceProperty>(),
+                [GameConfigType.Forest] = new List<PieceProperty>(),
+            };
+            foreach (var item in pieceConfigChanges)
+            {
+                GameConfigType[] gct = { GameConfigType.Elven, GameConfigType.Sewers, GameConfigType.Forest };
+                foreach (var gameConfigType in gct)
                 {
-                    Piece = item.Piece,
-                    Property = item.Property,
-                    Value = Convert.ToSingle(propertyTraverse.GetValue()),
-                });
+                    var pieceConfigDto = gameConfigPieceConfigs[gameConfigType][item.Piece];
+                    var propertyTraverse = Traverse.Create(pieceConfigDto).Field(item.Property);
 
-                propertyTraverse.SetValue(castedNewValue);
+                    previousProperties[gameConfigType].Add(new PieceProperty
+                    {
+                        Piece = item.Piece,
+                        Property = item.Property,
+                        Value = Convert.ToSingle(propertyTraverse.GetValue()),
+                    });
+
+                    ModifyPieceConfig(ref pieceConfigDto, item.Property, item.Value);
+                    gameConfigPieceConfigs[gameConfigType][item.Piece] = pieceConfigDto;
+                }
             }
 
             return previousProperties;
         }
 
-        private static object CastPropertyValue(float value, Type propertyValueType)
+        private static void ModifyPieceConfig(ref PieceConfigDTO pieceConfigDto, string property, float value)
         {
-            if (propertyValueType == typeof(int))
+            var valueType = Traverse.Create(pieceConfigDto).Field(property).GetValueType();
+            if (valueType == typeof(int))
             {
-                return (int)value;
+                AccessTools.StructFieldRefAccess<PieceConfigDTO, int>(ref pieceConfigDto, property) = (int)value;
+                return;
             }
 
-            if (propertyValueType == typeof(float))
+            if (valueType == typeof(float))
             {
-                return value;
+                AccessTools.StructFieldRefAccess<PieceConfigDTO, float>(ref pieceConfigDto, property) = value;
+                return;
             }
 
-            throw new ArgumentException($"Can not support a piece property of type: {propertyValueType}");
+            throw new ArgumentException($"Can not support property of type: {valueType}");
         }
     }
 }

--- a/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -59,7 +59,6 @@
                 [MotherbrainGlobalVars.CurrentConfig] = new List<PieceProperty>(),
             };
 
-            GameConfigType[] gct = { GameConfigType.Elven, GameConfigType.Sewers, GameConfigType.Forest };
             foreach (var item in pieceConfigChanges)
             {
                 var pieceConfigDto = gameConfigPieceConfigs[gameConfigType][item.Piece];
@@ -75,6 +74,7 @@
                 ModifyPieceConfig(ref pieceConfigDto, item.Property, item.Value);
                 gameConfigPieceConfigs[gameConfigType][item.Piece] = pieceConfigDto;
             }
+
             return previousProperties;
         }
 

--- a/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
@@ -42,7 +42,7 @@
         /// <summary>
         /// Replaces existing PieceConfig properties with those specified.
         /// </summary>
-        /// <returns>Dictionary of GameConfigYypes and lists of previous PieceConfig properties that are now replaced.</returns>
+        /// <returns>Dictionary of lists of previous PieceConfig properties that are now replaced.</returns>
         private static Dictionary<BoardPieceId, List<AbilityKey>> ReplaceExistingProperties(Dictionary<BoardPieceId, List<AbilityKey>> pieceConfigChanges)
         {
             var gameConfigPieceConfigs = Traverse.Create(typeof(GameDataAPI)).Field<Dictionary<GameConfigType, Dictionary<BoardPieceId, PieceConfigDTO>>>("PieceConfigDTOdict").Value;

--- a/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
@@ -11,10 +11,10 @@
     {
         public override string Description => "Piece UseWhenKilled lists are overridden";
 
-        protected override SpecialSyncData ModifiedData => SpecialSyncData.StatusEffectImmunity;
+        protected override SpecialSyncData ModifiedData => SpecialSyncData.PieceData;
 
         private readonly Dictionary<BoardPieceId, List<AbilityKey>> _adjustments;
-        private Dictionary<GameConfigType, Dictionary<BoardPieceId, List<AbilityKey>>> _originals;
+        private Dictionary<BoardPieceId, List<AbilityKey>> _originals;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PieceUseWhenKilledOverriddenRule"/> class.
@@ -24,44 +24,38 @@
         public PieceUseWhenKilledOverriddenRule(Dictionary<BoardPieceId, List<AbilityKey>> adjustments)
         {
             _adjustments = adjustments;
-            _originals = new Dictionary<GameConfigType, Dictionary<BoardPieceId, List<AbilityKey>>>();
+            _originals = new Dictionary<BoardPieceId, List<AbilityKey>>();
         }
 
         public Dictionary<BoardPieceId, List<AbilityKey>> GetConfigObject() => _adjustments;
 
         protected override void OnPreGameCreated(GameContext gameContext)
         {
-            _originals = ReplaceExistingProperties(MotherbrainGlobalVars.CurrentConfig, _adjustments);
+            _originals = ReplaceExistingProperties(_adjustments);
         }
 
         protected override void OnDeactivate(GameContext gameContext)
         {
-            foreach (var gameConfigType in _originals)
-            {
-                ReplaceExistingProperties(gameConfigType.Key, _originals[gameConfigType.Key]);
-            }
+            ReplaceExistingProperties(_originals);
         }
 
         /// <summary>
         /// Replaces existing PieceConfig properties with those specified.
         /// </summary>
         /// <returns>Dictionary of GameConfigYypes and lists of previous PieceConfig properties that are now replaced.</returns>
-        private static Dictionary<GameConfigType, Dictionary<BoardPieceId, List<AbilityKey>>> ReplaceExistingProperties(GameConfigType gameConfigType, Dictionary<BoardPieceId, List<AbilityKey>> pieceConfigChanges)
+        private static Dictionary<BoardPieceId, List<AbilityKey>> ReplaceExistingProperties(Dictionary<BoardPieceId, List<AbilityKey>> pieceConfigChanges)
         {
             var gameConfigPieceConfigs = Traverse.Create(typeof(GameDataAPI)).Field<Dictionary<GameConfigType, Dictionary<BoardPieceId, PieceConfigDTO>>>("PieceConfigDTOdict").Value;
-            var previousProperties = new Dictionary<GameConfigType, Dictionary<BoardPieceId, List<AbilityKey>>>
-            {
-                [MotherbrainGlobalVars.CurrentConfig] = new Dictionary<BoardPieceId, List<AbilityKey>>(),
-            };
+            var previousProperties = new Dictionary<BoardPieceId, List<AbilityKey>>();
 
             foreach (var item in pieceConfigChanges)
             {
-                var pieceConfigDto = gameConfigPieceConfigs[gameConfigType][item.Key];
+                var pieceConfigDto = gameConfigPieceConfigs[MotherbrainGlobalVars.CurrentConfig][item.Key];
                 var property = Traverse.Create(pieceConfigDto).Property<List<AbilityKey>>("UseWhenKilled");
 
-                previousProperties[gameConfigType][item.Key] = property.Value;
+                previousProperties[item.Key] = property.Value;
                 pieceConfigDto.UseWhenKilled = item.Value.ToArray();
-                gameConfigPieceConfigs[gameConfigType][item.Key] = pieceConfigDto;
+                gameConfigPieceConfigs[MotherbrainGlobalVars.CurrentConfig][item.Key] = pieceConfigDto;
             }
 
             return previousProperties;

--- a/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
@@ -1,0 +1,56 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Boardgame;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Types;
+    using UnityEngine;
+
+    public sealed class PieceUseWhenKilledOverriddenRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<AbilityKey>>>, IMultiplayerSafe
+    {
+        public override string Description => "Piece immunities are adjusted";
+
+        protected override SpecialSyncData ModifiedData => SpecialSyncData.StatusEffectImmunity;
+
+        private readonly Dictionary<BoardPieceId, List<AbilityKey>> _adjustments;
+        private readonly Dictionary<BoardPieceId, List<AbilityKey>> _originals;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PieceUseWhenKilledOverriddenRule"/> class.
+        /// </summary>
+        /// <param name="adjustments">Dict of piece name and EffectStateType[]
+        /// Replaces original settings with new list.</param>
+        public PieceUseWhenKilledOverriddenRule(Dictionary<BoardPieceId, List<AbilityKey>> adjustments)
+        {
+            _adjustments = adjustments;
+            _originals = new Dictionary<BoardPieceId, List<AbilityKey>>();
+        }
+
+        public Dictionary<BoardPieceId, List<AbilityKey>> GetConfigObject() => _adjustments;
+
+        protected override void OnPostGameCreated(GameContext gameContext)
+        {
+            var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            foreach (var item in _adjustments)
+            {
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
+                _originals[item.Key] = pieceConfig.UseWhenKilled;
+                var property = Traverse.Create(pieceConfig).Property<List<AbilityKey>>("UseWhenKilled");
+                property.Value = item.Value;
+            }
+        }
+
+        protected override void OnDeactivate(GameContext gameContext)
+        {
+            var pieceConfigs = Resources.FindObjectsOfTypeAll<PieceConfig>();
+            foreach (var item in _originals)
+            {
+                var pieceConfig = pieceConfigs.First(c => c.name.Equals($"PieceConfig_{HR.FixBossNames(item.Key)}"));
+                var property = Traverse.Create(pieceConfig).Property<List<AbilityKey>>("UseWhenKilled");
+                property.Value = item.Value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Modify PieceConfigDTOdict directly.

This pull request implements modifications to the PieceConfigAdjustedRule so that it directly modifies `PieceConfigDTOdict` during `OnPreGameCreated`. In order to enable this, we need `ModPatcher.cs` to make sure that `MotherbrainGlobalVars.CurrentConfig` is set earlier than it normally would be. 

This PR also adds a new rule for overriding a piece's UseWhenKilled list of abilities. 

I thought I'd PR this now because I don't like being away from `main` for too long. The `PieceUseWhenKilledOverriddenRule` is a reasonable template for the changes that will be required to `PieceAbilityListOverriddenRule`, `PieceBehaviourListOverriddenRule` `PieceImmunityListOverriddenRule` & `PiecePieceTypeListOverriddenRule` - Those changes can follow in a later PR.

## Suggested JSON for testing.
```
{
  "Name": "Slay to Play",
  "Description": "Kill spiders to regain health.",
  "Rules": [
    {
      "Rule": "AbilityAoeAdjusted",
      "Config": {
        "Heal": 1,
      }
    },
    {
      "Rule": "PieceUseWhenKilledOverridden",
      "Config": {
        "Spiderling": [ "Heal" ],
      }
    },
  ]
}
```