### PR TITLE
Enable HouseRules users to race through the Hangout game starting procedure.

### DIFF
--- a/HouseRules_Core/CoreMod.cs
+++ b/HouseRules_Core/CoreMod.cs
@@ -15,6 +15,7 @@
             var harmony = new Harmony("com.orendain.demeomods.houserules.core");
             LifecycleDirector.Patch(harmony);
             BoardSyncer.Patch(harmony);
+            HangoutsGameRacer.Patch(harmony);
 
             HR.Rulebook.Register(Ruleset.None);
         }

--- a/HouseRules_Core/HangoutsGameRacer.cs
+++ b/HouseRules_Core/HangoutsGameRacer.cs
@@ -125,7 +125,7 @@
 
             StopWatch.Stop();
             var timeElapsed = StopWatch.Elapsed;
-            HR.Logger.Msg($"Time to join game from Hangouts: {timeElapsed.Seconds:00}.{timeElapsed.Milliseconds:00}s");
+            HR.Logger.Msg($"[HangoutGameRacer] Time to join game from Hangouts: {timeElapsed.Seconds:00}.{timeElapsed.Milliseconds:00}s");
         }
 
         private static GroupLaunchModuleData.ModuleType FindSelectedModelType(GroupLaunchTable groupLaunchTable)

--- a/HouseRules_Core/HangoutsGameRacer.cs
+++ b/HouseRules_Core/HangoutsGameRacer.cs
@@ -1,0 +1,165 @@
+﻿namespace HouseRules
+{
+    using System;
+    using System.Diagnostics;
+    using System.Reflection;
+    using Boardgame.Social;
+    using Bowser;
+    using Bowser.Core;
+    using Bowser.GameIntegration;
+    using HarmonyLib;
+    using Photon.Pun;
+
+    internal static class HangoutsGameRacer
+    {
+        private static readonly Stopwatch StopWatch = new Stopwatch();
+
+        private static GameStateHobbyShop _gameStateHobbyShop;
+        private static GameStateHobbyShopData _coroutineSpinner;
+
+        private static bool _isStartingHangoutsGame;
+        private static JoinParameters _joinParameters;
+
+        internal static void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(GameStateHobbyShop), "Start"),
+                postfix: new HarmonyMethod(
+                    typeof(HangoutsGameRacer),
+                    nameof(GameStateHobbyShop_Start_Postfix)));
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(GroupLaunchTable), "OnStartButtonPressed"),
+                prefix: new HarmonyMethod(
+                    typeof(HangoutsGameRacer),
+                    nameof(GroupLaunchTable_OnStartButtonPressed_Prefix)));
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(GroupLaunchTable), "OnStartGroupLaunchRPC"),
+                prefix: new HarmonyMethod(
+                    typeof(HangoutsGameRacer),
+                    nameof(GroupLaunchTable_OnStartGroupLaunchRPC_Prefix)));
+
+            harmony.Patch(
+                original: AccessTools.Constructor(
+                    typeof(SocialProviderParea),
+                    new[] { typeof(StringToRoomCode), typeof(Action<ISocialProvider, JoinParameters>) }),
+                prefix: new HarmonyMethod(typeof(HangoutsGameRacer), nameof(SocialProviderParea_Constructor_Prefix)));
+
+            harmony.Patch(
+                original: AccessTools
+                    .Inner(typeof(GameStateMachine), "CreatingGameState").GetTypeInfo()
+                    .GetDeclaredMethod("OnJoinedRoom"),
+                prefix: new HarmonyMethod(typeof(HangoutsGameRacer), nameof(CreatingGameState_OnJoinedRoom_Prefix)));
+        }
+
+        private static void GameStateHobbyShop_Start_Postfix(GameStateHobbyShop __instance, GameStateData baseData)
+        {
+            _gameStateHobbyShop = __instance;
+            _coroutineSpinner = (GameStateHobbyShopData)baseData;
+        }
+
+        private static bool GroupLaunchTable_OnStartButtonPressed_Prefix(GroupLaunchTable __instance)
+        {
+            HR.Logger.Msg("[HangoutGameRacer] Attempting to race out of Hangouts by front-loading computation.");
+            _isStartingHangoutsGame = true;
+
+            var moduleType = FindSelectedModelType(__instance);
+            var destination = ConvertModuleTypeToDestination(moduleType);
+            var uniqueId = Guid.NewGuid().ToString();
+
+            var stringToRoomCode = new StringToRoomCode(_coroutineSpinner);
+            stringToRoomCode.GetRoomCodeFromString(uniqueId, delegate(string roomCode)
+            {
+                _joinParameters = new JoinParameters();
+                _joinParameters.groupId = GetPareaRoomCode(roomCode);
+                _joinParameters.gameId = string.Empty;
+                _joinParameters.destination = destination;
+
+                HR.Logger.Msg("[HangoutGameRacer] Pre-fetched room code.");
+                NotifyPlayersAndLeaveHangouts(__instance, _joinParameters.groupId, moduleType);
+            });
+
+            return false;
+        }
+
+        private static void NotifyPlayersAndLeaveHangouts(GroupLaunchTable groupLaunchTable, string groupId, GroupLaunchModuleData.ModuleType moduleType)
+        {
+            HR.Logger.Msg("[HangoutGameRacer] Finally notifying players of race.");
+            Traverse.Create(groupLaunchTable).Field<bool>("leavingBowser").Value = true;
+
+            // Recreating `GameStateHobbyShop.ExitBowser`
+            var teleport = Traverse.Create(_gameStateHobbyShop).Field<Teleport>("teleport").Value;
+            teleport.SetTeleportationEnabled(enabled: false);
+            Traverse.Create<BowserTriggerHandler>().Method("StopHobbyShopAmbience").GetValue();
+
+            // Originally from `GroupLaunchTable.OnStartButtonPressed`.
+            var playersInParty = Traverse.Create(groupLaunchTable).Field<int[]>("playersInParty").Value;
+            var groupLaunchTableData = Traverse.Create(groupLaunchTable).Field<GroupLaunchTableData>("data").Value;
+            groupLaunchTableData.photonView.RPC("BowserStartGroupLaunchRPC", RpcTarget.All, playersInParty[0], playersInParty[1], playersInParty[2], playersInParty[3], groupId, (int)moduleType, -1);
+
+            PhotonNetwork.SendAllOutgoingCommands();
+            BowserIntegration.ExitBowser();
+        }
+
+        private static void GroupLaunchTable_OnStartGroupLaunchRPC_Prefix()
+        {
+            StopWatch.Restart();
+        }
+
+        private static bool SocialProviderParea_Constructor_Prefix(SocialProviderParea __instance, Action<ISocialProvider, JoinParameters> onJoinReceived)
+        {
+            if (!_isStartingHangoutsGame)
+            {
+                return true;
+            }
+
+            Traverse.Create(__instance).Field<JoinParameters>("joinParameters").Value = _joinParameters;
+            Traverse.Create(__instance).Field<Action<ISocialProvider, JoinParameters>>("onJoinReceived").Value = onJoinReceived;
+            return false;
+        }
+
+        private static void CreatingGameState_OnJoinedRoom_Prefix()
+        {
+            _isStartingHangoutsGame = false;
+
+            StopWatch.Stop();
+            var timeElapsed = StopWatch.Elapsed;
+            HR.Logger.Msg($"Time to join game from Hangouts: {timeElapsed.Seconds:00}.{timeElapsed.Milliseconds:00}s");
+        }
+
+        private static GroupLaunchModuleData.ModuleType FindSelectedModelType(GroupLaunchTable groupLaunchTable)
+        {
+            var modules = Traverse.Create(groupLaunchTable).Field<GroupLaunchModuleData[]>("modules").Value;
+            var selectedModuleIndex = Traverse.Create(groupLaunchTable).Field<int>("selectedModuleIndex").Value;
+            var moduleType = modules[selectedModuleIndex].moduleType;
+            if (moduleType == GroupLaunchModuleData.ModuleType.Random)
+            {
+                moduleType = (GroupLaunchModuleData.ModuleType)UnityEngine.Random.Range(1, Enum.GetValues(typeof(GroupLaunchModuleData.ModuleType)).Length);
+            }
+
+            return moduleType;
+        }
+
+        private static PlayWithFriendsController.Destination ConvertModuleTypeToDestination(GroupLaunchModuleData.ModuleType moduleType)
+        {
+            switch (moduleType)
+            {
+                case GroupLaunchModuleData.ModuleType.ElvenQueen:
+                    return PlayWithFriendsController.Destination.TheBlackSarcophagus;
+                case GroupLaunchModuleData.ModuleType.RatKing:
+                    return PlayWithFriendsController.Destination.RealmOfTheRatKing;
+                case GroupLaunchModuleData.ModuleType.RootsOfEvil:
+                    return PlayWithFriendsController.Destination.RootsOfEvil;
+                default:
+                    return PlayWithFriendsController.Destination.TheBlackSarcophagus;
+            }
+        }
+
+        // Recreated from `SocialProviderParea`.
+        private static string GetPareaRoomCode(string response)
+        {
+            return response.Length > 5 ? response.Substring(1, 5) : "12345";
+        }
+    }
+}

--- a/HouseRules_Core/HouseRules_Core.csproj
+++ b/HouseRules_Core/HouseRules_Core.csproj
@@ -41,11 +41,11 @@
         <Reference Include="MelonLoader">
             <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
         </Reference>
-        <Reference Include="PhotonUnityNetworking">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\PhotonUnityNetworking.dll</HintPath>
-        </Reference>
         <Reference Include="PhotonRealtime">
             <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\PhotonRealtime.dll</HintPath>
+        </Reference>
+        <Reference Include="PhotonUnityNetworking">
+            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\PhotonUnityNetworking.dll</HintPath>
         </Reference>
         <Reference Include="System" />
         <Reference Include="UnityEngine.CoreModule">

--- a/HouseRules_Core/HouseRules_Core.csproj
+++ b/HouseRules_Core/HouseRules_Core.csproj
@@ -44,6 +44,9 @@
         <Reference Include="PhotonUnityNetworking">
             <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\PhotonUnityNetworking.dll</HintPath>
         </Reference>
+        <Reference Include="PhotonRealtime">
+            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\PhotonRealtime.dll</HintPath>
+        </Reference>
         <Reference Include="System" />
         <Reference Include="UnityEngine.CoreModule">
             <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
@@ -51,6 +54,7 @@
     </ItemGroup>
     <ItemGroup>
         <Compile Include="BoardSyncer.cs" />
+        <Compile Include="HangoutsGameRacer.cs" />
         <Compile Include="LifecycleDirector.cs" />
         <Compile Include="Properties\AssemblyInfo.cs" />
         <Compile Include="HR.cs" />


### PR DESCRIPTION
Resolves https://github.com/orendain/DemeoMods/issues/260.

A subsequent PR can focus on the converse of this: to _slow_ HouseRules users if they do not want to be the host.

Here are my latest findings (3 trials, results in seconds).  "Warmed" suggests a game was previously started that session, "Speed" suggests this feature was enabled.

TL;DR:  This feature shaves off about a second.

```
Not warmed, no speed:
5.729
5.608
5.82

Warmed, no speed:
5.147
5.637
5.639

Not warmed, speed:
4.284
4.631
4.87

Warmed, speed:
4.698
4.574
4.643
```

> Note:  During speeding through, there may be a message in the log `[UnityExplorer] [WARNING] The target UnityEngine.Object was destroyed!` which I believe is due to skipping the full instantiation of the `SocialProviderPar`.  Not 100% verified, but the warning should be harmless.