### PR TITLE
Improve performance of the board syncing feature.

### DIFF
--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -86,7 +86,7 @@
             var isNewPieceCheckRequired = (HR.SelectedRuleset.ModifiedSyncables & SyncableTrigger.NewPieceModified) > 0;
             if (isNewPieceCheckRequired)
             {
-                if (CanEventRepresentNewSpawn(serializableEvent))
+                if (CanRepresentNewSpawn(serializableEvent))
                 {
                     _isSyncScheduled = true;
                 }
@@ -123,7 +123,7 @@
             }
         }
 
-        private static bool CanEventRepresentNewSpawn(SerializableEvent serializableEvent)
+        private static bool CanRepresentNewSpawn(SerializableEvent serializableEvent)
         {
             switch (serializableEvent.type)
             {
@@ -133,15 +133,15 @@
                 case SerializableEvent.Type.SlimeFusion:
                     return true;
                 case SerializableEvent.Type.OnAbilityUsed:
-                    return CanAbilityEventRepresentNewSpawn((SerializableEventOnAbilityUsed)serializableEvent);
+                    return CanRepresentNewSpawn((SerializableEventOnAbilityUsed)serializableEvent);
                 case SerializableEvent.Type.PieceDied:
-                    return CanPieceDiedEventRepresentNewSpawn((SerializableEventPieceDied)serializableEvent);
+                    return CanRepresentNewSpawn((SerializableEventPieceDied)serializableEvent);
                 default:
                     return false;
             }
         }
 
-        private static bool CanAbilityEventRepresentNewSpawn(SerializableEventOnAbilityUsed onAbilityUsedEvent)
+        private static bool CanRepresentNewSpawn(SerializableEventOnAbilityUsed onAbilityUsedEvent)
         {
             var abilityKey = Traverse.Create(onAbilityUsedEvent).Field<AbilityKey>("abilityKey").Value;
             switch (abilityKey)
@@ -171,7 +171,7 @@
             return isSpawnAbility || isLampAbility;
         }
 
-        private static bool CanPieceDiedEventRepresentNewSpawn(SerializableEventPieceDied pieceDiedEvent)
+        private static bool CanRepresentNewSpawn(SerializableEventPieceDied pieceDiedEvent)
         {
             foreach (var pieceId in pieceDiedEvent.deadPieces)
             {

--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -28,19 +28,19 @@
         private static bool _isNewSpawnPossible;
         private static bool _isStatusImmunitiesTouched;
         private static bool _isStatusEffectsTouched;
-        private static bool _isResyncScheduled;
+        private static bool _isSyncScheduled;
 
         /// <summary>
-        /// Schedules a resync to be triggered at the next available opportunity.
+        /// Schedules a sync to be triggered at the next available opportunity.
         /// </summary>
-        internal static void ScheduleResync()
+        internal static void ScheduleSync()
         {
             if (!HR.IsRulesetActive)
             {
-                throw new InvalidOperationException("Can not request resync without an active ruleset.");
+                throw new InvalidOperationException("Can not request sync without an active ruleset.");
             }
 
-            _isResyncScheduled = true;
+            _isSyncScheduled = true;
         }
 
         internal static void Patch(Harmony harmony)
@@ -81,7 +81,7 @@
                 return;
             }
 
-            if (!_isResyncScheduled && HR.SelectedRuleset.ModifiedSyncables == SyncableTrigger.None)
+            if (!_isSyncScheduled && HR.SelectedRuleset.ModifiedSyncables == SyncableTrigger.None)
             {
                 return;
             }
@@ -187,7 +187,7 @@
 
         private static bool IsSyncNeeded()
         {
-            if (_isResyncScheduled)
+            if (_isSyncScheduled)
             {
                 return true;
             }
@@ -228,7 +228,7 @@
             _isNewSpawnPossible = false;
             _isStatusImmunitiesTouched = false;
             _isStatusEffectsTouched = false;
-            _isResyncScheduled = false;
+            _isSyncScheduled = false;
             _gameContext.serializableEventQueue.SendResponseEvent(SerializableEvent.CreateRecovery());
         }
     }

--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -87,17 +87,10 @@
                 }
             }
 
-            if (!_isSyncScheduled)
+            if (_isSyncScheduled && IsSyncOpportunity(serializableEvent))
             {
-                return;
+                SyncBoard();
             }
-
-            if (!IsSyncOpportunity(serializableEvent))
-            {
-                return;
-            }
-
-            SyncBoard();
         }
 
         private static void Piece_IsImmuneToStatusEffect_Postfix()

--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -78,13 +78,8 @@
                 return;
             }
 
-            if (!_isSyncScheduled && HR.SelectedRuleset.ModifiedSyncables == SyncableTrigger.None)
-            {
-                return;
-            }
-
             var isNewPieceCheckRequired = (HR.SelectedRuleset.ModifiedSyncables & SyncableTrigger.NewPieceModified) > 0;
-            if (isNewPieceCheckRequired)
+            if (isNewPieceCheckRequired && !_isSyncScheduled)
             {
                 if (CanRepresentNewSpawn(serializableEvent))
                 {

--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -79,12 +79,9 @@
             }
 
             var isNewPieceCheckRequired = (HR.SelectedRuleset.ModifiedSyncables & SyncableTrigger.NewPieceModified) > 0;
-            if (isNewPieceCheckRequired && !_isSyncScheduled)
+            if (!_isSyncScheduled && isNewPieceCheckRequired && CanRepresentNewSpawn(serializableEvent))
             {
-                if (CanRepresentNewSpawn(serializableEvent))
-                {
-                    _isSyncScheduled = true;
-                }
+                _isSyncScheduled = true;
             }
 
             if (_isSyncScheduled && IsSyncOpportunity(serializableEvent))

--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -39,9 +39,9 @@ namespace HouseRules
             Logger.Msg($"Selected ruleset: {SelectedRuleset.Name}");
         }
 
-        public static void ScheduleResync()
+        public static void ScheduleBoardSync()
         {
-            BoardSyncer.ScheduleResync();
+            BoardSyncer.ScheduleSync();
         }
     }
 }

--- a/HouseRules_Essentials/Rules/LevelExitLockedUntilAllEnemiesDefeatedRule.cs
+++ b/HouseRules_Essentials/Rules/LevelExitLockedUntilAllEnemiesDefeatedRule.cs
@@ -101,7 +101,7 @@
 
             var levelExit = context.pieceAndTurnController.FindFirstPiece(p => p.HasPieceType(PieceType.LevelExit));
             levelExit?.DisableEffectState(EffectStateType.Locked);
-            HR.ScheduleResync();
+            HR.ScheduleBoardSync();
         }
 
         private static bool IsEnemyRemaining(GameContext gameContext)


### PR DESCRIPTION
Tried to split changes into commits that may be easier to digest.

**Changes:**
- [Rename "resync" to "boardSync" for consistency and clarity."](https://github.com/orendain/DemeoMods/pull/310/commits/9653fa1c3a22e36fcd627c8acb41c592aa354841)
- [Combine all sync flags into a single sync flag. Allow setting this flag only if the active ruleset has the corresponding sync type.](https://github.com/orendain/DemeoMods/pull/310/commits/2d9fad286b667008a81d4d8d6e3db14124296f8d)
  - Checking for sync types _before_ processing a particular event allows us to skip processing if the ruleset doesn't act on it anyway.
- [Make variable names more specific.](https://github.com/orendain/DemeoMods/pull/310/commits/d80bfd62335c0b606f9238029ef4c9a047bd480d)
- [Simplify function names.](https://github.com/orendain/DemeoMods/pull/310/commits/62812605e910c8fb5d3580d9f1646f4dda9cedb4)
- [Collapse now-duplicated checks into one that only processes an event if a check is required _and_ a sync is not already scheduled.](https://github.com/orendain/DemeoMods/pull/310/commits/4b6dba34eb92f7902d6b44f14d0f91fce921c707)
- [Collapse two guard clauses into one non-guard clause, to improve readability and intent of the code.](https://github.com/orendain/DemeoMods/pull/310/commits/81a07037d66f0ef968ee4a9fcc7c067db4387501)
- [Collapse two conditionals into one.](https://github.com/orendain/DemeoMods/pull/310/commits/d3932404790ef5eb298203db86a165f3f40b865b)