### PR TITLE
Apply partial semver checking when determining if an online version is an update.

### DIFF
--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -134,5 +134,18 @@
             version = tag.Substring(1).Replace("-houserules", string.Empty);
             return true;
         }
+
+        /// <summary>
+        /// Returns true if a newer release is known to be available, false otherwise.
+        /// </summary>
+        internal static bool IsUpdateAvailable()
+        {
+            if (string.IsNullOrEmpty(ConfigurationMod.LatestHouseRulesVersion))
+            {
+                return false;
+            }
+
+            return ConfigurationMod.LatestHouseRulesVersion != BuildVersion.Version;
+        }
     }
 }

--- a/HouseRules_Configuration/UI/RulesetSelectionUI.cs
+++ b/HouseRules_Configuration/UI/RulesetSelectionUI.cs
@@ -56,20 +56,20 @@
                 Quaternion.Euler(-90, 0, 0); // Un-flip card from it's default face-up position.
             _background.transform.localScale = new Vector3(3.75f, 1, 2.5f);
 
-            var menuTitleText = "HouseRules";
-            if (ConfigurationMod.LatestHouseRulesVersion != BuildVersion.Version)
-            {
-                ConfigurationMod.Logger.Warning($"Using {BuildVersion.Version} but the latest release is {ConfigurationMod.LatestHouseRulesVersion}");
-                menuTitleText = $"Legacy {BuildVersion.Version}";
-            }
-
-            var menuTitle = _uiHelper.CreateMenuHeaderText(menuTitleText);
+            var menuTitle = _uiHelper.CreateMenuHeaderText("HouseRules");
             menuTitle.transform.SetParent(this.transform, worldPositionStays: false);
             menuTitle.transform.localPosition = new Vector3(0, 5.95f, UiHelper.DefaultTextZShift);
 
             var selectionPanel = _rulesetSelectionPanel.Panel;
             selectionPanel.transform.SetParent(this.transform, worldPositionStays: false);
             selectionPanel.transform.localPosition = new Vector3(0, 2.5f, 0);
+
+            var versionMessage = ConfigurationMod.IsUpdateAvailable()
+                ? $"v{BuildVersion.Version} >>> new update available! <<<"
+                : $"v{BuildVersion.Version}";
+            var versionText = _uiHelper.CreateLabelText(versionMessage);
+            versionText.transform.SetParent(this.transform, worldPositionStays: false);
+            versionText.transform.localPosition = new Vector3(0, -15f, UiHelper.DefaultTextZShift);
 
             // TODO(orendain): Fix so that ray interacts with entire object.
             this.gameObject.AddComponent<BoxCollider>();

--- a/HouseRules_Configuration/UI/RulesetSelectionUI.cs
+++ b/HouseRules_Configuration/UI/RulesetSelectionUI.cs
@@ -64,12 +64,16 @@
             selectionPanel.transform.SetParent(this.transform, worldPositionStays: false);
             selectionPanel.transform.localPosition = new Vector3(0, 2.5f, 0);
 
-            var versionMessage = ConfigurationMod.IsUpdateAvailable()
-                ? $"v{BuildVersion.Version} >>> new update available! <<<"
-                : $"v{BuildVersion.Version}";
-            var versionText = _uiHelper.CreateLabelText(versionMessage);
+            var versionText = _uiHelper.CreateLabelText($"v{BuildVersion.Version}");
             versionText.transform.SetParent(this.transform, worldPositionStays: false);
-            versionText.transform.localPosition = new Vector3(0, -15f, UiHelper.DefaultTextZShift);
+            versionText.transform.localPosition = new Vector3(-7, -15.85f, UiHelper.DefaultTextZShift);
+
+            if (ConfigurationMod.IsUpdateAvailable())
+            {
+                var updateText = _uiHelper.CreateLabelText("NEW UPDATE AVAILABLE!");
+                updateText.transform.SetParent(this.transform, worldPositionStays: false);
+                updateText.transform.localPosition = new Vector3(4.8f, -15.85f, UiHelper.DefaultTextZShift);
+            }
 
             // TODO(orendain): Fix so that ray interacts with entire object.
             this.gameObject.AddComponent<BoxCollider>();


### PR DESCRIPTION
So as not to require an additional library to bundle, this PR introduces its own partial semver checking.

"Partial" meaning that this check supports only:
- Periods delimiters (`.`)
- Integer identifiers

An invalid pattern (ones that do not follow the two rules above) will result in `IsUpdateAvailable()` returning false (and a log entry).

The following truth table shows results:

| Client Version | Online Version | IsUpdateAvailable() |
| --- | ----------- | ----------- |
| 1.2 | 1.3.0 | True |
| 1.2.0 | 1.3.0 | True |
| 1.2.9.9 | 1.3.0 | True |
| 1.3 | 1.3.0 | False |
| 1.3.0 | 1.3.0 | False |
| 1.3.0.0 | 1.3.0 | False |
| 1.4 | 1.3.0 | False |
| hello | 1.3.0 | False |
| 1.3.0-SNAPSHOT | 1.3.0 | False |
| 0.0 | hello | False |