### PR TITLE
Skip intro loading sequence on PC editions.

### DIFF
--- a/SkipIntro/ModPatcher.cs
+++ b/SkipIntro/ModPatcher.cs
@@ -1,6 +1,8 @@
 ﻿namespace SkipIntro
 {
     using Boardgame;
+    using Boardgame.NonVR;
+    using Boardgame.NonVR.Ui;
     using HarmonyLib;
     using UnityEngine;
 
@@ -11,6 +13,14 @@
             harmony.Patch(
                 original: typeof(MotherbrainSceneUtil).GetMethod("LoadIntro"),
                 prefix: new HarmonyMethod(typeof(ModPatcher), nameof(MotherbrainSceneUtil_LoadIntro_Prefix)));
+
+            harmony.Patch(
+                original: AccessTools.Constructor(typeof(NonVrBoot)),
+                prefix: new HarmonyMethod(typeof(ModPatcher), nameof(NonVrBoot_Constructor_Prefix)));
+
+            harmony.Patch(
+                original: typeof(GlobalCanvasSystem).GetMethod("RunLoading"),
+                prefix: new HarmonyMethod(typeof(ModPatcher), nameof(GlobalCanvasSystem_RunLoading_Prefix)));
         }
 
         private static bool MotherbrainSceneUtil_LoadIntro_Prefix(ref AsyncOperation __result)
@@ -18,6 +28,18 @@
             SkipIntroMod.Logger.Msg("Skipping the intro scene.");
             __result = MotherbrainSceneUtil.LoadLobby();
             return false;
+        }
+
+        private static void NonVrBoot_Constructor_Prefix()
+        {
+            MotherbrainGlobalVars.isRunningBrainTests = true;
+            SkipIntroMod.Logger.Msg("Temporarily setting a field required to skip the intro scene.");
+        }
+
+        private static void GlobalCanvasSystem_RunLoading_Prefix()
+        {
+            MotherbrainGlobalVars.isRunningBrainTests = false;
+            SkipIntroMod.Logger.Msg("Reverting temporarily field setting.");
         }
     }
 }

--- a/SkipIntro/Properties/AssemblyInfo.cs
+++ b/SkipIntro/Properties/AssemblyInfo.cs
@@ -37,7 +37,8 @@ using SkipIntro;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 // Melon Loader.
-[assembly: MelonInfo(typeof(SkipIntroMod), "SkipIntro", "1.3.0", "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonInfo(typeof(SkipIntroMod), "SkipIntro", "1.4.0", "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
+[assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("566782")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]


### PR DESCRIPTION
**Changes:**
- Skip intro loading sequence on PC editions.
- Bump version to `1.4.0`.
- Add the PC edition as a compatible target.

> Note: I would have wanted to more elegantly modify the boot sequence code to skip the starting video, but ran into issues adding a transpiler.