### PR TITLE
Perform a lookup against an AbilityKey to find a corresponding StatModifier to modify.

### DIFF
--- a/HouseRules_Essentials/Rules/RegainAbilityIfMaxxedOutOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/RegainAbilityIfMaxxedOutOverriddenRule.cs
@@ -28,7 +28,7 @@
 
         public Dictionary<AbilityKey, bool> GetConfigObject() => _adjustments;
 
-        protected override void OnPostGameCreated(GameContext gameContext)
+        protected override void OnPreGameCreated(GameContext gameContext)
         {
             _originals = ReplaceStatModifiers(_adjustments);
         }

--- a/HouseRules_Essentials/Rules/StatModifiersOverridenRule.cs
+++ b/HouseRules_Essentials/Rules/StatModifiersOverridenRule.cs
@@ -28,7 +28,7 @@
 
         public Dictionary<AbilityKey, int> GetConfigObject() => _adjustments;
 
-        protected override void OnPostGameCreated(GameContext gameContext)
+        protected override void OnPreGameCreated(GameContext gameContext)
         {
             _originals = ReplaceStatModifiers(_adjustments);
         }

--- a/HouseRules_Essentials/Rules/StatModifiersOverridenRule.cs
+++ b/HouseRules_Essentials/Rules/StatModifiersOverridenRule.cs
@@ -1,31 +1,32 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
+    using System;
     using System.Collections.Generic;
-    using System.Linq;
     using Boardgame;
+    using Boardgame.BoardEntities.Abilities;
+    using DataKeys;
     using HarmonyLib;
     using HouseRules.Types;
-    using UnityEngine;
 
-    public sealed class StatModifiersOverridenRule : Rule, IConfigWritable<Dictionary<string, int>>, IMultiplayerSafe
+    public sealed class StatModifiersOverridenRule : Rule, IConfigWritable<Dictionary<AbilityKey, int>>, IMultiplayerSafe
     {
         public override string Description => "StatModifiersOverridenRule are overridden";
 
-        private readonly Dictionary<string, int> _adjustments;
-        private Dictionary<string, int> _originals;
+        private readonly Dictionary<AbilityKey, int> _adjustments;
+        private Dictionary<AbilityKey, int> _originals;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StatModifiersOverridenRule"/> class.
         /// </summary>
         /// <param name="adjustments">Key-value pairs mapping the name of a StatModifier and the new additiveBonus setting.
         /// Overwrites existing settings. Some StatModifiers require negative values.</param>
-        public StatModifiersOverridenRule(Dictionary<string, int> adjustments)
+        public StatModifiersOverridenRule(Dictionary<AbilityKey, int> adjustments)
         {
             _adjustments = adjustments;
-            _originals = new Dictionary<string, int>();
+            _originals = new Dictionary<AbilityKey, int>();
         }
 
-        public Dictionary<string, int> GetConfigObject() => _adjustments;
+        public Dictionary<AbilityKey, int> GetConfigObject() => _adjustments;
 
         protected override void OnPostGameCreated(GameContext gameContext)
         {
@@ -37,15 +38,23 @@
             ReplaceStatModifiers(_originals);
         }
 
-        private static Dictionary<string, int> ReplaceStatModifiers(Dictionary<string, int> replacements)
+        private static Dictionary<AbilityKey, int> ReplaceStatModifiers(Dictionary<AbilityKey, int> replacements)
         {
-            var originals = new Dictionary<string, int>();
+            var originals = new Dictionary<AbilityKey, int>();
 
             var statModifierType = AccessTools.TypeByName("Boardgame.GameplayEffects.StatModifier");
-            var statModifiers = Resources.FindObjectsOfTypeAll(statModifierType);
             foreach (var replacement in replacements)
             {
-                var statModifier = statModifiers.First(c => c.name.Equals($"{replacement.Key}(Clone)"));
+                if (!AbilityFactory.TryGetAbility(replacement.Key, out var ability))
+                {
+                    throw new InvalidOperationException($"AbilityKey [{replacement.Key}] does not have a corresponding ability.");
+                }
+
+                if (!ability.TryGetComponent(statModifierType, out var statModifier))
+                {
+                    throw new InvalidOperationException($"AbilityKey [{replacement.Key}] does not have a corresponding StatModifier.");
+                }
+
                 originals[replacement.Key] = Traverse.Create(statModifier).Field<int>("additiveBonus").Value;
                 Traverse.Create(statModifier).Field<int>("additiveBonus").Value = replacement.Value;
             }

--- a/docs/rulesets/Arachnophobia.json
+++ b/docs/rulesets/Arachnophobia.json
@@ -16,7 +16,6 @@
           { "Card": "WhirlwindAttack", "IsReplenishable": false },
           { "Card": "PiercingThrow", "IsReplenishable": false },
           { "Card": "Sneak", "IsReplenishable": false },
-
         ],
         "HeroHunter": [
           { "Card": "HealingPotion", "IsReplenishable": false },
@@ -66,8 +65,8 @@
     {
       "Rule": "RegainAbilityIfMaxxedOutOverridden",
       "Config": {
-        "Speed": false,
-        "Strength": false
+        "SwiftnessPotion": false,
+        "StrengthPotion": false
       }
     },
     {
@@ -147,7 +146,7 @@
         "Spider": [ "SpiderWebshot", "AcidSpit", "EnemyStealCard", "EnemyStealGold" ],
         "ElvenQueen": ["EnemyKnockbackMelee", "EnemyFireball", "EarthShatter"],
         "RatKing": ["DigRatsNest", "DiseasedBite", "VerminFrenzy"]
-     }
+      }
     },
     {
       "Rule": "PieceBehavioursListOverridden",

--- a/docs/rulesets/Arachnophobia.json
+++ b/docs/rulesets/Arachnophobia.json
@@ -188,7 +188,7 @@
           "healPerTurn": 3,
           "clearOnNewLevel": false,
           "damageTags": null
-        },       
+        },
         {
           "effectStateType": "Courageous",
           "durationTurns": 2,


### PR DESCRIPTION
In the same vein as #248, this modifies the two rules that make changes to StatModifiers.  Instead of searching across all Unity resources for a StatModifier in memory, we can perform a lookup to find the loaded StatModifier corresponding to a particular ability.

**Findings:**
- Changing `HuntersMark` does not have the intended effect.  After looking through the code, it appears as it the `AdditiveValue` for HuntersMark is not directly used in damage calculation.

**Testing:**

- Guardian's strength/speed will increase by 3 after using her potions.
- Second strength/speed potions will not be returned to her.
- ReplenishArmor _reduces_ her armor.
- SongOfResilience on herself will armor 10 instead of 5.
- ReplenishBarkArmor (skipped straight to the boss fight) no longer has an effect.

```
{
  "Name": "Testing",
  "Description": "Testing",
  "Rules": [
    {
      "Rule": "StatModifiersOverriden",
      "Config": {
        "SwiftnessPotion": 3,
        "StrengthPotion": 3,
        "ReplenishArmor": -2,
        "HuntersMark": -10,
        "SongOfResilience": 10,
        "ReplenishBarkArmor": 0
      }
    },
    {
      "Rule": "RegainAbilityIfMaxxedOutOverridden",
      "Config": {
        "SwiftnessPotion": false,
        "StrengthPotion": false
      }
    },
    {
      "Rule": "StartCardsModified",
      "Config": {
        "HeroGuardian": [
          {
            "Card": "StrengthPotion",
            "IsReplenishable": false
          },
          {
            "Card": "StrengthPotion",
            "IsReplenishable": false
          },
          {
            "Card": "SwiftnessPotion",
            "IsReplenishable": false
          },
          {
            "Card": "SwiftnessPotion",
            "IsReplenishable": false
          },
          {
            "Card": "HuntersMark",
            "IsReplenishable": false
          },
          {
            "Card": "ReplenishArmor",
            "IsReplenishable": false
          },
          {
            "Card": "SongOfResilience",
            "IsReplenishable": false
          }
        ]
      }
    }
  ]
}
```