### PR TITLE
Enable HangoutsGameRacer optimizations only when a ruleset is selected and for non-table hosts.

### DIFF
--- a/HouseRules_Core/HangoutsGameRacer.cs
+++ b/HouseRules_Core/HangoutsGameRacer.cs
@@ -9,6 +9,7 @@
     using Bowser.GameIntegration;
     using HarmonyLib;
     using Photon.Pun;
+    using Types;
 
     internal static class HangoutsGameRacer
     {
@@ -61,6 +62,11 @@
 
         private static bool GroupLaunchTable_OnStartButtonPressed_Prefix(GroupLaunchTable __instance)
         {
+            if (HR.SelectedRuleset == Ruleset.None)
+            {
+                return true;
+            }
+
             HR.Logger.Msg("[HangoutGameRacer] Attempting to race out of Hangouts by front-loading computation.");
             _isStartingHangoutsGame = true;
 

--- a/HouseRules_Core/HangoutsGameRacer.cs
+++ b/HouseRules_Core/HangoutsGameRacer.cs
@@ -10,8 +10,8 @@
     using Bowser.Core;
     using Bowser.GameIntegration;
     using HarmonyLib;
+    using HouseRules.Types;
     using Photon.Pun;
-    using Types;
 
     internal static class HangoutsGameRacer
     {
@@ -74,7 +74,7 @@
                 return true;
             }
 
-            HR.Logger.Msg("[HangoutGameRacer] Attempting to race out of Hangouts by front-loading computation.");
+            HR.Logger.Msg("[HangoutGameRacer] Attempting to race out of Hangouts as table host by front-loading computation.");
             _hasJoinedTheRace = true;
 
             var groupId = Guid.NewGuid().ToString();
@@ -97,6 +97,9 @@
             {
                 return false;
             }
+
+            HR.Logger.Msg("[HangoutGameRacer] Attempting to race out of Hangouts as table non-host.");
+            _hasJoinedTheRace = true;
 
             var moduleType = (GroupLaunchModuleData.ModuleType)selectedModuleType;
             if (moduleType == GroupLaunchModuleData.ModuleType.Random)
@@ -178,7 +181,6 @@
 
         private static void PrepareToLeaveHangouts(GroupLaunchTable groupLaunchTable)
         {
-            HR.Logger.Msg("[HangoutGameRacer] Optimizing preparation for leaving hangouts.");
             Traverse.Create(groupLaunchTable).Field<bool>("leavingBowser").Value = true;
 
             // Recreating `GameStateHobbyShop.ExitBowser`

--- a/HouseRules_Core/HangoutsGameRacer.cs
+++ b/HouseRules_Core/HangoutsGameRacer.cs
@@ -117,6 +117,11 @@
         {
             _hasJoinedTheRace = false;
 
+            if (!StopWatch.IsRunning)
+            {
+                return;
+            }
+
             StopWatch.Stop();
             var timeElapsed = StopWatch.Elapsed;
             HR.Logger.Msg($"[HangoutGameRacer] Time to join game from Hangouts: {timeElapsed.Seconds:00}.{timeElapsed.Milliseconds:00}s");


### PR DESCRIPTION
Resolves https://github.com/orendain/DemeoMods/issues/268.

**Changes:**
- Only optimize race path when user has a ruleset selected.
- Restructured functions to allow non-table-hosts to receive out-of-hangouts-path optimizations.
- Only display time-to-join when it was being timed.
- Reduce enforced delay before room creation down from 500ms to 50ms.