### PR TITLE
Add a `ScheduleResync` method to allow rules to manually schedule resyncs.

### DIFF
--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -228,6 +228,7 @@
             _isNewSpawnPossible = false;
             _isStatusImmunitiesTouched = false;
             _isStatusEffectsTouched = false;
+            _isResyncScheduled = false;
             _gameContext.serializableEventQueue.SendResponseEvent(SerializableEvent.CreateRecovery());
         }
     }

--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -31,7 +31,7 @@
         private static bool _isResyncScheduled;
 
         /// <summary>
-        /// Schedules a resync to be triggered at the next opportunity.
+        /// Schedules a resync to be triggered at the next available opportunity.
         /// </summary>
         internal static void ScheduleResync()
         {

--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -28,6 +28,20 @@
         private static bool _isNewSpawnPossible;
         private static bool _isStatusImmunitiesTouched;
         private static bool _isStatusEffectsTouched;
+        private static bool _isResyncScheduled;
+
+        /// <summary>
+        /// Schedules a resync to be triggered at the next opportunity.
+        /// </summary>
+        internal static void ScheduleResync()
+        {
+            if (!HR.IsRulesetActive)
+            {
+                throw new InvalidOperationException("Can not request resync without an active ruleset.");
+            }
+
+            _isResyncScheduled = true;
+        }
 
         internal static void Patch(Harmony harmony)
         {
@@ -67,7 +81,7 @@
                 return;
             }
 
-            if (HR.SelectedRuleset.ModifiedSyncables == SyncableTrigger.None)
+            if (!_isResyncScheduled && HR.SelectedRuleset.ModifiedSyncables == SyncableTrigger.None)
             {
                 return;
             }
@@ -173,6 +187,11 @@
 
         private static bool IsSyncNeeded()
         {
+            if (_isResyncScheduled)
+            {
+                return true;
+            }
+
             var hasSyncType = (HR.SelectedRuleset.ModifiedSyncables & SyncableTrigger.NewPieceModified) > 0;
             if (hasSyncType && _isNewSpawnPossible)
             {

--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -38,5 +38,10 @@ namespace HouseRules
 
             Logger.Msg($"Selected ruleset: {SelectedRuleset.Name}");
         }
+
+        public static void ScheduleResync()
+        {
+            BoardSyncer.ScheduleResync();
+        }
     }
 }


### PR DESCRIPTION
This will allow rules to trigger resyncs during special circumstances. For example, `LevelExitLockedUntilAllEnemiesDefeatedRule` can trigger the resync after it unlocks the door. In that particular situation, unless a sync occurs, non-host players continue to see the door as locked.