### PR TITLE
New rule for controlling the duration of TileEffects.

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -53,6 +53,7 @@
             HR.Rulebook.Register(typeof(StartCardsModifiedRule));
             HR.Rulebook.Register(typeof(StatModifiersOverridenRule));
             HR.Rulebook.Register(typeof(StatusEffectConfigRule));
+            HR.Rulebook.Register(typeof(TileEffectDurationOverriddenRule));
         }
 
         private static void RegisterRulesets()

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Rules\AbilityBackstabAdjustedRule.cs" />
     <Compile Include="Rules\AbilityHealOverriddenRule.cs" />
     <Compile Include="Rules\CardClassRestrictionOverriddenRule.cs" />
+    <Compile Include="Rules\TileEffectDurationOverriddenRule.cs" />
     <Compile Include="Rules\LampTypesOverriddenRule.cs" />
     <Compile Include="Rules\LevelSequenceOverriddenRule.cs" />
     <Compile Include="Rules\PieceUseWhenKilledOverriddenRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -809,3 +809,27 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
     ]
   },
   ```
+
+- __TileEffectDurationOverriden__: Overrides TileEffect durations settings for gas, acid, web etc.
+  - There are five different TileEffects in the game. Gas, Acid, Web, Water and Target.
+  - Overriding the durations allows for TileEffects to last for longer or shorter times.
+  - It is necessary to specify all five effects in the config for this rule, or they will assume a default duration of 9999 rounds.
+  - To configure:
+    - Specify the `TileEfect` (Gas, Acidm etc) of the effect whose duration should be replaced.
+    - Specify an integer representing the new duration in turns.
+
+  ###### _Example JSON config for TileEffectDurationOverriden_
+
+  ```json
+  {
+    "Rule": "TileEffectDurationOverriden",
+    "Config": {
+      "Gas": 3,
+      "Acid": 4,
+      "Web": 2,
+      "Water": 2,
+      "Target": 0,
+    }
+  },
+  ```
+

--- a/HouseRules_Essentials/Rules/TileEffectDurationOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/TileEffectDurationOverriddenRule.cs
@@ -41,23 +41,22 @@
                     nameof(TileEffectState_GetLayerExpireTime_Prefix)));
         }
 
-        private static bool TileEffectState_GetLayerExpireTime_Prefix(ref TileEffect type, ref int __result)
+        private static bool TileEffectState_GetLayerExpireTime_Prefix(TileEffect type, ref int __result)
         {
             if (!_isActivated)
             {
                 return true;
             }
 
-            if (_globalAdjustments.ContainsKey(type))
+            if (!_globalAdjustments.ContainsKey(type))
             {
-                __result = _globalAdjustments[type];
+                return true;
             }
             else
             {
-                __result = 9999;
+                __result = _globalAdjustments[type];
+                return false; // We returned an user-adjusted config.
             }
-
-            return false; // We returned an user-adjusted config.
         }
     }
 }

--- a/HouseRules_Essentials/Rules/TileEffectDurationOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/TileEffectDurationOverriddenRule.cs
@@ -1,0 +1,63 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System.Collections.Generic;
+    using Boardgame;
+    using Boardgame.Board;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Types;
+
+    public sealed class TileEffectDurationOverriddenRule : Rule, IConfigWritable<Dictionary<TileEffect, int>>, IPatchable, IMultiplayerSafe
+    {
+        public override string Description => "Tile Effect durations are overridden.";
+
+        private static Dictionary<TileEffect, int> _globalAdjustments;
+        private static bool _isActivated;
+
+        private readonly Dictionary<TileEffect, int> _adjustments;
+
+
+        public TileEffectDurationOverriddenRule(Dictionary<TileEffect, int> adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        public Dictionary<TileEffect, int> GetConfigObject() => _adjustments;
+
+        protected override void OnActivate(GameContext gameContext)
+        {
+            _globalAdjustments = _adjustments;
+            _isActivated = true;
+        }
+
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
+
+        private static void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(TileEffectState), "GetLayerExpireTime"),
+                prefix: new HarmonyMethod(
+                    typeof(TileEffectDurationOverriddenRule),
+                    nameof(TileEffectState_GetLayerExpireTime_Prefix)));
+        }
+
+        private static bool TileEffectState_GetLayerExpireTime_Prefix(ref TileEffect type, ref int __result)
+        {
+            if (!_isActivated)
+            {
+                return true;
+            }
+
+            if (_globalAdjustments.ContainsKey(type))
+            {
+                __result = _globalAdjustments[type];
+            }
+            else
+            {
+                __result = 9999;
+            }
+
+            return false; // We returned an user-adjusted config.
+        }
+    }
+}


### PR DESCRIPTION
There are five TileEffects in the game - Gas, Acid, Web, Water and Target(unused). 

The durations for each of these are defined in the GetLayerExpireTime function.

This rule overrides that function so that it can accept a user-defined list of expiry times instead.

