### PR TITLE
Replace names of Demeo paths with agnostic VR and PC names.

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -33,25 +33,25 @@
     </PropertyGroup>
     <ItemGroup>
         <Reference Include="0Harmony">
-            <HintPath>$(SteamDemeoDir)\MelonLoader\0Harmony.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\MelonLoader\0Harmony.dll</HintPath>
         </Reference>
         <Reference Include="MelonLoader">
-            <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\MelonLoader\MelonLoader.dll</HintPath>
         </Reference>
         <Reference Include="Assembly-CSharp">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
         </Reference>
         <Reference Include="Unity.TextMeshPro">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Unity.TextMeshPro.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.CoreModule">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.PhysicsModule">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.UI">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.UI.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\UnityEngine.UI.dll</HintPath>
         </Reference>
     </ItemGroup>
     <ItemGroup>

--- a/HouseRules_Configuration/HouseRules_Configuration.csproj
+++ b/HouseRules_Configuration/HouseRules_Configuration.csproj
@@ -33,26 +33,26 @@
     </PropertyGroup>
     <ItemGroup>
         <Reference Include="0Harmony">
-            <HintPath>$(SteamDemeoDir)\MelonLoader\0Harmony.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\MelonLoader\0Harmony.dll</HintPath>
         </Reference>
         <Reference Include="Assembly-CSharp">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
         </Reference>
         <Reference Include="MelonLoader">
-            <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\MelonLoader\MelonLoader.dll</HintPath>
         </Reference>
         <Reference Include="System" />
         <Reference Include="Unity.TextMeshPro">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Unity.TextMeshPro.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.CoreModule">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.PhysicsModule">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.UI">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.UI.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\UnityEngine.UI.dll</HintPath>
         </Reference>
     </ItemGroup>
     <ItemGroup>
@@ -78,7 +78,7 @@
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
     <Target Name="CopyToModsDir" AfterTargets="Build">
-        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(SteamDemeoDir)\Mods" />
-        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(OculusDemeoDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoVrDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoPcDir)\Mods" />
     </Target>
 </Project>

--- a/HouseRules_Core/HouseRules_Core.csproj
+++ b/HouseRules_Core/HouseRules_Core.csproj
@@ -33,23 +33,23 @@
     </PropertyGroup>
     <ItemGroup>
         <Reference Include="0Harmony">
-            <HintPath>$(SteamDemeoDir)\MelonLoader\0Harmony.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\MelonLoader\0Harmony.dll</HintPath>
         </Reference>
         <Reference Include="Assembly-CSharp">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
         </Reference>
         <Reference Include="MelonLoader">
-            <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\MelonLoader\MelonLoader.dll</HintPath>
         </Reference>
         <Reference Include="PhotonRealtime">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\PhotonRealtime.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\PhotonRealtime.dll</HintPath>
         </Reference>
         <Reference Include="PhotonUnityNetworking">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\PhotonUnityNetworking.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\PhotonUnityNetworking.dll</HintPath>
         </Reference>
         <Reference Include="System" />
         <Reference Include="UnityEngine.CoreModule">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
         </Reference>
     </ItemGroup>
     <ItemGroup>
@@ -72,7 +72,7 @@
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
     <Target Name="CopyToModsDir" AfterTargets="Build">
-        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(SteamDemeoDir)\Mods" />
-        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(OculusDemeoDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoVrDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoPcDir)\Mods" />
     </Target>
 </Project>

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -88,20 +88,20 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>$(SteamDemeoDir)\MelonLoader\0Harmony.dll</HintPath>
+      <HintPath>$(DemeoVrDir)\MelonLoader\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MelonLoader">
-      <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
+      <HintPath>$(DemeoVrDir)\MelonLoader\MelonLoader.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="PhotonUnityNetworking">
-      <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\PhotonUnityNetworking.dll</HintPath>
+      <HintPath>$(DemeoVrDir)\demeo_Data\Managed\PhotonUnityNetworking.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(DemeoVrDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -115,7 +115,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="CopyToModsDir" AfterTargets="Build">
-    <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(SteamDemeoDir)\Mods" />
-    <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(OculusDemeoDir)\Mods" />
+    <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoVrDir)\Mods" />
+    <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoPcDir)\Mods" />
   </Target>
 </Project>

--- a/RoomCode/RoomCode.csproj
+++ b/RoomCode/RoomCode.csproj
@@ -33,13 +33,13 @@
     </PropertyGroup>
     <ItemGroup>
         <Reference Include="0Harmony">
-            <HintPath>$(SteamDemeoDir)\MelonLoader\0Harmony.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\MelonLoader\0Harmony.dll</HintPath>
         </Reference>
         <Reference Include="Assembly-CSharp">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
         </Reference>
         <Reference Include="MelonLoader">
-            <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\MelonLoader\MelonLoader.dll</HintPath>
         </Reference>
     </ItemGroup>
     <ItemGroup>
@@ -52,7 +52,7 @@
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
     <Target Name="CopyToModsDir" AfterTargets="Build">
-        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(SteamDemeoDir)\Mods" />
-        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(OculusDemeoDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoVrDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoPcDir)\Mods" />
     </Target>
 </Project>

--- a/RoomFinder/RoomFinder.csproj
+++ b/RoomFinder/RoomFinder.csproj
@@ -33,34 +33,34 @@
     </PropertyGroup>
     <ItemGroup>
         <Reference Include="0Harmony">
-            <HintPath>$(SteamDemeoDir)\MelonLoader\0Harmony.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\MelonLoader\0Harmony.dll</HintPath>
         </Reference>
         <Reference Include="Assembly-CSharp">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
         </Reference>
         <Reference Include="MelonLoader">
-            <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\MelonLoader\MelonLoader.dll</HintPath>
         </Reference>
         <Reference Include="Photon3Unity3D">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Photon3Unity3D.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Photon3Unity3D.dll</HintPath>
         </Reference>
         <Reference Include="PhotonRealtime">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\PhotonRealtime.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\PhotonRealtime.dll</HintPath>
         </Reference>
         <Reference Include="PhotonUnityNetworking">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\PhotonUnityNetworking.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\PhotonUnityNetworking.dll</HintPath>
         </Reference>
         <Reference Include="Unity.TextMeshPro">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Unity.TextMeshPro.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.CoreModule">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.PhysicsModule">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.UI">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.UI.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\UnityEngine.UI.dll</HintPath>
         </Reference>
     </ItemGroup>
     <ItemGroup>
@@ -77,7 +77,7 @@
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
     <Target Name="CopyToModsDir" AfterTargets="Build">
-        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(SteamDemeoDir)\Mods" />
-        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(OculusDemeoDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoVrDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoPcDir)\Mods" />
     </Target>
 </Project>

--- a/SkipIntro/SkipIntro.csproj
+++ b/SkipIntro/SkipIntro.csproj
@@ -35,16 +35,16 @@
     </PropertyGroup>
     <ItemGroup>
         <Reference Include="0Harmony">
-            <HintPath>$(SteamDemeoDir)\MelonLoader\0Harmony.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\MelonLoader\0Harmony.dll</HintPath>
         </Reference>
         <Reference Include="Assembly-CSharp">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
         </Reference>
         <Reference Include="MelonLoader">
-            <HintPath>$(SteamDemeoDir)\MelonLoader\MelonLoader.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\MelonLoader\MelonLoader.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.CoreModule">
-            <HintPath>$(SteamDemeoDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
         </Reference>
     </ItemGroup>
     <ItemGroup>
@@ -54,7 +54,7 @@
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
     <Target Name="CopyToModsDir" AfterTargets="Build">
-        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(SteamDemeoDir)\Mods" />
-        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(OculusDemeoDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoVrDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoPcDir)\Mods" />
     </Target>
 </Project>


### PR DESCRIPTION
Follows in the spirit of https://github.com/orendain/DemeoMods/pull/280.

Originally, the defined paths assumed that developers had both Steam and Oculus versions of the game.  The path that was referenced the most, `SteamDemeoDir` was incorrectly named for most contributors to this project, who mainly develop against the Oculus version of the game.

With the introduction of the PC edition of the game, there are at least 4 possible locations wherein mods could go.

It seems reasonable to not assume developers have both Steam and Oculus versions of the game.  It also seems reasonable that developers would likely have both VR and PC editions of the game, despite their preferred Steam/Oculus platform.

Effectively, this PR is just a naming change.  Developers have always been able to set the path locations to these two fields - but this PR may help improve clarity.

---

Alternatively, instead of `DemeoVrDir` and `DemeoPCDir`, we could go with something even more generic.  E.g.: `DemeoDirPrimary` and `DemeoDirSecondary`.

However, I think there is value in suggesting/assuming that binaries from particular game type (VR vs PC) are the ones used as the main reference, as there may come a time when they diverge enough to keep track of.