### PR TITLE
A new rule for overriding the LevelSequence used in a game session.

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -37,6 +37,7 @@
             HR.Rulebook.Register(typeof(LampTypesOverriddenRule));
             HR.Rulebook.Register(typeof(LevelExitLockedUntilAllEnemiesDefeatedRule));
             HR.Rulebook.Register(typeof(LevelPropertiesModifiedRule));
+            HR.Rulebook.Register(typeof(LevelSequenceOverriddenRule));
             HR.Rulebook.Register(typeof(MonsterDeckOverriddenRule));
             HR.Rulebook.Register(typeof(PetsFocusHunterMarkRule));
             HR.Rulebook.Register(typeof(PieceConfigAdjustedRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Rules\AbilityHealOverriddenRule.cs" />
     <Compile Include="Rules\CardClassRestrictionOverriddenRule.cs" />
     <Compile Include="Rules\LampTypesOverriddenRule.cs" />
+    <Compile Include="Rules\LevelSequenceOverriddenRule.cs" />
     <Compile Include="Rules\PieceUseWhenKilledOverriddenRule.cs" />
     <Compile Include="Rules\MonsterDeckOverriddenRule.cs" />
     <Compile Include="Rules\SpawnCategoryOverriddenRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -413,6 +413,24 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
   },
   ```
 
+- __LevelSequenceOverridden__: The Level Sequence of dungeon floors is overridden.
+  - List of levels must be exactly five items long. The game will crash at the end if the list is any longer.
+  - Shop levels can be replaced with game levels.
+  - It is possible to use levels from any book (Elven, Sewers, Forest) together in a single list
+  - Level soundtracks may not match the played level or adventure (e.g. The shop "Ah Customers, Welcome" will always play on 2nd and 4th levels)
+  - Level names are ElvenFloor01-17, SewersFloor01-12, ForestFloor01-03, ForestFloor05-09, ShopFloor02, SewersShopFloor & ForestShopFloor
+  - To configure:
+    - Specify a list of strings of level names.
+
+  ###### _Example JSON config for LevelPropertiesModified_
+
+  ```json
+  {
+    "Rule": "LevelSequenceOverridden",
+    "Config": [ "ElvenFloor01", "SewersFloor07", "ForestFloor09", "ForestShopFloor", "ElvenFloor08" ]
+  },
+  ```
+
 - __MonsterDeckOverridden__: The MonsterDeck which is used for spawning monsters is overridden.
   - This rule is a more advanced implementation of SpawnCategoriesOverridden, and will directly configure the MonsterDeck from lists.
   - Within the game the `AIDirectorController` deals Monsters from the MonsterDeck when populating the levels.

--- a/HouseRules_Essentials/Rules/LevelSequenceOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/LevelSequenceOverriddenRule.cs
@@ -57,7 +57,7 @@
             };
             newlist.AddRange(replacements); // Append user supplied levels
             Traverse.Create(levelSequence).Field<string[]>("levels").Value = newlist.ToArray();
-            return originals.ToList();
+            return originals.ToList().GetRange(1, 5);
         }
     }
 }

--- a/HouseRules_Essentials/Rules/LevelSequenceOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/LevelSequenceOverriddenRule.cs
@@ -1,0 +1,63 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Boardgame;
+    using Boardgame.LevelLoading;
+    using Boardgame.Networking;
+    using Data.GameData;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Types;
+    using UnityEngine;
+
+    public sealed class LevelSequenceOverriddenRule : Rule, IConfigWritable<List<string>>, IMultiplayerSafe
+    {
+        public override string Description => "LevelSequence is overridden";
+
+        protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.NewPieceModified | SyncableTrigger.StatusEffectDataModified;
+
+        private readonly List<string> _adjustments;
+        private List<string> _originals;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LevelSequenceOverriddenRule"/> class.
+        /// </summary>
+        /// <param name="adjustments">List of strings of LevelNames.</param>
+        public LevelSequenceOverriddenRule(List<string> adjustments)
+        {
+            _adjustments = adjustments;
+            _originals = new List<string>();
+        }
+
+        public List<string> GetConfigObject() => _adjustments;
+
+        protected override void OnPostGameCreated(GameContext gameContext)
+        {
+            _originals = ReplaceExistingProperties(_adjustments);
+        }
+
+        protected override void OnDeactivate(GameContext gameContext)
+        {
+            ReplaceExistingProperties(_originals);
+        }
+
+        /// <summary>
+        /// Replaces LevelSequence levels with predefined list.
+        /// </summary>
+        /// <returns>List of previous LevelSequnece levels that are now replaced.</returns>
+        private static List<string> ReplaceExistingProperties(List<string> replacements)
+        {
+            var levelManager = Resources.FindObjectsOfTypeAll<LevelManager>().First();
+            var levelSequence = Traverse.Create(levelManager).Field<LevelSequence>("levelSequence").Value;
+            var originals = Traverse.Create(levelSequence).Field<string[]>("levels").Value;
+            var newlist = new List<string>
+            {
+                originals[0], // We need the Entrance to match the current one or the game will crash when moving to the next level.
+            };
+            newlist.AddRange(replacements); // Append user supplied levels
+            Traverse.Create(levelSequence).Field<string[]>("levels").Value = newlist.ToArray();
+            return originals.ToList();
+        }
+    }
+}


### PR DESCRIPTION
# LevelSequenceOverridenRule - Preselect your game maps.

A rule of questionable utility, but intersting possibilities. This rule is applied OnPostGameCreated to rewrite the LevelSequence.levels list. For reasons I have not investigated, the game crashes if the Entrance level is not the same as the one on the replaced list, so this rule only accepts config for the next five levels in the game.

I was looking into how we could make neverending games when I found the LevelSequence, so created this rule to facilitiate with experimentation, Playing games with the ruleset below revals some intersting things about the game's inner workings (such as how the soundtrack is not dependent on the level, or how monsterdeck generation depends on gametype etc). 

I think there was a No-Shopping weekly challenge at some time, so maybe hardcore gamers would like five back-to-back levels of torture to contend with.

## Test Ruleset
```
{
  "Name": "test",
  "Description": "Test rule for LevelSequenceOverriddenRule.",
  "Rules": [
    {
      "Rule": "LevelSequenceOverridden",
      "Config": [ "ElvenFloor01", "SewersFloor07", "ForestFloor09", "ForestShopFloor", "ElvenFloor08" ]
    },
  ]
}
```