### PR TITLE
Typofix - ScheduleResync method got renamed.

### DIFF
--- a/HouseRules_Core/HR.cs
+++ b/HouseRules_Core/HR.cs
@@ -12,7 +12,7 @@ namespace HouseRules
 
         internal static bool IsRulesetActive => LifecycleDirector.IsRulesetActive;
 
-        public static void ScheduleResync() => BoardSyncer.ScheduleResync();
+        public static void ScheduleResync() => BoardSyncer.ScheduleSync();
 
         public static void SelectRuleset(string ruleset)
         {


### PR DESCRIPTION
I just pulled main and tried to build, but failed.

This PR fixes that.