### PR TITLE
Override room codes on PC editions.

### DIFF
--- a/RoomCode/Properties/AssemblyInfo.cs
+++ b/RoomCode/Properties/AssemblyInfo.cs
@@ -37,7 +37,8 @@ using RoomCode;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 // Melon Loader.
-[assembly: MelonInfo(typeof(RoomCodeMod), "RoomCode", "1.0.0", "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonInfo(typeof(RoomCodeMod), "RoomCode", "1.1.0", "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
+[assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("581308")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]


### PR DESCRIPTION
**Changes:**
- Bump version to `1.1.0`.
- Add the PC edition as a compatible target.