### PR TITLE
Arachnophobia - Statmodifiers got renamed in error.

### DIFF
--- a/docs/rulesets/Arachnophobia.json
+++ b/docs/rulesets/Arachnophobia.json
@@ -66,8 +66,8 @@
     {
       "Rule": "RegainAbilityIfMaxxedOutOverridden",
       "Config": {
-        "SwiftnessPotion": false,
-        "StrengthPotion": false
+        "Speed": false,
+        "Strength": false
       }
     },
     {
@@ -170,6 +170,12 @@
     {
       "Rule": "EnemyRespawnDisabledRule",
       "Config": true
+    },
+    {
+      "Rule": "PieceUseWhenKilledOverridden",
+      "Config": {
+        "Spider": [ "HealingPotion" ],
+      }
     },
     {
       "Rule": "StatusEffectConfig",


### PR DESCRIPTION
These got changed with some global search/replace. Unfortunately the StatModifiers don't share the same names as the corresponding AbilityKey anymore.