### PR TITLE
Store replenishFrequency in the unused bits of Inventory 'flags'

### DIFF
--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -716,7 +716,8 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
   - To configure:
     - Specify the [BoardPieceId](../docs/SettingsReference.md#boardpieceids) of the piece to replace the starting card hand of.
     - Specify the [AbilityKey](../docs/SettingsReference.md#boardpieceids) of the cards to add to the piece's hand.
-    - Specify `true` if the card should replenish, or `false` if it should not.
+    - Specify integer value for replenish frequency. 0=NoReplenish, 1=EveryTurn, 2=Every 2 Turns etc
+    - Max replenish frequency value is 7 
 
   ###### _Example JSON config for StartCardsModified_
 
@@ -725,28 +726,28 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
     "Rule": "StartCardsModified",
     "Config": {
       "HeroGuardian": [
-        { "Card": "HealingPotion", "IsReplenishable": false },
-        { "Card": "ReplenishArmor", "IsReplenishable": true },
-        { "Card": "WhirlwindAttack", "IsReplenishable": true },
-        { "Card": "PiercingThrow", "IsReplenishable": false },
-        { "Card": "CoinFlip", "IsReplenishable": false },
-        { "Card": "TheBehemoth", "IsReplenishable": false },
-        { "Card": "SwordOfAvalon", "IsReplenishable": false },
+        { "Card": "HealingPotion", "IsReplenishable": 0 },
+        { "Card": "ReplenishArmor", "IsReplenishable": 1 },
+        { "Card": "WhirlwindAttack", "IsReplenishable": 1 },
+        { "Card": "PiercingThrow", "IsReplenishable": 0 },
+        { "Card": "CoinFlip", "IsReplenishable": 0 },
+        { "Card": "TheBehemoth", "IsReplenishable": 0 },
+        { "Card": "SwordOfAvalon", "IsReplenishable": 0 },
       ],
       "HeroHunter": [
-        { "Card": "HealingPotion", "IsReplenishable": false },
-        { "Card": "Arrow", "IsReplenishable": true },
-        { "Card": "Arrow", "IsReplenishable": true },
-        { "Card": "CoinFlip", "IsReplenishable": false },
-        { "Card": "DropChest", "IsReplenishable": false },
+        { "Card": "HealingPotion", "IsReplenishable": 0 },
+        { "Card": "Arrow", "IsReplenishable": 1 },
+        { "Card": "Arrow", "IsReplenishable": 1 },
+        { "Card": "CoinFlip", "IsReplenishable": 0 },
+        { "Card": "DropChest", "IsReplenishable": 0 },
       ],
       "HeroSorcerer": [
-        { "Card": "HealingPotion", "IsReplenishable": false },
-        { "Card": "Zap", "IsReplenishable": true },
-        { "Card": "WhirlwindAttack", "IsReplenishable": true },
-        { "Card": "Freeze", "IsReplenishable": false },
-        { "Card": "Fireball", "IsReplenishable": false },
-        { "Card": "CallCompanion", "IsReplenishable": false },
+        { "Card": "HealingPotion", "IsReplenishable": 0 },
+        { "Card": "Zap", "IsReplenishable": 1 },
+        { "Card": "WhirlwindAttack", "IsReplenishable": 1 },
+        { "Card": "Freeze", "IsReplenishable": 0 },
+        { "Card": "Fireball", "IsReplenishable": 0 },
+        { "Card": "CallCompanion", "IsReplenishable": 0 },
       ],
     }
   },

--- a/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
@@ -21,7 +21,7 @@
         public struct CardConfig
         {
             public AbilityKey Card;
-            public bool IsReplenishable;
+            public int IsReplenishable;
         }
 
         public StartCardsModifiedRule(Dictionary<BoardPieceId, List<CardConfig>> heroStartCards)
@@ -47,6 +47,50 @@
                 postfix: new HarmonyMethod(
                     typeof(StartCardsModifiedRule),
                     nameof(Piece_CreatePiece_Postfix)));
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Inventory), "RestoreReplenishables"),
+                prefix: new HarmonyMethod(
+                    typeof(StartCardsModifiedRule),
+                    nameof(Inventory_RestoreReplenishables_Prefix)));
+        }
+
+        private static bool Inventory_RestoreReplenishables_Prefix(bool __result, Piece piece)
+        {
+            if (!_isActivated)
+            {
+                return true;
+            }
+
+            __result = false;
+            for (int i = 0; i < piece.inventory.Items.Count; i++)
+            {
+                Inventory.Item value = piece.inventory.Items[i];
+                var targetRefresh = (value.flags & 224) >> 5;
+                var countdown = (value.flags & 28) >> 2;
+                if (piece.inventory.Items[i].IsReplenishing && (!piece.HasEffectState(EffectStateType.Stealthed) || piece.inventory.Items[i].abilityKey != AbilityKey.Sneak))
+                {
+                    // If countdown was zero when we got called, then we need to set it.
+                    if (countdown == 0)
+                    {
+                        countdown = targetRefresh;
+                    }
+
+                    // If we reached our desired turn count we can unset isReplenishing and return true
+                    if (countdown == 1)
+                    {
+                        value.flags &= -3; // unsets isReplenishing (bit1 ) allowing card to be used again.
+                        __result = true;
+                    }
+
+                    countdown -= 1;
+                    value.flags &= 227; // Zero only the countdown bits using a bitmask
+                    value.flags |= countdown << 2; // OR with countdown to set them again.
+                    piece.inventory.Items[i] = value;
+                    // piece.inventory.needSync = true;
+                }
+            }
+
+            return false;
         }
 
         private static void Piece_CreatePiece_Postfix(ref Piece __result)
@@ -71,7 +115,26 @@
 
             foreach (var card in _globalHeroStartCards[piece.boardPieceId])
             {
-                piece.TryAddAbilityToInventory(card.Card, isReplenishable: card.IsReplenishable);
+                // flag bits
+                // 0 : isReplenishable
+                // 1 : isReplenishing
+                // 2-4 : ReplenishCounter - 3-bit range used by RestoreReplenishables for counting rounds.
+                // 5-7 : ReplenishFrequency - 3-bit number, user-configured target.
+                int flags = 0;
+                if (card.IsReplenishable > 0)
+                {
+                    flags = 1;
+                    int refreshFrequency = card.IsReplenishable;
+                    flags |= refreshFrequency << 5; // logical or with refreshFrequency shifted 5 bits to the left to become ReplenishFrequency bits 5-7
+                }
+
+                piece.inventory.Items.Add(new Inventory.Item
+                {
+                    abilityKey = card.Card,
+                    flags = flags,
+                    originalOwner = -1,
+                });
+                // piece.inventory.needSync = true;
             }
         }
 
@@ -79,7 +142,7 @@
         {
             foreach (var startCards in heroStartCards.Values)
             {
-                if (startCards.Count(c => c.IsReplenishable) > 2)
+                if (startCards.Count(c => c.IsReplenishable > 0) > 2)
                 {
                     throw new ArgumentException("Only 2 replenishable cards allowed.");
                 }

--- a/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
@@ -124,7 +124,7 @@
                 if (card.IsReplenishable > 0)
                 {
                     flags = 1;
-                    int refreshFrequency = card.IsReplenishable;
+                    int refreshFrequency = (card.IsReplenishable < 0) ? 0 : (card.IsReplenishable > 7) ? 7 : card.IsReplenishable; // Clamp 0-7 range.
                     flags |= refreshFrequency << 5; // logical or with refreshFrequency shifted 5 bits to the left to become ReplenishFrequency bits 5-7
                 }
 

--- a/HouseRules_Essentials/Rulesets/Arachnophobia.cs
+++ b/HouseRules_Essentials/Rulesets/Arachnophobia.cs
@@ -17,47 +17,47 @@
 
             var bardCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.CourageShanty, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.IceLamp, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.SongOfRecovery, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HurricaneAnthem, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.ShatteringVoice, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.CourageShanty, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.IceLamp, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.SongOfRecovery, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HurricaneAnthem, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.ShatteringVoice, IsReplenishable = 0 },
             };
             var guardianCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.ReplenishArmor, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Bone, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.WhirlwindAttack, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PiercingThrow, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.ReplenishArmor, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Bone, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.WhirlwindAttack, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PiercingThrow, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = 0 },
             };
             var hunterCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Arrow, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PoisonedTip, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HailOfArrows, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.CallCompanion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Arrow, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PoisonedTip, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HailOfArrows, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.CallCompanion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = 0 },
             };
             var assassinCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PanicPowder, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.BoobyTrap, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PoisonBomb, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PanicPowder, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.BoobyTrap, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PoisonBomb, IsReplenishable = 0 },
             };
             var sorcererCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Zap, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.OilLamp, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HeavensFury, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DetectEnemies, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Zap, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.OilLamp, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HeavensFury, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DetectEnemies, IsReplenishable = 0 },
             };
             var startingCardsRule = new StartCardsModifiedRule(new Dictionary<BoardPieceId, List<StartCardsModifiedRule.CardConfig>>
             {

--- a/HouseRules_Essentials/Rulesets/EarthWindAndFire.cs
+++ b/HouseRules_Essentials/Rulesets/EarthWindAndFire.cs
@@ -16,48 +16,48 @@
 
             var guardianCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HurricaneAnthem, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Electricity, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HurricaneAnthem, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Electricity, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = 0 },
             };
             var hunterCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HurricaneAnthem, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Electricity, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HurricaneAnthem, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Electricity, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = 0 },
             };
             var sorcererCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HurricaneAnthem, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Electricity, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HurricaneAnthem, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Electricity, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = 0 },
             };
             var assassinCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HurricaneAnthem, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Electricity, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HurricaneAnthem, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Electricity, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = 0 },
             };
             var bardCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HurricaneAnthem, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Electricity, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HurricaneAnthem, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Electricity, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = 0 },
             };
             var startingCardsRule = new StartCardsModifiedRule(new Dictionary<BoardPieceId, List<StartCardsModifiedRule.CardConfig>>
             {

--- a/HouseRules_Essentials/Rulesets/HuntersParadiseRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/HuntersParadiseRuleset.cs
@@ -15,9 +15,9 @@
 
             var startCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.CallCompanion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.SummonElemental, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HuntersMark, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.CallCompanion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.SummonElemental, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HuntersMark, IsReplenishable = 1 },
             };
             var startingCardsRule = new StartCardsModifiedRule(
                 new Dictionary<BoardPieceId, List<StartCardsModifiedRule.CardConfig>>

--- a/HouseRules_Essentials/Rulesets/LuckyDip.cs
+++ b/HouseRules_Essentials/Rulesets/LuckyDip.cs
@@ -17,45 +17,45 @@
 
             var bardCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.CourageShanty, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.WebBomb, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.SongOfRecovery, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.CourageShanty, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.WebBomb, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.SongOfRecovery, IsReplenishable = 0 },
             };
             var guardianCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.ReplenishArmor, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Bone, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.ReplenishArmor, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Bone, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = 0 },
             };
             var hunterCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Arrow, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PoisonedTip, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Arrow, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PoisonedTip, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = 0 },
             };
             var assassinCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PanicPowder, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PanicPowder, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = 0 },
             };
             var sorcererCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Zap, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Torch, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Zap, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Torch, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = 0 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DropChest, IsReplenishable = 0 },
             };
             var startingCardsRule = new StartCardsModifiedRule(new Dictionary<BoardPieceId, List<StartCardsModifiedRule.CardConfig>>
             {

--- a/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
@@ -14,28 +14,28 @@
 
             var bardCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Vortex, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.CourageShanty, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Vortex, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.CourageShanty, IsReplenishable = 1 },
             };
             var guardianCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Vortex, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.ReplenishArmor, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Vortex, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.ReplenishArmor, IsReplenishable = 1 },
             };
             var hunterCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Vortex, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Arrow, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Vortex, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Arrow, IsReplenishable = 1 },
             };
             var assassinCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Vortex, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Vortex, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = 1 },
             };
             var sorcererCards = new List<StartCardsModifiedRule.CardConfig>
             {
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Vortex, IsReplenishable = true },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Zap, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Vortex, IsReplenishable = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Zap, IsReplenishable = 1 },
             };
             var startingCardsRule = new StartCardsModifiedRule(new Dictionary<BoardPieceId, List<StartCardsModifiedRule.CardConfig>>
             {


### PR DESCRIPTION
# Allow card replenish frequencies to be user-configured.

This PR is in response to #296. **Feature idea: card replenishing that takes more than one turn**

:construction:**This is a breaking change for any JSON rulesets using StartCardsModified**:construction: due to the change from `bool` to `int` for IsReplenishable within the `CardConfig` struct.

This PR makes use of six of the unused bits in the `flags` integer register in order to store 3-bit values for `refreshFrequency` and `countdown`.
 
// flag bits
// 0 : isReplenishable
// 1 : isReplenishing
// 2-4 : ReplenishCounter - 3-bit range used by RestoreReplenishables for counting rounds.
// 5-7 : ReplenishFrequency - 3-bit number, user-configured target.

I wanted to get this PR'd early to get some fresh reviewer eyes suggesting improvements. 

I made changes to the `SetInventory` method so that instead of calling `piece.TryAddAbilityToInventory` we manipulate `piece.inventory.Items` directly, allowing us to set the flags to include the refreshFrequency target in bits 5-7. However, I'm unable to then set `piece.inventory.needsSync = true` as it's `readOnly` - This may mean that I've broken things for multiplayer (which I haven't tested). This needs testing, and if I have broken things then some advice on how to set the readonly piece.inventory.needsSync would be appreciated.

I prefix patched `RestoreReplenishables` so that it could handle bitwise operations for the `ReplenishCounter` and `ReplenishFrequency` bits. The logic in here is somewhat convoluted and when combined with all of the bitwise operations it is pretty confusing to follow. Amazingly it does all appear to be working correctly (in the limited testing I've done). I'm pretty sure there will be some room for improvement here.

During my testing, I was tweaking the Arachnophobia ruleset's Hunter so that his two different Arrow types had different refresh intervals. I don't _think_ that I've broken 'Sneak', but I also haven't confirmed that. 

## Suggested JSON for testing
 ```json
  {
    "Rule": "StartCardsModified",
    "Config": {
      "HeroHunter": [
        { "Card": "HealingPotion", "IsReplenishable": 0 },
        { "Card": "Arrow", "IsReplenishable": 1 },
        { "Card": "PoisonedTip", "IsReplenishable": 2 },
        { "Card": "CoinFlip", "IsReplenishable": 0 },
        { "Card": "DropChest", "IsReplenishable": 0 },
      ],
    }
  },
  ```

