### PR TITLE
Update rules' sync triggers.

### DIFF
--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -13,13 +13,13 @@
         None = 0,
 
         /// <summary>New pieces are changed or have their attributes modified.</summary>
-        NewPieceChanged = 1,
+        NewPieceModified = 1,
 
         /// <summary>Status effect immunities are modified.</summary>
-        StatusEffectImmunityChanged = 2,
+        StatusEffectImmunityModified = 2,
 
         /// <summary>Status effect data (e.g., values, duration, etc.) are modified.</summary>
-        StatusEffectDataChanged = 4,
+        StatusEffectDataModified = 4,
     }
 
     internal static class BoardSyncer
@@ -173,19 +173,19 @@
 
         private static bool IsSyncNeeded()
         {
-            var hasSyncType = (HR.SelectedRuleset.ModifiedData & SyncableTrigger.NewPieceChanged) > 0;
+            var hasSyncType = (HR.SelectedRuleset.ModifiedData & SyncableTrigger.NewPieceModified) > 0;
             if (hasSyncType && _isNewSpawnPossible)
             {
                 return true;
             }
 
-            hasSyncType = (HR.SelectedRuleset.ModifiedData & SyncableTrigger.StatusEffectImmunityChanged) > 0;
+            hasSyncType = (HR.SelectedRuleset.ModifiedData & SyncableTrigger.StatusEffectImmunityModified) > 0;
             if (hasSyncType && _isStatusImmunitiesTouched)
             {
                 return true;
             }
 
-            hasSyncType = (HR.SelectedRuleset.ModifiedData & SyncableTrigger.StatusEffectDataChanged) > 0;
+            hasSyncType = (HR.SelectedRuleset.ModifiedData & SyncableTrigger.StatusEffectDataModified) > 0;
             if (hasSyncType && _isStatusEffectsTouched)
             {
                 return true;

--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -20,9 +20,6 @@
 
         /// <summary>Status effect data (e.g., values, duration, etc.) are modified.</summary>
         StatusEffectDataChanged = 4,
-
-        /// <summary>Existing pieces get their attributes modified.</summary>
-        ExistingPieceChanged = 8,
     }
 
     internal static class BoardSyncer

--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -8,12 +8,12 @@
     using HarmonyLib;
 
     [Flags]
-    public enum SpecialSyncData
+    public enum SyncableTrigger
     {
         None = 0,
-        PieceData = 1,
-        StatusEffectImmunity = 2,
-        StatusEffectData = 4,
+        PieceDataChanged = 1,
+        StatusEffectImmunityChanged = 2,
+        StatusEffectDataChanged = 4
     }
 
     internal static class BoardSyncer
@@ -61,7 +61,7 @@
                 return;
             }
 
-            if (HR.SelectedRuleset.ModifiedData == SpecialSyncData.None)
+            if (HR.SelectedRuleset.ModifiedData == SyncableTrigger.None)
             {
                 return;
             }
@@ -167,19 +167,19 @@
 
         private static bool IsSyncNeeded()
         {
-            var hasSyncType = (HR.SelectedRuleset.ModifiedData & SpecialSyncData.PieceData) > 0;
+            var hasSyncType = (HR.SelectedRuleset.ModifiedData & SyncableTrigger.PieceDataChanged) > 0;
             if (hasSyncType && _isNewSpawnPossible)
             {
                 return true;
             }
 
-            hasSyncType = (HR.SelectedRuleset.ModifiedData & SpecialSyncData.StatusEffectImmunity) > 0;
+            hasSyncType = (HR.SelectedRuleset.ModifiedData & SyncableTrigger.StatusEffectImmunityChanged) > 0;
             if (hasSyncType && _isStatusImmunitiesTouched)
             {
                 return true;
             }
 
-            hasSyncType = (HR.SelectedRuleset.ModifiedData & SpecialSyncData.StatusEffectData) > 0;
+            hasSyncType = (HR.SelectedRuleset.ModifiedData & SyncableTrigger.StatusEffectDataChanged) > 0;
             if (hasSyncType && _isStatusEffectsTouched)
             {
                 return true;

--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -67,7 +67,7 @@
                 return;
             }
 
-            if (HR.SelectedRuleset.ModifiedData == SyncableTrigger.None)
+            if (HR.SelectedRuleset.ModifiedSyncables == SyncableTrigger.None)
             {
                 return;
             }
@@ -173,19 +173,19 @@
 
         private static bool IsSyncNeeded()
         {
-            var hasSyncType = (HR.SelectedRuleset.ModifiedData & SyncableTrigger.NewPieceModified) > 0;
+            var hasSyncType = (HR.SelectedRuleset.ModifiedSyncables & SyncableTrigger.NewPieceModified) > 0;
             if (hasSyncType && _isNewSpawnPossible)
             {
                 return true;
             }
 
-            hasSyncType = (HR.SelectedRuleset.ModifiedData & SyncableTrigger.StatusEffectImmunityModified) > 0;
+            hasSyncType = (HR.SelectedRuleset.ModifiedSyncables & SyncableTrigger.StatusEffectImmunityModified) > 0;
             if (hasSyncType && _isStatusImmunitiesTouched)
             {
                 return true;
             }
 
-            hasSyncType = (HR.SelectedRuleset.ModifiedData & SyncableTrigger.StatusEffectDataModified) > 0;
+            hasSyncType = (HR.SelectedRuleset.ModifiedSyncables & SyncableTrigger.StatusEffectDataModified) > 0;
             if (hasSyncType && _isStatusEffectsTouched)
             {
                 return true;

--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -11,9 +11,18 @@
     public enum SyncableTrigger
     {
         None = 0,
-        PieceDataChanged = 1,
+
+        /// <summary>New pieces are changed or have their attributes modified.</summary>
+        NewPieceChanged = 1,
+
+        /// <summary>Status effect immunities are modified.</summary>
         StatusEffectImmunityChanged = 2,
-        StatusEffectDataChanged = 4
+
+        /// <summary>Status effect data (e.g., values, duration, etc.) are modified.</summary>
+        StatusEffectDataChanged = 4,
+
+        /// <summary>Existing pieces get their attributes modified.</summary>
+        ExistingPieceChanged = 8,
     }
 
     internal static class BoardSyncer
@@ -167,7 +176,7 @@
 
         private static bool IsSyncNeeded()
         {
-            var hasSyncType = (HR.SelectedRuleset.ModifiedData & SyncableTrigger.PieceDataChanged) > 0;
+            var hasSyncType = (HR.SelectedRuleset.ModifiedData & SyncableTrigger.NewPieceChanged) > 0;
             if (hasSyncType && _isNewSpawnPossible)
             {
                 return true;

--- a/HouseRules_Core/Types/Rule.cs
+++ b/HouseRules_Core/Types/Rule.cs
@@ -70,6 +70,6 @@
         /// </remarks>
         /// <example><code>SyncableTrigger.PieceDataChanged</code></example>
         /// <example><code>SyncableTrigger.PieceDataChanged | SyncableTrigger.StatusEffectImmunityChanged</code></example>
-        protected internal virtual SyncableTrigger ModifiedData => SyncableTrigger.None;
+        protected internal virtual SyncableTrigger ModifiedSyncables => SyncableTrigger.None;
     }
 }

--- a/HouseRules_Core/Types/Rule.cs
+++ b/HouseRules_Core/Types/Rule.cs
@@ -62,14 +62,14 @@
         /// <remarks>
         ///     <para>
         ///     There is no need to override this field unless the rule makes changes to one of the defined
-        ///     <see cref="SpecialSyncData"/> types.
+        ///     <see cref="SyncableTrigger"/> types.
         ///     </para>
         ///     <para>
         ///     Multiple types may be seperated by a vertical bar <c>|</c>.
         ///     </para>
         /// </remarks>
-        /// <example><code>SpecialSyncData.PieceData</code></example>
-        /// <example><code>SpecialSyncData.PieceData | SpecialSyncData.StatusEffectImmunity</code></example>
-        protected internal virtual SpecialSyncData ModifiedData => SpecialSyncData.None;
+        /// <example><code>SyncableTrigger.PieceDataChanged</code></example>
+        /// <example><code>SyncableTrigger.PieceDataChanged | SyncableTrigger.StatusEffectImmunityChanged</code></example>
+        protected internal virtual SyncableTrigger ModifiedData => SyncableTrigger.None;
     }
 }

--- a/HouseRules_Core/Types/Rule.cs
+++ b/HouseRules_Core/Types/Rule.cs
@@ -57,7 +57,7 @@
         }
 
         /// <summary>
-        /// Gets the type of data that the rule makes modifications to.
+        /// Gets the syncable types that this rule modifies.
         /// </summary>
         /// <remarks>
         ///     <para>

--- a/HouseRules_Core/Types/Ruleset.cs
+++ b/HouseRules_Core/Types/Ruleset.cs
@@ -28,7 +28,7 @@
         /// <summary>
         /// Gets the type of data that the rule makes modifications to.
         /// </summary>
-        public SpecialSyncData ModifiedData { get; }
+        public SyncableTrigger ModifiedData { get; }
 
         /// <summary>
         /// Represents the empty/missing ruleset.
@@ -43,11 +43,11 @@
         public static Ruleset NewInstance(string name, string description, List<Rule> rules)
         {
             var safeForMultiplayer = rules.All(r => r is IMultiplayerSafe);
-            var modifiedData = rules.Aggregate(SpecialSyncData.None, (data, rule) => data | rule.ModifiedData);
+            var modifiedData = rules.Aggregate(SyncableTrigger.None, (data, rule) => data | rule.ModifiedData);
             return new Ruleset(name, description, rules, safeForMultiplayer, modifiedData);
         }
 
-        private Ruleset(string name, string description, List<Rule> rules, bool isSafeForMultiplayer, SpecialSyncData modifiedData)
+        private Ruleset(string name, string description, List<Rule> rules, bool isSafeForMultiplayer, SyncableTrigger modifiedData)
         {
             Name = name;
             Description = description;

--- a/HouseRules_Core/Types/Ruleset.cs
+++ b/HouseRules_Core/Types/Ruleset.cs
@@ -43,7 +43,7 @@
         public static Ruleset NewInstance(string name, string description, List<Rule> rules)
         {
             var safeForMultiplayer = rules.All(r => r is IMultiplayerSafe);
-            var modifiedData = rules.Aggregate(SyncableTrigger.None, (data, rule) => data | rule.ModifiedData);
+            var modifiedData = rules.Aggregate(SyncableTrigger.None, (data, rule) => data | rule.ModifiedSyncables);
             return new Ruleset(name, description, rules, safeForMultiplayer, modifiedData);
         }
 

--- a/HouseRules_Core/Types/Ruleset.cs
+++ b/HouseRules_Core/Types/Ruleset.cs
@@ -26,7 +26,7 @@
         public bool IsSafeForMultiplayer { get; }
 
         /// <summary>
-        /// Gets the type of data that the rule makes modifications to.
+        /// Gets the syncable types that this rule modifies.
         /// </summary>
         public SyncableTrigger ModifiedSyncables { get; }
 

--- a/HouseRules_Core/Types/Ruleset.cs
+++ b/HouseRules_Core/Types/Ruleset.cs
@@ -28,7 +28,7 @@
         /// <summary>
         /// Gets the type of data that the rule makes modifications to.
         /// </summary>
-        public SyncableTrigger ModifiedData { get; }
+        public SyncableTrigger ModifiedSyncables { get; }
 
         /// <summary>
         /// Represents the empty/missing ruleset.
@@ -43,17 +43,17 @@
         public static Ruleset NewInstance(string name, string description, List<Rule> rules)
         {
             var safeForMultiplayer = rules.All(r => r is IMultiplayerSafe);
-            var modifiedData = rules.Aggregate(SyncableTrigger.None, (data, rule) => data | rule.ModifiedSyncables);
-            return new Ruleset(name, description, rules, safeForMultiplayer, modifiedData);
+            var syncables = rules.Aggregate(SyncableTrigger.None, (data, rule) => data | rule.ModifiedSyncables);
+            return new Ruleset(name, description, rules, safeForMultiplayer, syncables);
         }
 
-        private Ruleset(string name, string description, List<Rule> rules, bool isSafeForMultiplayer, SyncableTrigger modifiedData)
+        private Ruleset(string name, string description, List<Rule> rules, bool isSafeForMultiplayer, SyncableTrigger modifiedSyncables)
         {
             Name = name;
             Description = description;
             Rules = rules;
             IsSafeForMultiplayer = isSafeForMultiplayer;
-            ModifiedData = modifiedData;
+            ModifiedSyncables = modifiedSyncables;
         }
     }
 }

--- a/HouseRules_Essentials/Rules/AbilityHealOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityHealOverriddenRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Ability Heal settings are adjusted";
 
-        protected override SpecialSyncData ModifiedData => SpecialSyncData.PieceData;
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.PieceDataChanged;
 
         private readonly Dictionary<AbilityKey, int> _adjustments;
         private Dictionary<AbilityKey, int> _originals;

--- a/HouseRules_Essentials/Rules/AbilityHealOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityHealOverriddenRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Ability Heal settings are adjusted";
 
-        protected override SpecialSyncData ModifiedData => SpecialSyncData.StatusEffectData;
+        protected override SpecialSyncData ModifiedData => SpecialSyncData.PieceData;
 
         private readonly Dictionary<AbilityKey, int> _adjustments;
         private Dictionary<AbilityKey, int> _originals;

--- a/HouseRules_Essentials/Rules/AbilityHealOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityHealOverriddenRule.cs
@@ -12,8 +12,6 @@
     {
         public override string Description => "Ability Heal settings are adjusted";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
-
         private readonly Dictionary<AbilityKey, int> _adjustments;
         private Dictionary<AbilityKey, int> _originals;
 

--- a/HouseRules_Essentials/Rules/AbilityHealOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityHealOverriddenRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Ability Heal settings are adjusted";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.PieceDataChanged;
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
 
         private readonly Dictionary<AbilityKey, int> _adjustments;
         private Dictionary<AbilityKey, int> _originals;

--- a/HouseRules_Essentials/Rules/AbilityRandomPieceListRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityRandomPieceListRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Ability randomPieceLists are replaced";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
+        protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.NewPieceModified;
 
         private readonly Dictionary<AbilityKey, List<BoardPieceId>> _adjustments;
         private Dictionary<AbilityKey, List<BoardPieceId>> _originals;

--- a/HouseRules_Essentials/Rules/AbilityRandomPieceListRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityRandomPieceListRule.cs
@@ -12,6 +12,8 @@
     {
         public override string Description => "Ability randomPieceLists are replaced";
 
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
+
         private readonly Dictionary<AbilityKey, List<BoardPieceId>> _adjustments;
         private Dictionary<AbilityKey, List<BoardPieceId>> _originals;
 

--- a/HouseRules_Essentials/Rules/AbilityRandomPieceListRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityRandomPieceListRule.cs
@@ -12,8 +12,6 @@
     {
         public override string Description => "Ability randomPieceLists are replaced";
 
-        protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.NewPieceModified;
-
         private readonly Dictionary<AbilityKey, List<BoardPieceId>> _adjustments;
         private Dictionary<AbilityKey, List<BoardPieceId>> _originals;
 

--- a/HouseRules_Essentials/Rules/EnemyHealthScaledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyHealthScaledRule.cs
@@ -9,7 +9,7 @@
     {
         public override string Description => "Enemy health is scaled";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
+        protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.NewPieceModified;
 
         private static float _globalMultiplier;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/EnemyHealthScaledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyHealthScaledRule.cs
@@ -9,6 +9,8 @@
     {
         public override string Description => "Enemy health is scaled";
 
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
+
         private static float _globalMultiplier;
         private static bool _isActivated;
 

--- a/HouseRules_Essentials/Rules/PieceAbilityListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceAbilityListOverriddenRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Piece abilities are adjusted";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.PieceDataChanged;
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
 
         private readonly Dictionary<BoardPieceId, List<AbilityKey>> _adjustments;
         private Dictionary<BoardPieceId, List<AbilityKey>> _originals;

--- a/HouseRules_Essentials/Rules/PieceAbilityListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceAbilityListOverriddenRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Piece abilities are adjusted";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
+        protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.NewPieceModified;
 
         private readonly Dictionary<BoardPieceId, List<AbilityKey>> _adjustments;
         private Dictionary<BoardPieceId, List<AbilityKey>> _originals;

--- a/HouseRules_Essentials/Rules/PieceAbilityListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceAbilityListOverriddenRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Piece abilities are adjusted";
 
-        protected override SpecialSyncData ModifiedData => SpecialSyncData.PieceData;
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.PieceDataChanged;
 
         private readonly Dictionary<BoardPieceId, List<AbilityKey>> _adjustments;
         private Dictionary<BoardPieceId, List<AbilityKey>> _originals;

--- a/HouseRules_Essentials/Rules/PieceBehavioursListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceBehavioursListOverriddenRule.cs
@@ -13,7 +13,7 @@
     {
         public override string Description => "Piece behaviours are adjusted";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
+        protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.NewPieceModified;
 
         private readonly Dictionary<BoardPieceId, List<Behaviour>> _adjustments;
         private Dictionary<BoardPieceId, List<Behaviour>> _originals;

--- a/HouseRules_Essentials/Rules/PieceBehavioursListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceBehavioursListOverriddenRule.cs
@@ -13,7 +13,7 @@
     {
         public override string Description => "Piece behaviours are adjusted";
 
-        protected override SpecialSyncData ModifiedData => SpecialSyncData.PieceData;
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.PieceDataChanged;
 
         private readonly Dictionary<BoardPieceId, List<Behaviour>> _adjustments;
         private Dictionary<BoardPieceId, List<Behaviour>> _originals;

--- a/HouseRules_Essentials/Rules/PieceBehavioursListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceBehavioursListOverriddenRule.cs
@@ -13,7 +13,7 @@
     {
         public override string Description => "Piece behaviours are adjusted";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.PieceDataChanged;
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
 
         private readonly Dictionary<BoardPieceId, List<Behaviour>> _adjustments;
         private Dictionary<BoardPieceId, List<Behaviour>> _originals;

--- a/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Piece configuration is adjusted";
 
-        protected override SpecialSyncData ModifiedData => SpecialSyncData.PieceData;
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.PieceDataChanged;
 
         private readonly List<PieceProperty> _adjustments;
         private List<PieceProperty> _originals;

--- a/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Piece configuration is adjusted";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.PieceDataChanged;
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
 
         private readonly List<PieceProperty> _adjustments;
         private List<PieceProperty> _originals;

--- a/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Piece configuration is adjusted";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
+        protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.NewPieceModified;
 
         private readonly List<PieceProperty> _adjustments;
         private List<PieceProperty> _originals;

--- a/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Piece immunities are adjusted";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.StatusEffectImmunityChanged;
+        protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.StatusEffectImmunityModified;
 
         private readonly Dictionary<BoardPieceId, List<EffectStateType>> _adjustments;
         private Dictionary<BoardPieceId, List<EffectStateType>> _originals;

--- a/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Piece immunities are adjusted";
 
-        protected override SpecialSyncData ModifiedData => SpecialSyncData.StatusEffectImmunity;
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.StatusEffectImmunityChanged;
 
         private readonly Dictionary<BoardPieceId, List<EffectStateType>> _adjustments;
         private Dictionary<BoardPieceId, List<EffectStateType>> _originals;

--- a/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Piece piece types are adjusted";
 
-        protected override SpecialSyncData ModifiedData => SpecialSyncData.PieceData;
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.PieceDataChanged;
 
         private readonly Dictionary<BoardPieceId, List<PieceType>> _adjustments;
         private Dictionary<BoardPieceId, List<PieceType>> _originals;

--- a/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Piece piece types are adjusted";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
+        protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.NewPieceModified;
 
         private readonly Dictionary<BoardPieceId, List<PieceType>> _adjustments;
         private Dictionary<BoardPieceId, List<PieceType>> _originals;

--- a/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Piece piece types are adjusted";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.PieceDataChanged;
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
 
         private readonly Dictionary<BoardPieceId, List<PieceType>> _adjustments;
         private Dictionary<BoardPieceId, List<PieceType>> _originals;

--- a/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Piece UseWhenKilled lists are overridden";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.PieceDataChanged;
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
 
         private readonly Dictionary<BoardPieceId, List<AbilityKey>> _adjustments;
         private Dictionary<BoardPieceId, List<AbilityKey>> _originals;

--- a/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
@@ -12,8 +12,6 @@
     {
         public override string Description => "Piece UseWhenKilled lists are overridden";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.NewPieceChanged;
-
         private readonly Dictionary<BoardPieceId, List<AbilityKey>> _adjustments;
         private Dictionary<BoardPieceId, List<AbilityKey>> _originals;
 
@@ -59,6 +57,5 @@
 
             return previousProperties;
         }
-
     }
 }

--- a/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
@@ -12,7 +12,7 @@
     {
         public override string Description => "Piece UseWhenKilled lists are overridden";
 
-        protected override SpecialSyncData ModifiedData => SpecialSyncData.PieceData;
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.PieceDataChanged;
 
         private readonly Dictionary<BoardPieceId, List<AbilityKey>> _adjustments;
         private Dictionary<BoardPieceId, List<AbilityKey>> _originals;

--- a/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
@@ -12,6 +12,8 @@
     {
         public override string Description => "Piece UseWhenKilled lists are overridden";
 
+        protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.NewPieceModified | SyncableTrigger.StatusEffectDataModified;
+
         private readonly Dictionary<BoardPieceId, List<AbilityKey>> _adjustments;
         private Dictionary<BoardPieceId, List<AbilityKey>> _originals;
 

--- a/HouseRules_Essentials/Rules/StatusEffectConfigRule.cs
+++ b/HouseRules_Essentials/Rules/StatusEffectConfigRule.cs
@@ -10,7 +10,7 @@
     {
         public override string Description => "StatusEffects config is Overridden";
 
-        protected override SpecialSyncData ModifiedData => SpecialSyncData.StatusEffectData;
+        protected override SyncableTrigger ModifiedData => SyncableTrigger.StatusEffectDataChanged;
 
         private readonly List<StatusEffectData> _adjustments;
         private List<StatusEffectData> _originals;

--- a/HouseRules_Essentials/Rules/StatusEffectConfigRule.cs
+++ b/HouseRules_Essentials/Rules/StatusEffectConfigRule.cs
@@ -10,7 +10,7 @@
     {
         public override string Description => "StatusEffects config is Overridden";
 
-        protected override SyncableTrigger ModifiedData => SyncableTrigger.StatusEffectDataChanged;
+        protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.StatusEffectDataModified;
 
         private readonly List<StatusEffectData> _adjustments;
         private List<StatusEffectData> _originals;


### PR DESCRIPTION
Resolves https://github.com/orendain/DemeoMods/issues/261. ... I hope.

**Changes:**
- Rename `SyncableTrigger` enums and corresponding rule field name.
- Document each `SyncableTrigger`.
- Modify rules' `SyncableTrigger`s.

~> Note: I still need to playtest and see if things are working as intended.~

Update:  Tests went well.  Played a full game of Arachnophobia with no sync issues (from what I could gather from the group) and also some very specific testing of `PieceUseWhenKilledOverrideRule` and `AbilityHealOverriddenRule` with the help of some random players.