### PR TITLE
Fix resetting the original value for adjusted AoE abilities.

### DIFF
--- a/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
@@ -50,7 +50,7 @@
                     throw new InvalidOperationException($"AbilityKey [{replacement.Key}] does not have a corresponding ability.");
                 }
 
-                originals[replacement.Key] = -replacement.Value * 2;
+                originals[replacement.Key] = -replacement.Value;
                 var aoe = Traverse.Create(ability).Field<AreaOfEffect>("areaOfEffect").Value;
                 Traverse.Create(aoe).Field<int>("range").Value += replacement.Value; // Adjust the AOE outline when casting.
                 ability.areaOfEffectRange += replacement.Value; // Adjust value displayed on the card.


### PR DESCRIPTION
Fixes https://github.com/orendain/DemeoMods/issues/303

The cause was that the "original delta", which would get applied after the rule is deactivated, was twice of the modified delta.