### PR TITLE
Fix LevelExitLockedUntilAllEnemiesDefeated rule counting friendly monsters and spider eggs as monsters that must be killed.

### DIFF
--- a/HouseRules_Essentials/Rules/LevelExitLockedUntilAllEnemiesDefeatedRule.cs
+++ b/HouseRules_Essentials/Rules/LevelExitLockedUntilAllEnemiesDefeatedRule.cs
@@ -105,7 +105,7 @@
 
         private static bool IsEnemyRemaining(GameContext gameContext)
         {
-            return gameContext.pieceAndTurnController.GetEnemyPieces().Select(p =>
+            return gameContext.pieceAndTurnController.GetEnemyPieces().Where(p =>
             {
                 if (p.boardPieceId == BoardPieceId.SpiderEgg)
                 {

--- a/HouseRules_Essentials/Rules/LevelExitLockedUntilAllEnemiesDefeatedRule.cs
+++ b/HouseRules_Essentials/Rules/LevelExitLockedUntilAllEnemiesDefeatedRule.cs
@@ -100,12 +100,7 @@
             GameUI.ShowCameraMessage("All enemies have been defeated! You may advance.", 5);
 
             var levelExit = context.pieceAndTurnController.FindFirstPiece(p => p.HasPieceType(PieceType.LevelExit));
-            if (levelExit == null)
-            {
-                return;
-            }
-
-            levelExit.DisableEffectState(EffectStateType.Locked);
+            levelExit?.DisableEffectState(EffectStateType.Locked);
         }
 
         private static bool IsEnemyRemaining(GameContext gameContext)


### PR DESCRIPTION
Part of https://github.com/orendain/DemeoMods/issues/301.