### PR TITLE
Modify ability rules to perform abilityKey-to-ability lookups.

### DIFF
--- a/HouseRules_Configuration/ExampleRulesetExporter.cs
+++ b/HouseRules_Configuration/ExampleRulesetExporter.cs
@@ -18,20 +18,20 @@ namespace HouseRules.Configuration
 
         private static void ExportExampleRuleset()
         {
-            var aaca = new AbilityActionCostAdjustedRule(new Dictionary<string, bool>
+            var aaca = new AbilityActionCostAdjustedRule(new Dictionary<AbilityKey, bool>
             {
-                { "Zap", false }, // 0 casting cost for zap
-                { "CourageShanty", false }, // 0 casting cost for Courage
+                { AbilityKey.Zap, false }, // 0 casting cost for zap
+                { AbilityKey.CourageShanty, false }, // 0 casting cost for Courage
             });
-            var aaa = new AbilityAoeAdjustedRule(new Dictionary<string, int>
+            var aaa = new AbilityAoeAdjustedRule(new Dictionary<AbilityKey, int>
             {
-                { "Fireball", 1 }, // 5x5 fireball
-                { "Zap", 1 }, // Just testing
-                { "CourageShanty", 1 }, // Everyone should hear the bard sing the courage song
-                { "StrengthPotion", 1 }, // Everyone nearby should share the strength potion
-                { "SwiftnessPotion", 1 }, // Everyone nearby should share the speed potion
+                { AbilityKey.Fireball, 1 }, // 5x5 fireball
+                { AbilityKey.Zap, 1 }, // Just testing
+                { AbilityKey.CourageShanty, 1 }, // Everyone should hear the bard sing the courage song
+                { AbilityKey.StrengthPotion, 1 }, // Everyone nearby should share the strength potion
+                { AbilityKey.SwiftnessPotion, 1 }, // Everyone nearby should share the speed potion
             });
-            var ada = new AbilityDamageAdjustedRule(new Dictionary<string, int> { { "Zap", 1 } });
+            var ada = new AbilityDamageAdjustedRule(new Dictionary<AbilityKey, int> { { AbilityKey.Zap, 1 } });
             var cefam1 = new CardEnergyFromAttackMultipliedRule(2f);
             var cefam2 = new CardEnergyFromAttackMultipliedRule(2f);
             var cefam3 = new CardEnergyFromAttackMultipliedRule(2f);
@@ -72,10 +72,10 @@ namespace HouseRules.Configuration
             var sorcCards = new Dictionary<BoardPieceId, List<StartCardsModifiedRule.CardConfig>> { { BoardPieceId.HeroSorcerer, cards } };
             var sscm = new StartCardsModifiedRule(sorcCards);
 
-            BoardPieceId[] bps = { BoardPieceId.ChestGoblin, BoardPieceId.Slimeling };
-            var arpl = new AbilityRandomPieceListRule(new Dictionary<string, BoardPieceId[]>
+            List<BoardPieceId> bps = new List<BoardPieceId> { BoardPieceId.ChestGoblin, BoardPieceId.Slimeling };
+            var arpl = new AbilityRandomPieceListRule(new Dictionary<AbilityKey, List<BoardPieceId>>
             {
-                { "BeastWhisperer", bps },
+                { AbilityKey.BeastWhisperer, bps },
             });
 
             List<EffectStateType> effs = new List<EffectStateType>() { EffectStateType.Diseased, EffectStateType.Stunned, EffectStateType.MarkOfAvalon, EffectStateType.Weaken, EffectStateType.Frozen, EffectStateType.Tangled, EffectStateType.Petrified };

--- a/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
@@ -1,5 +1,6 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
+    using System;
     using System.Collections.Generic;
     using Boardgame;
     using Boardgame.BoardEntities.Abilities;
@@ -46,7 +47,7 @@
             {
                 if (!AbilityFactory.TryGetAbility(replacement.Key, out var ability))
                 {
-                    EssentialsMod.Logger.Warning($"Provided AbilityKey [{replacement.Key}] does not have a corresponding ability. Skipping that ability.");
+                    throw new InvalidOperationException($"AbilityKey [{replacement.Key}] does not have a corresponding ability.");
                 }
 
                 originals[replacement.Key] = -replacement.Value * 2;

--- a/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
@@ -1,53 +1,60 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
     using System.Collections.Generic;
-    using System.Linq;
     using Boardgame;
     using Boardgame.BoardEntities.Abilities;
+    using DataKeys;
     using HarmonyLib;
     using HouseRules.Types;
-    using UnityEngine;
 
-    public sealed class AbilityAoeAdjustedRule : Rule, IConfigWritable<Dictionary<string, int>>, IMultiplayerSafe
+    public sealed class AbilityAoeAdjustedRule : Rule, IConfigWritable<Dictionary<AbilityKey, int>>, IMultiplayerSafe
     {
         public override string Description => "Ability AOE Ranges are adjusted";
 
-        private readonly Dictionary<string, int> _adjustments;
+        private readonly Dictionary<AbilityKey, int> _adjustments;
+        private Dictionary<AbilityKey, int> _originals;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AbilityAoeAdjustedRule"/> class.
         /// </summary>
         /// <param name="adjustments">Key-value pairs mapping the name of an ability and the AOE range
         /// added to their base. Adding '1' to a 3x3 spell will make a 5x5. Negative values will reduce AOE.</param>
-        public AbilityAoeAdjustedRule(Dictionary<string, int> adjustments)
+        public AbilityAoeAdjustedRule(Dictionary<AbilityKey, int> adjustments)
         {
             _adjustments = adjustments;
+            _originals = new Dictionary<AbilityKey, int>();
         }
 
-        public Dictionary<string, int> GetConfigObject() => _adjustments;
+        public Dictionary<AbilityKey, int> GetConfigObject() => _adjustments;
 
-        protected override void OnPostGameCreated(GameContext gameContext)
+        protected override void OnPreGameCreated(GameContext gameContext)
         {
-            var abilities = Resources.FindObjectsOfTypeAll<Ability>();
-            foreach (var item in _adjustments)
-            {
-                var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
-                var aoe = Traverse.Create(ability).Field<AreaOfEffect>("areaOfEffect").Value;
-                Traverse.Create(aoe).Field<int>("range").Value += item.Value; // Adjust the yellow AOE outline when casting.
-                ability.areaOfEffectRange += item.Value; // Adjust value displayed on the card.
-            }
+            _originals = ReplaceAbility(_adjustments);
         }
 
         protected override void OnDeactivate(GameContext gameContext)
         {
-            var abilities = Resources.FindObjectsOfTypeAll<Ability>();
-            foreach (var item in _adjustments)
+            ReplaceAbility(_originals);
+        }
+
+        private static Dictionary<AbilityKey, int> ReplaceAbility(Dictionary<AbilityKey, int> replacements)
+        {
+            var originals = new Dictionary<AbilityKey, int>();
+
+            foreach (var replacement in replacements)
             {
-                var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
+                if (!AbilityFactory.TryGetAbility(replacement.Key, out var ability))
+                {
+                    EssentialsMod.Logger.Warning($"Provided AbilityKey [{replacement.Key}] does not have a corresponding ability. Skipping that ability.");
+                }
+
+                originals[replacement.Key] = ability.areaOfEffectRange;
                 var aoe = Traverse.Create(ability).Field<AreaOfEffect>("areaOfEffect").Value;
-                Traverse.Create(aoe).Field<int>("range").Value -= item.Value; // Adjust the yellow AOE outline when casting.
-                ability.areaOfEffectRange -= item.Value; // Adjust value displayed on the card.
+                Traverse.Create(aoe).Field<int>("range").Value += replacement.Value; // Adjust the AOE outline when casting.
+                ability.areaOfEffectRange += replacement.Value; // Adjust value displayed on the card.
             }
+
+            return originals;
         }
     }
 }

--- a/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
@@ -18,7 +18,8 @@
         /// Initializes a new instance of the <see cref="AbilityAoeAdjustedRule"/> class.
         /// </summary>
         /// <param name="adjustments">Key-value pairs mapping the name of an ability and the AOE range
-        /// added to their base. Adding '1' to a 3x3 spell will make a 5x5. Negative values will reduce AOE.</param>
+        /// added to their base.</param>
+        /// <remarks>Adding '1' to a 3x3 spell will make a 5x5. Negative values will reduce AOE.</remarks>
         public AbilityAoeAdjustedRule(Dictionary<AbilityKey, int> adjustments)
         {
             _adjustments = adjustments;

--- a/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
@@ -29,15 +29,15 @@
 
         protected override void OnPreGameCreated(GameContext gameContext)
         {
-            _originals = ReplaceAbility(_adjustments);
+            _originals = ReplaceAbilities(_adjustments);
         }
 
         protected override void OnDeactivate(GameContext gameContext)
         {
-            ReplaceAbility(_originals);
+            ReplaceAbilities(_originals);
         }
 
-        private static Dictionary<AbilityKey, int> ReplaceAbility(Dictionary<AbilityKey, int> replacements)
+        private static Dictionary<AbilityKey, int> ReplaceAbilities(Dictionary<AbilityKey, int> replacements)
         {
             var originals = new Dictionary<AbilityKey, int>();
 

--- a/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
@@ -49,7 +49,7 @@
                     EssentialsMod.Logger.Warning($"Provided AbilityKey [{replacement.Key}] does not have a corresponding ability. Skipping that ability.");
                 }
 
-                originals[replacement.Key] = ability.areaOfEffectRange;
+                originals[replacement.Key] = -replacement.Value * 2;
                 var aoe = Traverse.Create(ability).Field<AreaOfEffect>("areaOfEffect").Value;
                 Traverse.Create(aoe).Field<int>("range").Value += replacement.Value; // Adjust the AOE outline when casting.
                 ability.areaOfEffectRange += replacement.Value; // Adjust value displayed on the card.

--- a/HouseRules_Essentials/Rules/AbilityActionCostAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityActionCostAdjustedRule.cs
@@ -1,5 +1,6 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
+    using System;
     using System.Collections.Generic;
     using Boardgame;
     using Boardgame.BoardEntities.Abilities;
@@ -43,7 +44,7 @@
             {
                 if (!AbilityFactory.TryGetAbility(replacement.Key, out var ability))
                 {
-                    EssentialsMod.Logger.Warning($"Provided AbilityKey [{replacement.Key}] does not have a corresponding ability. Skipping that ability.");
+                    throw new InvalidOperationException($"AbilityKey [{replacement.Key}] does not have a corresponding ability.");
                 }
 
                 originals[replacement.Key] = ability.costActionPoint;

--- a/HouseRules_Essentials/Rules/AbilityActionCostAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityActionCostAdjustedRule.cs
@@ -25,7 +25,7 @@
 
         public Dictionary<AbilityKey, bool> GetConfigObject() => _adjustments;
 
-        protected override void OnPostGameCreated(GameContext gameContext)
+        protected override void OnPreGameCreated(GameContext gameContext)
         {
             _originals = ReplaceAbilities(_adjustments);
         }

--- a/HouseRules_Essentials/Rules/AbilityActionCostAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityActionCostAdjustedRule.cs
@@ -1,53 +1,56 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
     using System.Collections.Generic;
-    using System.Linq;
     using Boardgame;
     using Boardgame.BoardEntities.Abilities;
+    using DataKeys;
     using HouseRules.Types;
-    using UnityEngine;
 
-    public sealed class AbilityActionCostAdjustedRule : Rule, IConfigWritable<Dictionary<string, bool>>, IMultiplayerSafe
+    public sealed class AbilityActionCostAdjustedRule : Rule, IConfigWritable<Dictionary<AbilityKey, bool>>, IMultiplayerSafe
     {
         public override string Description => "Ability AP costs are adjusted";
 
-        private readonly Dictionary<string, bool> _adjustments;
-        private Dictionary<string, bool> _originals;
+        private readonly Dictionary<AbilityKey, bool> _adjustments;
+        private Dictionary<AbilityKey, bool> _originals;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AbilityActionCostAdjustedRule"/> class.
         /// </summary>
-        /// <param name="adjustments">Key-value pairs of abilitykey and bool that controls
-        /// the costActionPoint setting.</param>
-        public AbilityActionCostAdjustedRule(Dictionary<string, bool> adjustments)
+        /// <param name="adjustments">Key-value pairs of abilityKey and whether the ability costs any actions points.</param>
+        public AbilityActionCostAdjustedRule(Dictionary<AbilityKey, bool> adjustments)
         {
             _adjustments = adjustments;
+            _originals = new Dictionary<AbilityKey, bool>();
         }
 
-        public Dictionary<string, bool> GetConfigObject() => _adjustments;
+        public Dictionary<AbilityKey, bool> GetConfigObject() => _adjustments;
 
         protected override void OnPostGameCreated(GameContext gameContext)
         {
-            _originals = UpdateActionPoints(_adjustments);
+            _originals = ReplaceAbilities(_adjustments);
         }
 
         protected override void OnDeactivate(GameContext gameContext)
         {
-            UpdateActionPoints(_originals);
+            ReplaceAbilities(_originals);
         }
 
-        private static Dictionary<string, bool> UpdateActionPoints(Dictionary<string, bool> adjustments)
+        private static Dictionary<AbilityKey, bool> ReplaceAbilities(Dictionary<AbilityKey, bool> replacements)
         {
-            var abilities = Resources.FindObjectsOfTypeAll<Ability>();
-            var previousValues = new Dictionary<string, bool>();
-            foreach (var item in adjustments)
+            var originals = new Dictionary<AbilityKey, bool>();
+
+            foreach (var replacement in replacements)
             {
-                var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
-                previousValues.Add(item.Key, ability.costActionPoint);
-                ability.costActionPoint = item.Value;
+                if (!AbilityFactory.TryGetAbility(replacement.Key, out var ability))
+                {
+                    EssentialsMod.Logger.Warning($"Provided AbilityKey [{replacement.Key}] does not have a corresponding ability. Skipping that ability.");
+                }
+
+                originals[replacement.Key] = ability.costActionPoint;
+                ability.costActionPoint = replacement.Value;
             }
 
-            return previousValues;
+            return originals;
         }
     }
 }

--- a/HouseRules_Essentials/Rules/AbilityBackstabAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityBackstabAdjustedRule.cs
@@ -20,6 +20,7 @@
         public AbilityBackstabAdjustedRule(Dictionary<AbilityKey, bool> adjustments)
         {
             _adjustments = adjustments;
+            _originals = new Dictionary<AbilityKey, bool>();
         }
 
         public Dictionary<AbilityKey, bool> GetConfigObject() => _adjustments;

--- a/HouseRules_Essentials/Rules/AbilityBackstabAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityBackstabAdjustedRule.cs
@@ -1,5 +1,6 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
+    using System;
     using System.Collections.Generic;
     using Boardgame;
     using Boardgame.BoardEntities.Abilities;
@@ -43,7 +44,7 @@
             {
                 if (!AbilityFactory.TryGetAbility(replacement.Key, out var ability))
                 {
-                    EssentialsMod.Logger.Warning($"Provided AbilityKey [{replacement.Key}] does not have a corresponding ability. Skipping that ability.");
+                    throw new InvalidOperationException($"AbilityKey [{replacement.Key}] does not have a corresponding ability.");
                 }
 
                 originals[replacement.Key] = ability.enableBackstabBonus;

--- a/HouseRules_Essentials/Rules/AbilityBackstabAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityBackstabAdjustedRule.cs
@@ -1,53 +1,55 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
     using System.Collections.Generic;
-    using System.Linq;
     using Boardgame;
     using Boardgame.BoardEntities.Abilities;
+    using DataKeys;
     using HouseRules.Types;
-    using UnityEngine;
 
-    public sealed class AbilityBackstabAdjustedRule : Rule, IConfigWritable<Dictionary<string, bool>>, IMultiplayerSafe
+    public sealed class AbilityBackstabAdjustedRule : Rule, IConfigWritable<Dictionary<AbilityKey, bool>>, IMultiplayerSafe
     {
         public override string Description => "Ability backstab enablement is adjusted";
 
-        private readonly Dictionary<string, bool> _adjustments;
-        private Dictionary<string, bool> _originals;
+        private readonly Dictionary<AbilityKey, bool> _adjustments;
+        private Dictionary<AbilityKey, bool> _originals;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AbilityBackstabAdjustedRule"/> class.
         /// </summary>
-        /// <param name="adjustments">Key-value pairs of abilitykey and bool for whether backstab bonus
-        /// is enabled or not.</param>
-        public AbilityBackstabAdjustedRule(Dictionary<string, bool> adjustments)
+        /// <param name="adjustments">Key-value pairs of abilityKey and whether backstab bonus is enabled or not.</param>
+        public AbilityBackstabAdjustedRule(Dictionary<AbilityKey, bool> adjustments)
         {
             _adjustments = adjustments;
         }
 
-        public Dictionary<string, bool> GetConfigObject() => _adjustments;
+        public Dictionary<AbilityKey, bool> GetConfigObject() => _adjustments;
 
-        protected override void OnPostGameCreated(GameContext gameContext)
+        protected override void OnPreGameCreated(GameContext gameContext)
         {
-            _originals = UpdateAbilities(_adjustments);
+            _originals = ReplaceAbilities(_adjustments);
         }
 
         protected override void OnDeactivate(GameContext gameContext)
         {
-            UpdateAbilities(_originals);
+            ReplaceAbilities(_originals);
         }
 
-        private static Dictionary<string, bool> UpdateAbilities(Dictionary<string, bool> adjustments)
+        private static Dictionary<AbilityKey, bool> ReplaceAbilities(Dictionary<AbilityKey, bool> replacements)
         {
-            var abilities = Resources.FindObjectsOfTypeAll<Ability>();
-            var previousValues = new Dictionary<string, bool>();
-            foreach (var item in adjustments)
+            var originals = new Dictionary<AbilityKey, bool>();
+
+            foreach (var replacement in replacements)
             {
-                var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
-                previousValues.Add(item.Key, ability.enableBackstabBonus);
-                ability.enableBackstabBonus = item.Value;
+                if (!AbilityFactory.TryGetAbility(replacement.Key, out var ability))
+                {
+                    EssentialsMod.Logger.Warning($"Provided AbilityKey [{replacement.Key}] does not have a corresponding ability. Skipping that ability.");
+                }
+
+                originals[replacement.Key] = ability.enableBackstabBonus;
+                ability.enableBackstabBonus = replacement.Value;
             }
 
-            return previousValues;
+            return originals;
         }
     }
 }

--- a/HouseRules_Essentials/Rules/AbilityDamageAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityDamageAdjustedRule.cs
@@ -1,5 +1,6 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
+    using System;
     using System.Collections.Generic;
     using Boardgame;
     using Boardgame.BoardEntities.Abilities;
@@ -44,7 +45,7 @@
             {
                 if (!AbilityFactory.TryGetAbility(replacement.Key, out var ability))
                 {
-                    EssentialsMod.Logger.Warning($"Provided AbilityKey [{replacement.Key}] does not have a corresponding ability. Skipping that ability.");
+                    throw new InvalidOperationException($"AbilityKey [{replacement.Key}] does not have a corresponding ability.");
                 }
 
                 originals[replacement.Key] = ability.abilityDamage.targetDamage;

--- a/HouseRules_Essentials/Rules/AbilityRandomPieceListRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityRandomPieceListRule.cs
@@ -1,5 +1,6 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Boardgame;
@@ -45,7 +46,7 @@
             {
                 if (!AbilityFactory.TryGetAbility(replacement.Key, out var ability))
                 {
-                    EssentialsMod.Logger.Warning($"Provided AbilityKey [{replacement.Key}] does not have a corresponding ability. Skipping that ability.");
+                    throw new InvalidOperationException($"AbilityKey [{replacement.Key}] does not have a corresponding ability.");
                 }
 
                 originals[replacement.Key] = ability.randomPieceList.ToList();

--- a/HouseRules_Essentials/Rules/AbilityRandomPieceListRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityRandomPieceListRule.cs
@@ -5,51 +5,54 @@
     using Boardgame;
     using Boardgame.BoardEntities.Abilities;
     using DataKeys;
-    using HarmonyLib;
     using HouseRules.Types;
-    using UnityEngine;
 
-    public sealed class AbilityRandomPieceListRule : Rule, IConfigWritable<Dictionary<string, BoardPieceId[]>>
+    public sealed class AbilityRandomPieceListRule : Rule, IConfigWritable<Dictionary<AbilityKey, List<BoardPieceId>>>
     {
         public override string Description => "Ability randomPieceLists are replaced";
 
-        private readonly Dictionary<string, BoardPieceId[]> _adjustments;
-        private readonly Dictionary<string, BoardPieceId[]> _originals;
+        private readonly Dictionary<AbilityKey, List<BoardPieceId>> _adjustments;
+        private Dictionary<AbilityKey, List<BoardPieceId>> _originals;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AbilityRandomPieceListRule"/> class.
         /// </summary>
-        /// <param name="adjustments">Dict of ability name string and list of BoardPieceID[]s
-        /// Replaces the list of pieces that certain abilities will spawn (e.g. BeastWhisperer, SpawnCultists etc).</param>
-        public AbilityRandomPieceListRule(Dictionary<string, BoardPieceId[]> adjustments)
+        /// <param name="adjustments">Dict of ability name string and list of BoardPieceIDs.</param>
+        /// <remarks>Replaces the list of pieces that certain abilities will spawn (e.g. BeastWhisperer, SpawnCultists etc).</remarks>
+        public AbilityRandomPieceListRule(Dictionary<AbilityKey, List<BoardPieceId>> adjustments)
         {
             _adjustments = adjustments;
-            _originals = new Dictionary<string, BoardPieceId[]>();
+            _originals = new Dictionary<AbilityKey, List<BoardPieceId>>();
         }
 
-        public Dictionary<string, BoardPieceId[]> GetConfigObject() => _adjustments;
+        public Dictionary<AbilityKey, List<BoardPieceId>> GetConfigObject() => _adjustments;
 
-        protected override void OnPostGameCreated(GameContext gameContext)
+        protected override void OnPreGameCreated(GameContext gameContext)
         {
-            var abilities = Resources.FindObjectsOfTypeAll<Ability>();
-            foreach (var item in _adjustments)
-            {
-                var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
-                _originals[item.Key] = ability.randomPieceList;
-                var rpl = Traverse.Create(ability).Field<BoardPieceId[]>("randomPieceList");
-                rpl.Value = item.Value;
-            }
+            _originals = ReplaceAbilities(_adjustments);
         }
 
         protected override void OnDeactivate(GameContext gameContext)
         {
-            var abilities = Resources.FindObjectsOfTypeAll<Ability>();
-            foreach (var item in _originals)
+            ReplaceAbilities(_originals);
+        }
+
+        private static Dictionary<AbilityKey, List<BoardPieceId>> ReplaceAbilities(Dictionary<AbilityKey, List<BoardPieceId>> replacements)
+        {
+            var originals = new Dictionary<AbilityKey, List<BoardPieceId>>();
+
+            foreach (var replacement in replacements)
             {
-                var ability = abilities.First(c => c.name.Equals($"{item.Key}(Clone)"));
-                var rpl = Traverse.Create(ability).Field<BoardPieceId[]>("randomPieceList");
-                rpl.Value = item.Value;
+                if (!AbilityFactory.TryGetAbility(replacement.Key, out var ability))
+                {
+                    EssentialsMod.Logger.Warning($"Provided AbilityKey [{replacement.Key}] does not have a corresponding ability. Skipping that ability.");
+                }
+
+                originals[replacement.Key] = ability.randomPieceList.ToList();
+                ability.randomPieceList = replacement.Value.ToArray();
             }
+
+            return originals;
         }
     }
 }

--- a/HouseRules_Essentials/Rules/RatNestsSpawnGoldRule.cs
+++ b/HouseRules_Essentials/Rules/RatNestsSpawnGoldRule.cs
@@ -1,11 +1,10 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
-    using System.Linq;
+    using System;
     using Boardgame;
     using Boardgame.BoardEntities.Abilities;
     using DataKeys;
     using HouseRules.Types;
-    using UnityEngine;
 
     public sealed class RatNestsSpawnGoldRule : Rule, IConfigWritable<int>
     {
@@ -21,10 +20,13 @@
 
         public int GetConfigObject() => _pileCount;
 
-        protected override void OnPostGameCreated(GameContext gameContext)
+        protected override void OnPreGameCreated(GameContext gameContext)
         {
-            var abilities = Resources.FindObjectsOfTypeAll<Ability>();
-            var ability = abilities.First(c => c.name.Equals("SpawnRat(Clone)"));
+            if (!AbilityFactory.TryGetAbility(AbilityKey.SpawnRat, out var ability))
+            {
+                throw new InvalidOperationException($"AbilityKey [{AbilityKey.SpawnRat}] does not have a corresponding ability.");
+            }
+
             ability.pieceToSpawn = BoardPieceId.GoldPile;
             _originalSpawnAmount = ability.spawnMaxAmount;
             ability.spawnMaxAmount = _pileCount;
@@ -32,8 +34,11 @@
 
         protected override void OnDeactivate(GameContext gameContext)
         {
-            var abilities = Resources.FindObjectsOfTypeAll<Ability>();
-            var ability = abilities.First(c => c.name.Equals("SpawnRat(Clone)"));
+            if (!AbilityFactory.TryGetAbility(AbilityKey.SpawnRat, out var ability))
+            {
+                throw new InvalidOperationException($"AbilityKey [{AbilityKey.SpawnRat}] does not have a corresponding ability.");
+            }
+
             ability.pieceToSpawn = BoardPieceId.Rat;
             ability.spawnMaxAmount = _originalSpawnAmount;
         }

--- a/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
@@ -74,10 +74,10 @@
                 { "FloorThreeLootChests", 12 },
             });
 
-            var aoePotions = new AbilityAoeAdjustedRule(new Dictionary<string, int>
+            var aoePotions = new AbilityAoeAdjustedRule(new Dictionary<AbilityKey, int>
             {
-                { "StrengthPotion", 1 },
-                { "SwiftnessPotion", 1 },
+                { AbilityKey.StrengthPotion, 1 },
+                { AbilityKey.SwiftnessPotion, 1 },
             });
 
             var respawnsDisabledRule = new EnemyRespawnDisabledRule(true);

--- a/docs/rulesets/3x3 Potions and Buffs.json
+++ b/docs/rulesets/3x3 Potions and Buffs.json
@@ -5,20 +5,20 @@
     {
       "Rule": "AbilityAoeAdjusted",
       "Config": {
-        "StrengthenCourage": 1,
+        "CourageShanty": 1,
         "ReplenishArmor": 1,
-        "Strength": 1,
-        "Speed": 1,
-        "Antidote": 1,
-        "Invulnerability": 1,
-        "Heal": 1,
+        "StrengthPotion": 1,
+        "SwiftnessPotion": 1,
+        "Antitoxin": 1,
+        "AdamantPotion": 1,
+        "HealingPotion": 1,
       }
     },
     {
       "Rule": "RegainAbilityIfMaxxedOutOverridden",
       "Config": {
-        "Speed": false,
-        "Strength": false
+        "SwiftnessPotion": false,
+        "StrengthPotion": false
       }
     },
   ]

--- a/docs/rulesets/Arachnophobia.json
+++ b/docs/rulesets/Arachnophobia.json
@@ -1,389 +1,222 @@
 {
-    "Name": "Arachnophobia",
-    "Description": "Money Spiders everywhere. On the walls and in my hair.",
-    "Rules": [
-        {
-            "Rule": "AbilityDamageAdjusted",
-            "Config": { "Zap": 1 }
-        },
-        {
-            "Rule": "StartCardsModified",
-            "Config": {
-                "HeroGuardian": [
-                    {
-                        "Card": "HealingPotion",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "ReplenishArmor",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "Bone",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "WhirlwindAttack",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "PiercingThrow",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "Sneak",
-                        "IsReplenishable": false
-                    }
+  "Name": "Arachnophobia",
+  "Description": "Money Spiders everywhere. On the walls and in my hair.",
+  "Rules": [
+    {
+      "Rule": "AbilityDamageAdjusted",
+      "Config": { "Zap": 1 }
+    },
+    {
+      "Rule": "StartCardsModified",
+      "Config": {
+        "HeroGuardian": [
+          { "Card": "HealingPotion", "IsReplenishable": false },
+          { "Card": "ReplenishArmor", "IsReplenishable": true },
+          { "Card": "Bone", "IsReplenishable": true },
+          { "Card": "WhirlwindAttack", "IsReplenishable": false },
+          { "Card": "PiercingThrow", "IsReplenishable": false },
+          { "Card": "Sneak", "IsReplenishable": false },
 
-                ],
-                "HeroHunter": [
-                    {
-                        "Card": "HealingPotion",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "Arrow",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "PoisonedTip",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "HailOfArrows",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "CallCompanion",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "Sneak",
-                        "IsReplenishable": false
-                    }
-                ],
-                "HeroSorcerer": [
-                    {
-                        "Card": "HealingPotion",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "Zap",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "OilLamp",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "HeavensFury",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "DetectEnemies",
-                        "IsReplenishable": false
-                    }
-                ],
-                "HeroRogue": [
-                    {
-                        "Card": "HealingPotion",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "Sneak",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "PanicPowder",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "BoobyTrap",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "PoisonBomb",
-                        "IsReplenishable": false
-                    }
-                ],
-                "HeroBard": [
-                    {
-                        "Card": "HealingPotion",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "CourageShanty",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "IceLamp",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "SongOfRecovery",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "Sneak",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "HurricaneAnthem",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "ShatteringVoice",
-                        "IsReplenishable": false
-                    }
-                ]
-            }
-        },
-        {
-            "Rule": "AbilityAoeAdjusted",
-            "Config": {
-                "StrengthenCourage": 1,
-                "ReplenishArmor": 1,
-                "Strength": 1,
-                "Speed": 1,
-                "Antidote": 1,
-                "Invulnerability": 1,
-                "Heal": 1
-            }
-        },
-        {
-            "Rule": "RegainAbilityIfMaxxedOutOverridden",
-            "Config": {
-                "Speed": false,
-                "Strength": false
-            }
-        },
-        {
-            "Rule": "PieceConfigAdjusted",
-            "Config": [
-                {
-                    "Piece": "HeroSorcerer",
-                    "Property": "StartHealth",
-                    "Value": 15
-                },
-                {
-                    "Piece": "HeroGuardian",
-                    "Property": "StartHealth",
-                    "Value": 20
-                },
-                {
-                    "Piece": "HeroHunter",
-                    "Property": "StartHealth",
-                    "Value": 15
-                },
-                {
-                    "Piece": "HeroBard",
-                    "Property": "StartHealth",
-                    "Value": 15
-                },
-                {
-                    "Piece": "HeroRogue",
-                    "Property": "StartHealth",
-                    "Value": 15
-                },
-                {
-                    "Piece": "HeroHunter",
-                    "Property": "MoveRange",
-                    "Value": 5
-                },
-                {
-                    "Piece": "HeroBard",
-                    "Property": "MoveRange",
-                    "Value": 5
-                },
-                {
-                    "Piece": "SwordOfAvalon",
-                    "Property": "StartHealth",
-                    "Value": 20
-                },
-                {
-                    "Piece": "SmiteWard",
-                    "Property": "StartHealth",
-                    "Value": 20
-                },
-                {
-                    "Piece": "SmiteWard",
-                    "Property": "ActionPoint",
-                    "Value": 2
-                },
-                {
-                    "Piece": "Verochka",
-                    "Property": "ActionPoint",
-                    "Value": 3
-                },
-                {
-                    "Piece": "Verochka",
-                    "Property": "MoveRange",
-                    "Value": 6
-                },
-                {
-                    "Piece": "Verochka",
-                    "Property": "VisionRange",
-                    "Value": 40
-                },
-                {
-                    "Piece": "Lure",
-                    "Property": "StartHealth",
-                    "Value": 30
-                },
-                {
-                    "Piece": "Spider",
-                    "Property": "StartHealth",
-                    "Value": 1
-                },
-                {
-                    "Piece": "Spider",
-                    "Property": "ActionPoint",
-                    "Value": 3
-                },
-                {
-                    "Piece": "Spider",
-                    "Property": "MoveRange",
-                    "Value": 2
-                },
-                {
-                    "Piece": "RatKing",
-                    "Property": "StartHealth",
-                    "Value": 45
-                },
-                {
-                    "Piece": "RatKing",
-                    "Property": "MoveRange",
-                    "Value": 2
-                },
-                {
-                    "Piece": "ElvenQueen",
-                    "Property": "StartHealth",
-                    "Value": 35
-                }
-            ]
-        },
-        {
-            "Rule": "AbilityActionCostAdjusted",
-            "Config": {
-                "Zap": false,
-                "StrengthenCourage": false,
-                "Stealth": false
-            }
-        },
-        {
-            "Rule": "LevelPropertiesModifiedRule",
-            "Config": {
-                "FloorOneHealingFountains": 4,
-                "FloorOneLootChests": 12,
-                "FloorOneClassCardChests": 8,
-                "FloorOneGoldMaxAmount": 1500,
-                "FloorTwoHealingFountains": 4,
-                "FloorTwoLootChests": 9,
-                "FloorTwoGoldMaxAmount": 2500,
-                "FloorThreeHealingFountains": 6,
-                "FloorThreeLootChests": 0
+        ],
+        "HeroHunter": [
+          { "Card": "HealingPotion", "IsReplenishable": false },
+          { "Card": "Arrow", "IsReplenishable": true },
+          { "Card": "PoisonedTip", "IsReplenishable": true },
+          { "Card": "HailOfArrows", "IsReplenishable": false },
+          { "Card": "CallCompanion", "IsReplenishable": false },
+          { "Card": "Sneak", "IsReplenishable": false },
+        ],
+        "HeroSorcerer": [
+          { "Card": "HealingPotion", "IsReplenishable": false },
+          { "Card": "Zap", "IsReplenishable": true },
+          { "Card": "OilLamp", "IsReplenishable": true },
+          { "Card": "HeavensFury", "IsReplenishable": false },
+          { "Card": "DetectEnemies", "IsReplenishable": false },
+        ],
+        "HeroRogue": [
+          { "Card": "HealingPotion", "IsReplenishable": false },
+          { "Card": "Sneak", "IsReplenishable": true },
+          { "Card": "PanicPowder", "IsReplenishable": true },
+          { "Card": "BoobyTrap", "IsReplenishable": false },
+          { "Card": "PoisonBomb", "IsReplenishable": false },
+        ],
+        "HeroBard": [
+          { "Card": "HealingPotion", "IsReplenishable": false },
+          { "Card": "CourageShanty", "IsReplenishable": true },
+          { "Card": "IceLamp", "IsReplenishable": true },
+          { "Card": "SongOfRecovery", "IsReplenishable": false },
+          { "Card": "Sneak", "IsReplenishable": false },
+          { "Card": "HurricaneAnthem", "IsReplenishable": false },
+          { "Card": "ShatteringVoice", "IsReplenishable": false },
+        ]
+      }
+    },
+    {
+      "Rule": "AbilityAoeAdjusted",
+      "Config": {
+        "CourageShanty": 1,
+        "ReplenishArmor": 1,
+        "StrengthPotion": 1,
+        "SwiftnessPotion": 1,
+        "Antitoxin": 1,
+        "AdamantPotion": 1,
+        "HealingPotion": 1,
+      }
+    },
+    {
+      "Rule": "RegainAbilityIfMaxxedOutOverridden",
+      "Config": {
+        "SwiftnessPotion": false,
+        "StrengthPotion": false
+      }
+    },
+    {
+      "Rule": "PieceConfigAdjusted",
+      "Config": [
+        { "Piece": "HeroSorcerer", "Property": "StartHealth", "Value": 15 },
+        { "Piece": "HeroGuardian", "Property": "StartHealth", "Value": 20 },
+        { "Piece": "HeroHunter", "Property": "StartHealth", "Value": 15 },
+        { "Piece": "HeroBard", "Property": "StartHealth", "Value": 15 },
+        { "Piece": "HeroRogue", "Property": "StartHealth", "Value": 15 },
+        { "Piece": "HeroHunter", "Property": "MoveRange", "Value": 5 },
+        { "Piece": "HeroBard", "Property": "MoveRange", "Value": 5 },
+        { "Piece": "SwordOfAvalon", "Property": "StartHealth", "Value": 20 },
+        { "Piece": "SmiteWard", "Property": "StartHealth", "Value": 20 },
+        { "Piece": "SmiteWard", "Property": "ActionPoint", "Value": 2 },
+        { "Piece": "Verochka", "Property": "ActionPoint", "Value": 3 },
+        { "Piece": "Verochka", "Property": "MoveRange", "Value": 6 },
+        { "Piece": "Verochka", "Property": "VisionRange", "Value": 40 },
+        { "Piece": "Lure", "Property": "StartHealth", "Value": 30 },
+        { "Piece": "Spider", "Property": "StartHealth", "Value": 1 },
+        { "Piece": "Spider", "Property": "ActionPoint", "Value": 3 },
+        { "Piece": "Spider", "Property": "MoveRange", "Value": 2 },
+        { "Piece": "RatKing", "Property": "StartHealth", "Value": 45 },
+        { "Piece": "RatKing", "Property": "MoveRange", "Value": 2 },
+        { "Piece": "ElvenQueen", "Property": "StartHealth", "Value": 35 },
+      ]
+    },
+    {
+      "Rule": "AbilityActionCostAdjusted",
+      "Config": {
+        "Zap": false,
+        "CourageShanty": false,
+        "Sneak": false
+      }
+    },
+    {
+      "Rule": "LevelPropertiesModifiedRule",
+      "Config": {
+        "FloorOneHealingFountains": 4,
+        "FloorOneLootChests": 12,
+        "FloorOneClassCardChests": 8,
+        "FloorOneGoldMaxAmount": 1500,
+        "FloorTwoHealingFountains": 4,
+        "FloorTwoLootChests": 9,
+        "FloorTwoGoldMaxAmount": 2500,
+        "FloorThreeHealingFountains": 6,
+        "FloorThreeLootChests": 0,
 
-            }
+      }
+    },
+    {
+      "Rule": "PieceImmunityListAdjusted",
+      "Config": {
+        "HeroSorcerer": [ "Diseased", "Frozen" ],
+        "HeroGuardian": [ "Diseased", "Frozen" ],
+        "HeroBard": [ "Diseased", "Frozen" ],
+        "HeroHunter": [ "Diseased", "Frozen" ],
+        "HeroRogue": [ "Diseased", "Frozen" ],
+        "Verochka": [ "Diseased" ],
+        "RatKing": ["Petrified"],
+        "ElvenQueen": ["Petrified"],
+      }
+    },
+    {
+      "Rule": "SpawnCategoryOverridden",
+      "Config": {
+        "Spider": [ 200, 50, 1 ],
+        "SpiderEgg": [ 20, 10, 1 ] ,
+        "GiantSpider": [ 30, 10, 1 ],
+        "RatKing": [ 1, 1, 1 ],
+        "ElvenQueen": [ 1, 1, 2 ],
+      }
+    },
+    {
+      "Rule": "PieceAbilityListOverridden",
+      "Config": {
+        "Spider": [ "SpiderWebshot", "AcidSpit", "EnemyStealCard", "EnemyStealGold" ],
+        "ElvenQueen": ["EnemyKnockbackMelee", "EnemyFireball", "EarthShatter"],
+        "RatKing": ["DigRatsNest", "DiseasedBite", "VerminFrenzy"]
+     }
+    },
+    {
+      "Rule": "PieceBehavioursListOverridden",
+      "Config": {
+        "Spider": [ "AttackAndRetreat", "Patrol", "FleeToFOW", "ChargeMove" ],
+      }
+    },
+    {
+      "Rule": "PiecePieceTypeListOverridden",
+      "Config": {
+        "Spider": [ "Enemy", "Thief", "Canine" ],
+      }
+    },
+    {
+      "Rule": "CardClassRestrictionOverridden",
+      "Config": {
+        "BeastWhisperer": "SporeFungus",
+      }
+    },
+    {
+      "Rule": "EnemyRespawnDisabledRule",
+      "Config": true
+    },
+    {
+      "Rule": "StatusEffectConfig",
+      "Config": [
+        {
+          "effectStateType": "HealingSong",
+          "durationTurns": 5,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "healPerTurn": 3,
+          "clearOnNewLevel": false,
+          "damageTags": null
+        },       
+        {
+          "effectStateType": "Courageous",
+          "durationTurns": 2,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "clearOnNewLevel": false,
+          "damageTags": null
         },
         {
-            "Rule": "PieceImmunityListAdjusted",
-            "Config": {
-                "HeroSorcerer": [ "Diseased", "Frozen" ],
-                "HeroGuardian": [ "Diseased", "Frozen" ],
-                "HeroBard": [ "Diseased", "Frozen" ],
-                "HeroHunter": [ "Diseased", "Frozen" ],
-                "HeroRogue": [ "Diseased", "Frozen" ],
-                "Verochka": [ "Diseased" ],
-                "RatKing": [ "Petrified" ],
-                "ElvenQueen": [ "Petrified" ]
-            }
+          "effectStateType": "Heroic",
+          "durationTurns": 4,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "clearOnNewLevel": false,
+          "damageTags": null
         },
         {
-            "Rule": "SpawnCategoryOverridden",
-            "Config": {
-                "Spider": [ 200, 50, 1 ],
-                "SpiderEgg": [ 20, 10, 1 ],
-                "GiantSpider": [ 30, 10, 1 ],
-                "RatKing": [ 1, 1, 1 ],
-                "ElvenQueen": [ 1, 1, 2 ]
-            }
+          "effectStateType": "Fearless",
+          "durationTurns": 6,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "clearOnNewLevel": false,
+          "damageTags": null
         },
         {
-            "Rule": "PieceAbilityListOverridden",
-            "Config": {
-                "Spider": [ "SpiderWebshot", "AcidSpit", "EnemyStealCard", "EnemyStealGold" ],
-                "ElvenQueen": [ "EnemyKnockbackMelee", "EnemyFireball", "EarthShatter" ],
-                "RatKing": [ "DigRatsNest", "DiseasedBite", "VerminFrenzy" ]
-            }
+          "effectStateType": "Recovery",
+          "durationTurns": 5,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "healPerTurn": 3,
+          "clearOnNewLevel": false,
+          "damageTags": null
         },
-        {
-            "Rule": "PieceBehavioursListOverridden",
-            "Config": {
-                "Spider": [ "AttackAndRetreat", "Patrol", "FleeToFOW", "ChargeMove" ]
-            }
-        },
-        {
-            "Rule": "PiecePieceTypeListOverridden",
-            "Config": {
-                "Spider": [ "Enemy", "Thief", "Canine" ]
-            }
-        },
-        {
-            "Rule": "CardClassRestrictionOverridden",
-            "Config": {
-                "BeastWhisperer": "SporeFungus"
-            }
-        },
-        {
-            "Rule": "EnemyRespawnDisabledRule",
-            "Config": true
-        },
-        {
-            "Rule": "StatusEffectConfig",
-            "Config": [
-                {
-                    "effectStateType": "HealingSong",
-                    "durationTurns": 5,
-                    "tickWhen": "EndTurn",
-                    "stacks": false,
-                    "healPerTurn": 3,
-                    "clearOnNewLevel": false,
-                    "damageTags": null
-                },
-                {
-                    "effectStateType": "Courageous",
-                    "durationTurns": 2,
-                    "tickWhen": "EndTurn",
-                    "stacks": false,
-                    "clearOnNewLevel": false,
-                    "damageTags": null
-                },
-                {
-                    "effectStateType": "Heroic",
-                    "durationTurns": 4,
-                    "tickWhen": "EndTurn",
-                    "stacks": false,
-                    "clearOnNewLevel": false,
-                    "damageTags": null
-                },
-                {
-                    "effectStateType": "Fearless",
-                    "durationTurns": 6,
-                    "tickWhen": "EndTurn",
-                    "stacks": false,
-                    "clearOnNewLevel": false,
-                    "damageTags": null
-                },
-                {
-                    "effectStateType": "Recovery",
-                    "durationTurns": 5,
-                    "tickWhen": "EndTurn",
-                    "stacks": false,
-                    "healPerTurn": 3,
-                    "clearOnNewLevel": false,
-                    "damageTags": null
-                }
-            ]
-        }
-    ]
+      ]
+    }
+  ]
 }

--- a/docs/rulesets/LuckyDip.json
+++ b/docs/rulesets/LuckyDip.json
@@ -3,322 +3,181 @@
     "Description": "Life is like a box of chocolates + AOE changes, so stay close to your allies",
     "Rules": [
         {
-            "Rule": "AbilityDamageAdjusted",
-            "Config": { "Zap": 1 }
+          "Rule": "AbilityDamageAdjusted",
+          "Config": { "Zap": 1 }
         },
         {
-            "Rule": "StartCardsModified",
-            "Config": {
-                "HeroGuardian": [
-                    {
-                        "Card": "HealingPotion",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "ReplenishArmor",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "Bone",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "DropChest",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "DropChest",
-                        "IsReplenishable": false
-                    }
-                ],
-                "HeroHunter": [
-                    {
-                        "Card": "HealingPotion",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "Arrow",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "PoisonedTip",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "Sneak",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "DropChest",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "DropChest",
-                        "IsReplenishable": false
-                    }
-                ],
-                "HeroSorcerer": [
-                    {
-                        "Card": "HealingPotion",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "Zap",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "Torch",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "DropChest",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "DropChest",
-                        "IsReplenishable": false
-                    }
-                ],
-                "HeroRogue": [
-                    {
-                        "Card": "HealingPotion",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "Sneak",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "PanicPowder",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "DropChest",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "DropChest",
-                        "IsReplenishable": false
-                    }
-                ],
-                "HeroBard": [
-                    {
-                        "Card": "HealingPotion",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "CourageShanty",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "WebBomb",
-                        "IsReplenishable": true
-                    },
-                    {
-                        "Card": "DropChest",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "DropChest",
-                        "IsReplenishable": false
-                    },
-                    {
-                        "Card": "SongOfRecovery",
-                        "IsReplenishable": false
-                    }
-                ]
-            }
-        },
-        {
-            "Rule": "AbilityAoeAdjusted",
-            "Config": {
-                "StrengthenCourage": 1,
-                "ReplenishArmor": 1,
-                "Strength": 1,
-                "Speed": 1,
-                "Antidote": 1,
-                "Invulnerability": 1,
-                "Heal": 1
-            }
-        },
-        {
-            "Rule": "PieceConfigAdjusted",
-            "Config": [
-                {
-                    "Piece": "HeroSorcerer",
-                    "Property": "StartHealth",
-                    "Value": 15
-                },
-                {
-                    "Piece": "HeroGuardian",
-                    "Property": "StartHealth",
-                    "Value": 20
-                },
-                {
-                    "Piece": "HeroHunter",
-                    "Property": "StartHealth",
-                    "Value": 15
-                },
-                {
-                    "Piece": "HeroBard",
-                    "Property": "StartHealth",
-                    "Value": 15
-                },
-                {
-                    "Piece": "HeroRogue",
-                    "Property": "StartHealth",
-                    "Value": 15
-                },
-                {
-                    "Piece": "HeroHunter",
-                    "Property": "MoveRange",
-                    "Value": 5
-                },
-                {
-                    "Piece": "HeroBard",
-                    "Property": "MoveRange",
-                    "Value": 5
-                },
-                {
-                    "Piece": "Verochka",
-                    "Property": "StartHealth",
-                    "Value": 20
-                },
-                {
-                    "Piece": "SwordOfAvalon",
-                    "Property": "StartHealth",
-                    "Value": 20
-                },
-                {
-                    "Piece": "SmiteWard",
-                    "Property": "StartHealth",
-                    "Value": 20
-                },
-                {
-                    "Piece": "SmiteWard",
-                    "Property": "ActionPoint",
-                    "Value": 2
-                },
-                {
-                    "Piece": "Verochka",
-                    "Property": "ActionPoint",
-                    "Value": 3
-                },
-                {
-                    "Piece": "Verochka",
-                    "Property": "MoveRange",
-                    "Value": 8
-                },
-                {
-                    "Piece": "Verochka",
-                    "Property": "VisionRange",
-                    "Value": 40
-                },
-                {
-                    "Piece": "Lure",
-                    "Property": "StartHealth",
-                    "Value": 30
-                }
+          "Rule": "StartCardsModified",
+          "Config": {
+            "HeroGuardian": [
+              { "Card": "HealingPotion", "IsReplenishable": false },
+              { "Card": "ReplenishArmor", "IsReplenishable": true },
+              { "Card": "Bone", "IsReplenishable": true },
+              { "Card": "DropChest", "IsReplenishable": false },
+              { "Card": "DropChest", "IsReplenishable": false }
+            ],
+            "HeroHunter": [
+              { "Card": "HealingPotion", "IsReplenishable": false },
+              { "Card": "Arrow", "IsReplenishable": true },
+              { "Card": "PoisonedTip", "IsReplenishable": true },
+              { "Card": "Sneak", "IsReplenishable": false },
+              { "Card": "DropChest", "IsReplenishable": false },
+              { "Card": "DropChest", "IsReplenishable": false }
+            ],
+            "HeroSorcerer": [
+              { "Card": "HealingPotion", "IsReplenishable": false },
+              { "Card": "Zap", "IsReplenishable": true },
+              { "Card": "Torch", "IsReplenishable": true },
+              { "Card": "DropChest", "IsReplenishable": false },
+              { "Card": "DropChest", "IsReplenishable": false }
+            ],
+            "HeroRogue": [
+              { "Card": "HealingPotion", "IsReplenishable": false },
+              { "Card": "Sneak", "IsReplenishable": true },
+              { "Card": "PanicPowder", "IsReplenishable": true },
+              { "Card": "DropChest", "IsReplenishable": false },
+              { "Card": "DropChest", "IsReplenishable": false }
+            ],
+            "HeroBard": [
+              { "Card": "HealingPotion", "IsReplenishable": false },
+              { "Card": "CourageShanty", "IsReplenishable": true },
+              { "Card": "WebBomb", "IsReplenishable": true },
+              { "Card": "DropChest", "IsReplenishable": false },          
+              { "Card": "DropChest", "IsReplenishable": false },
+              { "Card": "SongOfRecovery", "IsReplenishable": false }
             ]
+          }
         },
         {
-            "Rule": "AbilityActionCostAdjusted",
-            "Config": {
-                "Zap": false,
-                "StrengthenCourage": false,
-                "Stealth": false
-            }
+          "Rule": "AbilityAoeAdjusted",
+          "Config": {
+            "CourageShanty": 1,
+            "ReplenishArmor": 1,
+            "StrengthPotion": 1,
+            "SwiftnessPotion": 1,
+            "Antitoxin": 1,
+            "AdamantPotion": 1,
+            "HealingPotion": 1
+          }
         },
         {
-            "Rule": "CardEnergyFromAttackMultiplied",
-            "Config": 1.25
+          "Rule": "PieceConfigAdjusted",
+          "Config": [
+            { "Piece": "HeroSorcerer", "Property": "StartHealth", "Value": 15 },
+            { "Piece": "HeroGuardian", "Property": "StartHealth", "Value": 20 },
+            { "Piece": "HeroHunter", "Property": "StartHealth", "Value": 15 },
+            { "Piece": "HeroBard", "Property": "StartHealth", "Value": 15 },
+            { "Piece": "HeroRogue", "Property": "StartHealth", "Value": 15 },
+            { "Piece": "HeroHunter", "Property": "MoveRange", "Value": 5 },
+            { "Piece": "HeroBard", "Property": "MoveRange", "Value": 5 },
+            { "Piece": "Verochka", "Property": "StartHealth", "Value": 20 },
+            { "Piece": "SwordOfAvalon", "Property": "StartHealth", "Value": 20 },
+            { "Piece": "SmiteWard", "Property": "StartHealth", "Value": 20 },
+            { "Piece": "SmiteWard", "Property": "ActionPoint", "Value": 2 },
+            { "Piece": "Verochka", "Property": "ActionPoint", "Value": 3 },
+            { "Piece": "Verochka", "Property": "MoveRange", "Value": 8 },
+            { "Piece": "Verochka", "Property": "VisionRange", "Value": 40 },
+            { "Piece": "Lure", "Property": "StartHealth", "Value": 30 },
+          ]
         },
         {
-            "Rule": "CardAdditionOverridden",
-            "Config": {
-                "HeroSorcerer": [ "StrengthPotion", "SwiftnessPotion", "Bone", "Fireball", "Freeze", "BottleOfLye", "Teleportation", "HeavensFury", "RevealPath" ],
-                "HeroHunter": [ "CallCompanion", "HuntersMark", "BeastWhisperer", "RevealPath" ]
-            }
+          "Rule": "AbilityActionCostAdjusted",
+          "Config": {
+            "Zap": false,
+            "CourageShanty": false,
+            "Sneak": false
+          }
         },
         {
-            "Rule": "PieceImmunityListAdjusted",
-            "Config": {
-                "HeroSorcerer": [ "Diseased", "Stunned", "Frozen", "Tangled", "Petrified" ],
-                "HeroGuardian": [ "Diseased", "Frozen", "Tangled", "Petrified" ],
-                "HeroBard": [ "Weaken", "MarkOfAvalon" ],
-                "HeroHunter": [ "Diseased", "Frozen", "Petrified" ],
-                "HeroRogue": [ "Frozen", "Petrified" ]
-            }
+          "Rule": "CardEnergyFromAttackMultiplied",
+          "Config": 1.25
         },
         {
-            "Rule": "PetsFocusHunterMark",
-            "Config": true
+          "Rule": "CardAdditionOverridden",
+          "Config": {
+              "HeroSorcerer": [ "StrengthPotion", "SwiftnessPotion", "Bone", "Fireball", "Freeze", "BottleOfLye", "Teleportation", "HeavensFury", "RevealPath" ],
+              "HeroHunter" : [ "CallCompanion", "HuntersMark", "BeastWhisperer", "RevealPath" ],
+              }
         },
-        {
-            "Rule": "StatusEffectConfig",
-            "Config": [
-                {
-                    "effectStateType": "TorchPlayer",
-                    "durationTurns": 15,
-                    "tickWhen": "StartTurn",
-                    "stacks": true,
-                    "damagePerTurn": 0,
-                    "clearOnNewLevel": false,
-                    "damageTags": null,
-                    "healPerTurn": 0
-                },
-                {
-                    "effectStateType": "Stealthed",
-                    "durationTurns": 5,
-                    "tickWhen": "StartTurn",
-                    "stacks": false,
-                    "damagePerTurn": 0,
-                    "clearOnNewLevel": false,
-                    "damageTags": null
-                },
-                {
-                    "effectStateType": "HealingSong",
-                    "durationTurns": 5,
-                    "tickWhen": "EndTurn",
-                    "stacks": false,
-                    "healPerTurn": 3,
-                    "clearOnNewLevel": false,
-                    "damageTags": null
-                },
-                {
-                    "effectStateType": "Courageous",
-                    "durationTurns": 5,
-                    "tickWhen": "EndTurn",
-                    "stacks": false,
-                    "clearOnNewLevel": false,
-                    "damageTags": null
-                },
-                {
-                    "effectStateType": "Heroic",
-                    "durationTurns": 6,
-                    "tickWhen": "EndTurn",
-                    "stacks": false,
-                    "clearOnNewLevel": false,
-                    "damageTags": null
-                },
-                {
-                    "effectStateType": "Fearless",
-                    "durationTurns": 8,
-                    "tickWhen": "EndTurn",
-                    "stacks": false,
-                    "clearOnNewLevel": false,
-                    "damageTags": null
-                },
-                {
-                    "effectStateType": "Recovery",
-                    "durationTurns": 5,
-                    "tickWhen": "EndTurn",
-                    "stacks": false,
-                    "healPerTurn": 3,
-                    "clearOnNewLevel": false,
-                    "damageTags": null
-                }
-            ]
+      {
+        "Rule": "PieceImmunityListAdjusted",
+        "Config": {
+          "HeroSorcerer": [ "Diseased", "Stunned", "Frozen", "Tangled", "Petrified" ],
+          "HeroGuardian": [ "Diseased", "Frozen", "Tangled", "Petrified" ],
+          "HeroBard": [ "Weaken", "MarkOfAvalon" ],
+          "HeroHunter": [ "Diseased", "Frozen", "Petrified" ],
+          "HeroRogue": [ "Frozen", "Petrified" ]
         }
+      },
+      {
+      "Rule": "PetsFocusHunterMark",
+      "Config": true,
+      },
+      {
+        "Rule": "StatusEffectConfig",
+        "Config": [
+          {
+            "effectStateType": "TorchPlayer",
+            "durationTurns": 15,
+            "tickWhen": "StartTurn",
+            "stacks": true,
+            "damagePerTurn": 0,
+            "clearOnNewLevel": false,
+            "damageTags": null,
+            "healPerTurn": 0
+          },
+          {
+            "effectStateType": "Stealthed",
+            "durationTurns": 5,
+            "tickWhen": "StartTurn",
+            "stacks": false,
+            "damagePerTurn": 0,
+            "clearOnNewLevel": false,
+            "damageTags": null
+          },
+          {
+            "effectStateType": "HealingSong",
+            "durationTurns": 5,
+            "tickWhen": "EndTurn",
+            "stacks": false,
+            "healPerTurn": 3,
+            "clearOnNewLevel": false,
+            "damageTags": null
+          },       
+          {
+            "effectStateType": "Courageous",
+            "durationTurns": 5,
+            "tickWhen": "EndTurn",
+            "stacks": false,
+            "clearOnNewLevel": false,
+            "damageTags": null
+          },
+          {
+            "effectStateType": "Heroic",
+            "durationTurns": 6,
+            "tickWhen": "EndTurn",
+            "stacks": false,
+            "clearOnNewLevel": false,
+            "damageTags": null
+          },
+          {
+            "effectStateType": "Fearless",
+            "durationTurns": 8,
+            "tickWhen": "EndTurn",
+            "stacks": false,
+            "clearOnNewLevel": false,
+            "damageTags": null
+          },
+          {
+            "effectStateType": "Recovery",
+            "durationTurns": 5,
+            "tickWhen": "EndTurn",
+            "stacks": false,
+            "healPerTurn": 3,
+            "clearOnNewLevel": false,
+            "damageTags": null
+          },
+        ]
+      }
     ]
   }


### PR DESCRIPTION
**Notes:**
- Added our typical helper method to the rules to de-duplicate code.
- Moved to be called on `OnPreGameCreated`, instead of `OnPostGameCreated`, as:
  1. It now can be.
  2. Fail earlier if need to.
- Throws an error if a specified abilityKey does not map to a valid ability.