### PR TITLE
Fix the door staying locked for players when using the `LevelExitLockedUntilAllEnemiesDefeated` rule.

### DIFF
--- a/HouseRules_Essentials/Rules/LevelExitLockedUntilAllEnemiesDefeatedRule.cs
+++ b/HouseRules_Essentials/Rules/LevelExitLockedUntilAllEnemiesDefeatedRule.cs
@@ -101,6 +101,7 @@
 
             var levelExit = context.pieceAndTurnController.FindFirstPiece(p => p.HasPieceType(PieceType.LevelExit));
             levelExit?.DisableEffectState(EffectStateType.Locked);
+            HR.ScheduleResync();
         }
 
         private static bool IsEnemyRemaining(GameContext gameContext)


### PR DESCRIPTION
Resolves https://github.com/orendain/DemeoMods/issues/301.