### PR TITLE
Enable HouseRules to run on PC edition.

### DIFF
--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -11,6 +11,8 @@
 
     internal class ConfigurationMod : MelonMod
     {
+        private const string DemeoPCEditionString = "Demeo PC Edition";
+
         internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("HouseRules:Configuration");
         internal static readonly ConfigManager ConfigManager = ConfigManager.NewInstance();
 
@@ -54,6 +56,12 @@
 
         public override void OnSceneWasInitialized(int buildIndex, string sceneName)
         {
+            if (MelonUtils.CurrentGameAttribute.Name == DemeoPCEditionString)
+            {
+                Logger.Msg("PC Edition detected. Skipping VR UI loading.");
+                return;
+            }
+
             if (buildIndex == LobbySceneIndex || buildIndex == HangoutsSceneIndex)
             {
                 _ = new GameObject("HouseRules_RulesetSelection", typeof(UI.RulesetSelectionUI));

--- a/HouseRules_Configuration/Properties/AssemblyInfo.cs
+++ b/HouseRules_Configuration/Properties/AssemblyInfo.cs
@@ -39,6 +39,7 @@ using MelonLoader;
 // Melon Loader.
 [assembly: MelonInfo(typeof(ConfigurationMod), "HouseRules: Configuration", HouseRules.BuildVersion.Version, "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
+[assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("574512")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]
 [assembly: MelonAdditionalDependencies("HouseRules_Core")]

--- a/HouseRules_Core/Properties/AssemblyInfo.cs
+++ b/HouseRules_Core/Properties/AssemblyInfo.cs
@@ -39,5 +39,6 @@ using MelonLoader;
 // Melon Loader.
 [assembly: MelonInfo(typeof(CoreMod), "HouseRules: Core", BuildVersion.Version, "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
+[assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("574512")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]

--- a/HouseRules_Essentials/Properties/AssemblyInfo.cs
+++ b/HouseRules_Essentials/Properties/AssemblyInfo.cs
@@ -39,6 +39,7 @@ using MelonLoader;
 // Melon Loader.
 [assembly: MelonInfo(typeof(EssentialsMod), "HouseRules: Essentials", HouseRules.BuildVersion.Version, "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
+[assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("574512")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]
 [assembly: MelonAdditionalDependencies("HouseRules_Core")]


### PR DESCRIPTION
Including just the minimum changes required for now.