### PR TITLE
Modify ExampleRulesetExporter to export all registered rules.

### DIFF
--- a/HouseRules_Configuration/ConfigManager.cs
+++ b/HouseRules_Configuration/ConfigManager.cs
@@ -12,7 +12,7 @@
 
     public class ConfigManager
     {
-        private static readonly string RulesetDirectory = Path.Combine(MelonUtils.UserDataDirectory, "HouseRules");
+        internal static readonly string RulesetDirectory = Path.Combine(MelonUtils.UserDataDirectory, "HouseRules");
 
         private readonly MelonPreferences_Category _configCategory;
         private readonly MelonPreferences_Entry<string> _defaultRulesetEntry;
@@ -63,11 +63,22 @@
         internal List<string> RulesetFiles => Directory.EnumerateFiles(RulesetDirectory, "*.json").ToList();
 
         /// <summary>
-        /// Exports the specified ruleset by writing it to a file.
+        /// Exports the specified ruleset by writing it to a file in the default ruleset directory.
         /// </summary>
         /// <param name="ruleset">The ruleset to export.</param>
         /// <returns>The path of the file that the ruleset was written to.</returns>
         internal string ExportRuleset(Ruleset ruleset)
+        {
+            return ExportRuleset(ruleset, RulesetDirectory);
+        }
+
+        /// <summary>
+        /// Exports the specified ruleset by writing it to a file in the specified directory.
+        /// </summary>
+        /// <param name="ruleset">The ruleset to export.</param>
+        /// <param name="directory">The path of the directory to export to.</param>
+        /// <returns>The path of the file that the ruleset was written to.</returns>
+        internal string ExportRuleset(Ruleset ruleset, string directory)
         {
             if (string.IsNullOrEmpty(ruleset.Name))
             {
@@ -102,7 +113,7 @@
                 Rules = ruleEntries,
             };
             var serializedRuleset = JsonConvert.SerializeObject(rulesetConfig);
-            var rulesetFilePath = Path.Combine(RulesetDirectory, $"{ruleset.Name}.json");
+            var rulesetFilePath = Path.Combine(directory, $"{ruleset.Name}.json");
             File.WriteAllText(rulesetFilePath, serializedRuleset);
 
             ConfigurationMod.Logger.Msg($"Successfully exported ruleset to: {rulesetFilePath}");

--- a/HouseRules_Configuration/ConfigManager.cs
+++ b/HouseRules_Configuration/ConfigManager.cs
@@ -113,7 +113,8 @@
                 Rules = ruleEntries,
             };
             var serializedRuleset = JsonConvert.SerializeObject(rulesetConfig);
-            var rulesetFilePath = Path.Combine(directory, $"{ruleset.Name}.json");
+            var rulesetFilename = SanitizeRulesetFilename(ruleset.Name);
+            var rulesetFilePath = Path.Combine(directory, $"{rulesetFilename}.json");
             File.WriteAllText(rulesetFilePath, serializedRuleset);
 
             ConfigurationMod.Logger.Msg($"Successfully exported ruleset to: {rulesetFilePath}");
@@ -228,6 +229,12 @@
             return ruleName.EndsWith("Rule", StringComparison.OrdinalIgnoreCase)
                 ? ruleName.Substring(0, ruleName.Length - 4)
                 : ruleName;
+        }
+
+        internal static string SanitizeRulesetFilename(string rulesetName)
+        {
+            var invalids = Path.GetInvalidFileNameChars();
+            return string.Join(string.Empty, rulesetName.Split(invalids, StringSplitOptions.RemoveEmptyEntries)).TrimEnd('.');
         }
 
         /// <summary>

--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -21,7 +21,7 @@
 
         public override void OnApplicationLateStart()
         {
-            ExampleRulesetExporter.ExportExampleRulesetIfNeeded();
+            ExampleRulesetExporter.ExportExampleRulesetsIfNeeded();
 
             var loadRulesetsFromConfig = ConfigManager.GetLoadRulesetsFromConfig();
             if (loadRulesetsFromConfig)

--- a/HouseRules_Configuration/ExampleRulesetExporter.cs
+++ b/HouseRules_Configuration/ExampleRulesetExporter.cs
@@ -15,11 +15,13 @@
 
         private static void ExportRegisteredRuleset()
         {
+            Directory.CreateDirectory(ExampleRulesetDirectory);
+
             foreach (var ruleset in HR.Rulebook.Rulesets)
             {
-                var clonedNamed = $"(Custom) {ruleset.Name}";
-                var rulesetCopy = Ruleset.NewInstance(clonedNamed, ruleset.Description, ruleset.Rules);
-                ConfigurationMod.ConfigManager.ExportRuleset(rulesetCopy);
+                var newName = $"(Custom) {ruleset.Name}";
+                var rulesetCopy = Ruleset.NewInstance(newName, ruleset.Description, ruleset.Rules);
+                ConfigurationMod.ConfigManager.ExportRuleset(rulesetCopy, ExampleRulesetDirectory);
             }
         }
     }

--- a/HouseRules_Configuration/ExampleRulesetExporter.cs
+++ b/HouseRules_Configuration/ExampleRulesetExporter.cs
@@ -1,113 +1,26 @@
-﻿// TODO(orendain): Remove when writing this example ruleset is no longer necessary.
-
-namespace HouseRules.Configuration
+﻿namespace HouseRules.Configuration
 {
-    using System.Collections.Generic;
-    using DataKeys;
-    using global::Types;
-    using HouseRules.Essentials.Rules;
+    using System.IO;
     using HouseRules.Types;
 
     internal static class ExampleRulesetExporter
     {
-        internal static void ExportExampleRulesetIfNeeded()
+        private static readonly string ExampleRulesetDirectory = Path.Combine(ConfigManager.RulesetDirectory, "ExampleRulesets");
+
+        internal static void ExportExampleRulesetsIfNeeded()
         {
-            // Uncomment to export example ruleset.
-            // ExportExampleRuleset();
+            // Uncomment to export registered rulesets.
+            // ExportRegisteredRuleset();
         }
 
-        private static void ExportExampleRuleset()
+        private static void ExportRegisteredRuleset()
         {
-            var aaca = new AbilityActionCostAdjustedRule(new Dictionary<AbilityKey, bool>
+            foreach (var ruleset in HR.Rulebook.Rulesets)
             {
-                { AbilityKey.Zap, false }, // 0 casting cost for zap
-                { AbilityKey.CourageShanty, false }, // 0 casting cost for Courage
-            });
-            var aaa = new AbilityAoeAdjustedRule(new Dictionary<AbilityKey, int>
-            {
-                { AbilityKey.Fireball, 1 }, // 5x5 fireball
-                { AbilityKey.Zap, 1 }, // Just testing
-                { AbilityKey.CourageShanty, 1 }, // Everyone should hear the bard sing the courage song
-                { AbilityKey.StrengthPotion, 1 }, // Everyone nearby should share the strength potion
-                { AbilityKey.SwiftnessPotion, 1 }, // Everyone nearby should share the speed potion
-            });
-            var ada = new AbilityDamageAdjustedRule(new Dictionary<AbilityKey, int> { { AbilityKey.Zap, 1 } });
-            var cefam1 = new CardEnergyFromAttackMultipliedRule(2f);
-            var cefam2 = new CardEnergyFromAttackMultipliedRule(2f);
-            var cefam3 = new CardEnergyFromAttackMultipliedRule(2f);
-            var cefam4 = new CardEnergyFromAttackMultipliedRule(2f);
-            var cefrm = new CardEnergyFromRecyclingMultipliedRule(5f);
-            var csvm = new CardSellValueMultipliedRule(2f);
-            var eas = new EnemyAttackScaledRule(0.5f);
-            var edod = new EnemyDoorOpeningDisabledRule(true);
-            var ehs = new EnemyHealthScaledRule(2);
-            var erd = new EnemyRespawnDisabledRule(true);
-            var gpus = new GoldPickedUpMultipliedRule(2f);
-            var pca = new PieceConfigAdjustedRule(new List<PieceConfigAdjustedRule.PieceProperty>
-            {
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroSorcerer, Property = "MoveRange", Value = 6 }, // Increased from the default of 4
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroSorcerer, Property = "StartHealth", Value = 20 }, // 10 extra HP
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroGuardian, Property = "MoveRange", Value = 5 },
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroGuardian, Property = "StartHealth", Value = 15 },
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroHunter, Property = "MoveRange", Value = 6 },
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroHunter, Property = "StartHealth", Value = 18 },
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroBard, Property = "MoveRange", Value = 8 },
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroBard, Property = "StartHealth", Value = 12 },
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroRogue, Property = "MoveRange", Value = 5 },
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroRogue, Property = "StartHealth", Value = 20 },
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Verochka, Property = "StartHealth", Value = 20 }, // Wolf lots of HP wandering through gas
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.SwordOfAvalon, Property = "StartHealth", Value = 20 },
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.SmiteWard, Property = "StartHealth", Value = 25 },
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.SmiteWard, Property = "ActionPoint", Value = 2 }, // Behemoth gets to fire two rounds
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Lure, Property = "StartHealth", Value = 25 }, // Lure needs to last a little longer
-            });
-            var rnsg = new RatNestsSpawnGoldRule(8);
-            var cards = new List<StartCardsModifiedRule.CardConfig>
-            {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Blink, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.WhirlwindAttack, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PoisonedTip, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PoisonedTip, IsReplenishable = false },
-            };
-            var sorcCards = new Dictionary<BoardPieceId, List<StartCardsModifiedRule.CardConfig>> { { BoardPieceId.HeroSorcerer, cards } };
-            var sscm = new StartCardsModifiedRule(sorcCards);
-
-            List<BoardPieceId> bps = new List<BoardPieceId> { BoardPieceId.ChestGoblin, BoardPieceId.Slimeling };
-            var arpl = new AbilityRandomPieceListRule(new Dictionary<AbilityKey, List<BoardPieceId>>
-            {
-                { AbilityKey.BeastWhisperer, bps },
-            });
-
-            List<EffectStateType> effs = new List<EffectStateType>() { EffectStateType.Diseased, EffectStateType.Stunned, EffectStateType.MarkOfAvalon, EffectStateType.Weaken, EffectStateType.Frozen, EffectStateType.Tangled, EffectStateType.Petrified };
-            var pila = new PieceImmunityListAdjustedRule(new Dictionary<BoardPieceId, List<EffectStateType>> { { BoardPieceId.HeroSorcerer, effs } });
-
-            var sec = new List<StatusEffectData>
-            {
-                new StatusEffectData
-                {
-                    effectStateType = EffectStateType.TorchPlayer,
-                    durationTurns = 15,
-                    damagePerTurn = 0,
-                    stacks = true,
-                    clearOnNewLevel = false,
-                    tickWhen = StatusEffectsConfig.TickWhen.StartTurn,
-                },
-                new StatusEffectData
-                {
-                    effectStateType = EffectStateType.HealingSong,
-                    durationTurns = 4,
-                    healPerTurn = 3,
-                    stacks = false,
-                    tickWhen = StatusEffectsConfig.TickWhen.StartTurn,
-                },
-            };
-            var seca = new StatusEffectConfigRule(sec);
-            var customRuleset = Ruleset.NewInstance("DemoConfigurableRuleset", "Just a random description.", new List<Rule>
-            {
-                aaca, aaa, ada, cefam1, cefam2, cefam3, cefam4, cefrm, csvm, eas, edod, ehs, erd, gpus, pca, rnsg, sscm, arpl, pila, seca,
-            });
-
-            ConfigurationMod.ConfigManager.ExportRuleset(customRuleset);
+                var clonedNamed = $"(Custom) {ruleset.Name}";
+                var rulesetCopy = Ruleset.NewInstance(clonedNamed, ruleset.Description, ruleset.Rules);
+                ConfigurationMod.ConfigManager.ExportRuleset(rulesetCopy);
+            }
         }
     }
 }

--- a/HouseRules_Configuration/HouseRules_Configuration.csproj
+++ b/HouseRules_Configuration/HouseRules_Configuration.csproj
@@ -55,8 +55,8 @@
     <ItemGroup>
         <Compile Include="ConfigManager.cs" />
         <Compile Include="ConfigurationMod.cs" />
-        <Compile Include="ExampleRulesetExporter.cs" />
         <Compile Include="Properties\AssemblyInfo.cs" />
+        <Compile Include="ExampleRulesetExporter.cs" />
         <Compile Include="UI\RulesetSelectionUI.cs" />
         <Compile Include="UI\RulesetSelectionPanel.cs" />
         <Compile Include="..\Common\**\*.cs" Exclude="..\Common\Properties\AssemblyInfo.cs;..\Common\bin\**\*.*;..\Common\obj\**\*.*;..\Common\**\*.csproj;..\Common\**\*.user;..\Common\**\*.vstemplate">
@@ -71,10 +71,6 @@
         <ProjectReference Include="..\HouseRules_Core\HouseRules_Core.csproj">
             <Project>{b412463f-a4f7-46ce-ac4e-37448762b45b}</Project>
             <Name>HouseRules_Core</Name>
-        </ProjectReference>
-        <ProjectReference Include="..\HouseRules_Essentials\HouseRules_Essentials.csproj">
-          <Project>{8fc09405-8e06-4090-bb68-94882f0a52d8}</Project>
-          <Name>HouseRules_Essentials</Name>
         </ProjectReference>
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
**Changes:**
- Removes the old `ExampleRulesetExporter `, which created and exported a single ruleset.
- Releases dependency on HR Essentials mod.
  - As a result of no longer creating an example ruleset in the configuration mod, it no longer has a dependency on the mod where the rules/rulesets are defined.
- Introduce a new `ExampleRulesetExporter` that exports all registered rulesets as JSON to the path `UserData\HouseRules\ExampleRulesets`.
  - In the process, exported rulesets are prepended with the string `(Custom) `.
- Add filename sanitization usable in general export procedures.

**Note:**

There are two lines in `ExampleRulesetExporter.cs`:
```cs
// Uncomment to export registered rulesets.
// ExportRegisteredRuleset();
```

These lines may be uncommented to view the effects.  This will be part of the release cycle, so that all registered rulesets are written out, but not during regular use.  This may be made easier with the use of `#pragma` and the `DEBUG` (or some other) constant, but is not part of this PR.