### PR TITLE
Bump houserules to v1.3.0.

### DIFF
--- a/HouseRules_Configuration/Properties/AssemblyInfo.cs
+++ b/HouseRules_Configuration/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using MelonLoader;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 // Melon Loader.
-[assembly: MelonInfo(typeof(ConfigurationMod), "HouseRules: Configuration", "1.2.0", "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonInfo(typeof(ConfigurationMod), "HouseRules: Configuration", "1.3.0", "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonID("574512")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]

--- a/HouseRules_Core/Properties/AssemblyInfo.cs
+++ b/HouseRules_Core/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using MelonLoader;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 // Melon Loader.
-[assembly: MelonInfo(typeof(CoreMod), "HouseRules: Core", "1.2.0", "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonInfo(typeof(CoreMod), "HouseRules: Core", "1.3.0", "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonID("574512")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]

--- a/HouseRules_Essentials/Properties/AssemblyInfo.cs
+++ b/HouseRules_Essentials/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using MelonLoader;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 // Melon Loader.
-[assembly: MelonInfo(typeof(EssentialsMod), "HouseRules: Essentials", "1.2.0", "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonInfo(typeof(EssentialsMod), "HouseRules: Essentials", "1.3.0", "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonID("574512")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]


### PR DESCRIPTION
Bump houserules to v1.3.0 (SNAPSHOT) in preparation for the next eventual release.