### PR TITLE
Modify lamp type rule to support arbitrary number of levels.

### DIFF
--- a/HouseRules_Essentials/Rules/LampTypesOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/LampTypesOverriddenRule.cs
@@ -7,28 +7,21 @@
     using HarmonyLib;
     using HouseRules.Types;
 
-    public sealed class LampTypesOverriddenRule : Rule, IConfigWritable<LampTypesOverriddenRule.LampConfig>, IPatchable, IMultiplayerSafe
+    public sealed class LampTypesOverriddenRule : Rule, IConfigWritable<Dictionary<int, List<BoardPieceId>>>, IPatchable, IMultiplayerSafe
     {
         public override string Description => "Lamp types are overridden.";
 
-        private static LampTypesOverriddenRule.LampConfig _globalAdjustments;
+        private static Dictionary<int, List<BoardPieceId>> _globalAdjustments;
         private static bool _isActivated;
 
-        private readonly LampTypesOverriddenRule.LampConfig _adjustments;
+        private readonly Dictionary<int, List<BoardPieceId>> _adjustments;
 
-        public struct LampConfig
-        {
-            public List<BoardPieceId> Floor1Lamps;
-            public List<BoardPieceId> Floor2Lamps;
-            public List<BoardPieceId> Floor3Lamps;
-        }
-
-        public LampTypesOverriddenRule(LampTypesOverriddenRule.LampConfig adjustments)
+        public LampTypesOverriddenRule(Dictionary<int, List<BoardPieceId>> adjustments)
         {
             _adjustments = adjustments;
         }
 
-        public LampTypesOverriddenRule.LampConfig GetConfigObject() => _adjustments;
+        public Dictionary<int, List<BoardPieceId>> GetConfigObject() => _adjustments;
 
         protected override void OnActivate(GameContext gameContext)
         {
@@ -54,21 +47,13 @@
                 return true;
             }
 
-            var floorIndex = MotherTracker.motherTrackerData.floorIndex;
-
-            if (floorIndex == 0)
+            var floorIndex = MotherTracker.motherTrackerData.floorIndex + 1;
+            if (!_globalAdjustments.ContainsKey(floorIndex))
             {
-                __result = _globalAdjustments.Floor1Lamps.ToArray();
-            }
-            else if (floorIndex == 1)
-            {
-                __result = _globalAdjustments.Floor2Lamps.ToArray();
-            }
-            else
-            {
-                __result = _globalAdjustments.Floor3Lamps.ToArray();
+                return true;
             }
 
+            __result = _globalAdjustments[floorIndex].ToArray();
             return false; // We returned an user-adjusted config.
         }
     }

--- a/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceConfigAdjustedRule.cs
@@ -43,7 +43,7 @@
 
         protected override void OnDeactivate(GameContext gameContext)
         {
-                ReplaceExistingProperties(_originals);
+            ReplaceExistingProperties(_originals);
         }
 
         /// <summary>

--- a/HouseRules_Essentials/Rulesets/EarthWindAndFire.cs
+++ b/HouseRules_Essentials/Rulesets/EarthWindAndFire.cs
@@ -220,28 +220,34 @@
 
             var enemyRespawnRule = new EnemyRespawnDisabledRule(true);
 
-            var lampTypesRule = new LampTypesOverriddenRule(new LampTypesOverriddenRule.LampConfig
+            var lampTypesRule = new LampTypesOverriddenRule(new Dictionary<int, List<BoardPieceId>>
             {
-                Floor1Lamps = new List<BoardPieceId>
                 {
-                    BoardPieceId.OilLamp,
-                    BoardPieceId.OilLamp,
-                    BoardPieceId.OilLamp,
-                    BoardPieceId.VortexLamp,
+                    1, new List<BoardPieceId>
+                    {
+                        BoardPieceId.OilLamp,
+                        BoardPieceId.OilLamp,
+                        BoardPieceId.OilLamp,
+                        BoardPieceId.VortexLamp,
+                    }
                 },
-                Floor2Lamps = new List<BoardPieceId>
                 {
-                    BoardPieceId.GasLamp,
-                    BoardPieceId.GasLamp,
-                    BoardPieceId.GasLamp,
-                    BoardPieceId.VortexLamp,
+                    2, new List<BoardPieceId>
+                    {
+                        BoardPieceId.GasLamp,
+                        BoardPieceId.GasLamp,
+                        BoardPieceId.GasLamp,
+                        BoardPieceId.VortexLamp,
+                    }
                 },
-                Floor3Lamps = new List<BoardPieceId>
                 {
-                    BoardPieceId.IceLamp,
-                    BoardPieceId.IceLamp,
-                    BoardPieceId.IceLamp,
-                    BoardPieceId.VortexLamp,
+                    3, new List<BoardPieceId>
+                    {
+                        BoardPieceId.IceLamp,
+                        BoardPieceId.IceLamp,
+                        BoardPieceId.IceLamp,
+                        BoardPieceId.VortexLamp,
+                    }
                 },
             });
 


### PR DESCRIPTION
With the level sequence rule now supporting an arbitrary number of levels, the lamp rule was still only supporting a max of three lamp configurations.

This PR:
- Allows setting lamps for any number of levels.
- Allows user to not have to specify an override for a particular floor, by leaving it out from the config.

Testing ruleset:
- First floor should have all ice lamps.
- Second floor should have all oil lamps.
- Third floor is not affected.
- Fourth floor should have all gas lamps.
- Fifth floor should have all vortex lamps.
- Sixth floor is not affected.

```json
{
  "Name": "Testing",
  "Description": "Testing.",
  "Rules": [
    {
      "Rule": "LampTypesOverridden",
      "Config": {
        "1": [ "IceLamp" ],
        "2": [ "OilLamp" ],
        "4": [ "GasLamp" ],
        "5": [ "VortexLamp" ]
      }
    },
    {
      "Rule": "LevelSequenceOverridden",
      "Config": [
        "ElvenFloor01", "ElvenFloor13", "ForestFloor08",
        "ElvenFloor01", "ElvenFloor13", "ForestFloor08"
      ]
    }
  ]
}
```