### PR TITLE
Its a trap ruleset

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -62,6 +62,7 @@
             HR.Rulebook.Register(LuckyDip.Create());
             HR.Rulebook.Register(TheSwirlRuleset.Create());
             HR.Rulebook.Register(BeatTheClockRuleset.Create());
+            HR.Rulebook.Register(ItsATrapRuleset.Create());
             HR.Rulebook.Register(HuntersParadiseRuleset.Create());
             HR.Rulebook.Register(DifficultyEasyRuleset.Create());
             HR.Rulebook.Register(DifficultyHardRuleset.Create());

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Rulesets\DifficultyHardRuleset.cs" />
     <Compile Include="Rulesets\DifficultyLegendaryRuleset.cs" />
     <Compile Include="Rulesets\HuntersParadiseRuleset.cs" />
+    <Compile Include="Rulesets\ItsATrapRuleset.cs" />
     <Compile Include="Rulesets\LuckyDip.cs" />
     <Compile Include="Rulesets\QuickAndDeadRuleset.cs" />
     <Compile Include="Rulesets\NoSurprisesRuleset.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -18,6 +18,7 @@ HouseRules API.
 - __🎲LuckyDip🎲__ : Players each start with two 'Drop Chest' cards instead of their normal
   starting cards, meaning that no two games start the same. Many potions have AOE effect, because it's rude not to share.
   Many other changes included for faster gameplay with an aim of around 90 minutes per game.
+- __💣It's A Trap💣__ : Build fiendiesh traps for your enemies and lure them to their deaths, but do try not to kill your friends. Lamps and BoobyTraps aplenty. Enemies cannot open doors, DetectEnemies/EyeOfAvalon & Torch will not be attacked, Stealth & TileEffect durations extended.
 - __The Swirl__ : Only poison, fireballs and vortexes. Health and POIs aplenty, but must defeat all enemies to escape.
 - __Beat The Clock__ : Ultra health. Ultra card recycling. Only 15 rounds to escape...
 - __Hunter's Paradise__ : Pets, pets, pets! And hunter's mark.

--- a/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
@@ -21,7 +21,8 @@
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.OilLamp, IsReplenishable = false },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.GasLamp, IsReplenishable = false },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.IceLamp, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.VortexLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DetectEnemies, IsReplenishable = false },
             };
             var guardianCards = new List<StartCardsModifiedRule.CardConfig>
             {
@@ -30,7 +31,7 @@
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.OilLamp, IsReplenishable = false },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.GasLamp, IsReplenishable = false },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.IceLamp, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.VortexLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DetectEnemies, IsReplenishable = false },
             };
             var hunterCards = new List<StartCardsModifiedRule.CardConfig>
             {
@@ -39,7 +40,7 @@
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.OilLamp, IsReplenishable = false },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.GasLamp, IsReplenishable = false },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.IceLamp, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.VortexLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DetectEnemies, IsReplenishable = false },
             };
             var assassinCards = new List<StartCardsModifiedRule.CardConfig>
             {
@@ -48,7 +49,7 @@
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.OilLamp, IsReplenishable = false },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.GasLamp, IsReplenishable = false },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.IceLamp, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.VortexLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DetectEnemies, IsReplenishable = false },
             };
             var sorcererCards = new List<StartCardsModifiedRule.CardConfig>
             {
@@ -57,7 +58,7 @@
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.OilLamp, IsReplenishable = false },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.GasLamp, IsReplenishable = false },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.IceLamp, IsReplenishable = false },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.VortexLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.DetectEnemies, IsReplenishable = false },
             };
             var startingCardsRule = new StartCardsModifiedRule(new Dictionary<BoardPieceId, List<StartCardsModifiedRule.CardConfig>>
             {
@@ -78,6 +79,8 @@
                         AbilityKey.OilLamp,
                         AbilityKey.GasLamp,
                         AbilityKey.IceLamp,
+                        AbilityKey.TheBehemoth,
+                        AbilityKey.RepeatingBallista,
                         AbilityKey.TheBehemoth,
                         AbilityKey.VortexLamp,
                         AbilityKey.HealingPotion,
@@ -127,7 +130,7 @@
                         AbilityKey.OilLamp,
                         AbilityKey.GasLamp,
                         AbilityKey.IceLamp,
-                        AbilityKey.RepeatingBallista,
+                        AbilityKey.Vortex,
                         AbilityKey.Torch,
                         AbilityKey.Bone,
                         AbilityKey.DetectEnemies,
@@ -136,12 +139,10 @@
                 {
                     BoardPieceId.HeroSorcerer, new List<AbilityKey>
                     {
-                        AbilityKey.PoisonBomb,
                         AbilityKey.HealingPotion,
                         AbilityKey.OilLamp,
                         AbilityKey.GasLamp,
                         AbilityKey.IceLamp,
-                        AbilityKey.TheBehemoth,
                         AbilityKey.Vortex,
                         AbilityKey.Torch,
                         AbilityKey.Sneak,
@@ -198,7 +199,6 @@
                     BoardPieceId.OilLamp,
                     BoardPieceId.OilLamp,
                     BoardPieceId.HealingBeacon,
-                    BoardPieceId.HealingBeacon,
                 }
                 },
                 {
@@ -213,7 +213,6 @@
                     BoardPieceId.GasLamp,
                     BoardPieceId.OilLamp,
                     BoardPieceId.OilLamp,
-                    BoardPieceId.HealingBeacon,
                     BoardPieceId.HealingBeacon,
                 }
                 },

--- a/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
@@ -1,0 +1,279 @@
+﻿namespace HouseRules.Essentials.Rulesets
+{
+    using System.Collections.Generic;
+    using Boardgame.Board;
+    using DataKeys;
+    using global::Types;
+    using HouseRules.Essentials.Rules;
+    using HouseRules.Types;
+
+    internal static class ItsATrapRuleset
+    {
+        internal static Ruleset Create()
+        {
+            const string name = "It's A Trap!";
+            const string description = "Everything you need to build devious traps for your enemies, but try not to kill your friends.";
+
+            var bardCards = new List<StartCardsModifiedRule.CardConfig>
+            {
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.BoobyTrap, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.CourageShanty, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.OilLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.GasLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.IceLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.VortexLamp, IsReplenishable = false },
+            };
+            var guardianCards = new List<StartCardsModifiedRule.CardConfig>
+            {
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.BoobyTrap, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.ReplenishArmor, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.OilLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.GasLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.IceLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.VortexLamp, IsReplenishable = false },
+            };
+            var hunterCards = new List<StartCardsModifiedRule.CardConfig>
+            {
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.BoobyTrap, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Arrow, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.OilLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.GasLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.IceLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.VortexLamp, IsReplenishable = false },
+            };
+            var assassinCards = new List<StartCardsModifiedRule.CardConfig>
+            {
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.BoobyTrap, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.OilLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.GasLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.IceLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.VortexLamp, IsReplenishable = false },
+            };
+            var sorcererCards = new List<StartCardsModifiedRule.CardConfig>
+            {
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.BoobyTrap, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Zap, IsReplenishable = true },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.OilLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.GasLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.IceLamp, IsReplenishable = false },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.VortexLamp, IsReplenishable = false },
+            };
+            var startingCardsRule = new StartCardsModifiedRule(new Dictionary<BoardPieceId, List<StartCardsModifiedRule.CardConfig>>
+            {
+                { BoardPieceId.HeroBard, bardCards },
+                { BoardPieceId.HeroGuardian, guardianCards },
+                { BoardPieceId.HeroHunter, hunterCards },
+                { BoardPieceId.HeroRogue, assassinCards },
+                { BoardPieceId.HeroSorcerer, sorcererCards },
+            });
+
+            var allowedCardsRule = new CardAdditionOverriddenRule(new Dictionary<BoardPieceId, List<AbilityKey>>
+            {
+                {
+                    BoardPieceId.HeroBard, new List<AbilityKey>
+                    {
+                        AbilityKey.PoisonBomb,
+                        AbilityKey.MagicBarrier,
+                        AbilityKey.OilLamp,
+                        AbilityKey.GasLamp,
+                        AbilityKey.IceLamp,
+                        AbilityKey.TheBehemoth,
+                        AbilityKey.VortexLamp,
+                        AbilityKey.HealingPotion,
+                        AbilityKey.Torch,
+                        AbilityKey.Sneak,
+                        AbilityKey.Bone,
+                        AbilityKey.DetectEnemies,
+                    }
+                },
+                {
+                    BoardPieceId.HeroGuardian, new List<AbilityKey>
+                    {
+                        AbilityKey.PoisonBomb,
+                        AbilityKey.MagicBarrier,
+                        AbilityKey.Bone,
+                        AbilityKey.HealingPotion,
+                        AbilityKey.OilLamp,
+                        AbilityKey.GasLamp,
+                        AbilityKey.IceLamp,
+                        AbilityKey.VortexLamp,
+                        AbilityKey.RevealPath,
+                        AbilityKey.Torch,
+                        AbilityKey.Sneak,
+                        AbilityKey.DetectEnemies,
+                    }
+                },
+                {
+                    BoardPieceId.HeroHunter, new List<AbilityKey>
+                    {
+                        AbilityKey.PoisonBomb,
+                        AbilityKey.MagicBarrier,
+                        AbilityKey.HealingPotion,
+                        AbilityKey.PoisonedTip,
+                        AbilityKey.OilLamp,
+                        AbilityKey.GasLamp,
+                        AbilityKey.IceLamp,
+                        AbilityKey.Torch,
+                        AbilityKey.Sneak,
+                        AbilityKey.DetectEnemies,
+                    }
+                },
+                {
+                    BoardPieceId.HeroRogue, new List<AbilityKey>
+                    {
+                        AbilityKey.PoisonBomb,
+                        AbilityKey.HealingPotion,
+                        AbilityKey.OilLamp,
+                        AbilityKey.GasLamp,
+                        AbilityKey.IceLamp,
+                        AbilityKey.RepeatingBallista,
+                        AbilityKey.Torch,
+                        AbilityKey.Bone,
+                        AbilityKey.DetectEnemies,
+                    }
+                },
+                {
+                    BoardPieceId.HeroSorcerer, new List<AbilityKey>
+                    {
+                        AbilityKey.PoisonBomb,
+                        AbilityKey.HealingPotion,
+                        AbilityKey.OilLamp,
+                        AbilityKey.GasLamp,
+                        AbilityKey.IceLamp,
+                        AbilityKey.TheBehemoth,
+                        AbilityKey.Vortex,
+                        AbilityKey.Torch,
+                        AbilityKey.Sneak,
+                        AbilityKey.DetectEnemies,
+                    }
+                },
+            });
+
+            var piecesAdjustedRule = new PieceConfigAdjustedRule(new List<PieceConfigAdjustedRule.PieceProperty>
+            {
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroBard, Property = "StartHealth", Value = 30 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroGuardian, Property = "StartHealth", Value = 30 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroHunter, Property = "StartHealth", Value = 30 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroRogue, Property = "StartHealth", Value = 30 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroSorcerer, Property = "StartHealth", Value = 30 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Torch, Property = "VisionRange", Value = 40 },
+            });
+
+            var levelPropertiesRule = new LevelPropertiesModifiedRule(new Dictionary<string, int>
+            {
+                { "FloorOneHealingFountains", 0 },
+                { "FloorOneLootChests", 11 },
+                { "FloorTwoHealingFountains", 1 },
+                { "FloorTwoLootChests", 14 },
+                { "FloorThreeHealingFountains", 1 },
+                { "FloorThreeLootChests", 12 },
+                { "FloorOneEndZoneSpikeMaxBudget", 12 },
+                { "PacingSpikeSegmentFloorOneBudget", 12 },
+            });
+
+            var aoePotions = new AbilityAoeAdjustedRule(new Dictionary<AbilityKey, int>
+            {
+                { AbilityKey.StrengthPotion, 1 },
+                { AbilityKey.SwiftnessPotion, 1 },
+                { AbilityKey.HealingPotion, 1 },
+            });
+
+            var abilityActionCostRule = new AbilityActionCostAdjustedRule(new Dictionary<AbilityKey, bool>
+            {
+                { AbilityKey.BoobyTrap, false },
+            });
+
+            var lampTypesRule = new LampTypesOverriddenRule(new Dictionary<int, List<BoardPieceId>>
+            {
+                {
+                    1, new List<BoardPieceId>
+                {
+                    BoardPieceId.GasLamp,
+                    BoardPieceId.OilLamp,
+                    BoardPieceId.VortexLamp,
+                    BoardPieceId.GasLamp,
+                    BoardPieceId.OilLamp,
+                    BoardPieceId.VortexLamp,
+                    BoardPieceId.OilLamp,
+                    BoardPieceId.OilLamp,
+                    BoardPieceId.HealingBeacon,
+                    BoardPieceId.HealingBeacon,
+                }
+                },
+                {
+                    2, new List<BoardPieceId>
+                {
+                    BoardPieceId.GasLamp,
+                    BoardPieceId.GasLamp,
+                    BoardPieceId.GasLamp,
+                    BoardPieceId.GasLamp,
+                    BoardPieceId.GasLamp,
+                    BoardPieceId.GasLamp,
+                    BoardPieceId.GasLamp,
+                    BoardPieceId.OilLamp,
+                    BoardPieceId.OilLamp,
+                    BoardPieceId.HealingBeacon,
+                    BoardPieceId.HealingBeacon,
+                }
+                },
+                {
+                    3, new List<BoardPieceId>
+                {
+                    BoardPieceId.OilLamp,
+                    BoardPieceId.IceLamp,
+                    BoardPieceId.VortexLamp,
+                    BoardPieceId.OilLamp,
+                    BoardPieceId.IceLamp,
+                    BoardPieceId.VortexLamp,
+                    BoardPieceId.HealingBeacon,
+                }
+                },
+            });
+
+            var piecePieceTypeRule = new PiecePieceTypeListOverriddenRule(new Dictionary<BoardPieceId, List<PieceType>>
+            {
+                { BoardPieceId.Torch, new List<PieceType> { PieceType.Prop, PieceType.UpdateFogOfWar, PieceType.ShowNameplate } },
+                { BoardPieceId.EyeOfAvalon, new List<PieceType> { PieceType.Prop, PieceType.UpdateFogOfWar, PieceType.Immovable, PieceType.ShowHealthbar, PieceType.ShowNameplate } },
+                { BoardPieceId.HealingBeacon, new List<PieceType> { PieceType.Prop, PieceType.Bot, PieceType.ShowNameplate } },
+            });
+
+            var statusEffectRule = new StatusEffectConfigRule(new List<StatusEffectData>
+            {
+                new StatusEffectData
+                {
+                    effectStateType = EffectStateType.Stealthed,
+                    durationTurns = 5,
+                    damagePerTurn = 0,
+                    stacks = false,
+                    clearOnNewLevel = false,
+                    tickWhen = StatusEffectsConfig.TickWhen.StartTurn,
+                },
+            });
+
+            var tileEffectDuration = new TileEffectDurationOverriddenRule(new Dictionary<Boardgame.Board.TileEffect, int>
+            {
+                { TileEffect.Gas, 10 },
+                { TileEffect.Acid, 1 },
+                { TileEffect.Web, 10 },
+                { TileEffect.Water, 10 },
+                { TileEffect.Target, 0 },
+            });
+
+            return Ruleset.NewInstance(
+                name,
+                description,
+                abilityActionCostRule,
+                allowedCardsRule,
+                aoePotions,
+                lampTypesRule,
+                levelPropertiesRule,
+                piecesAdjustedRule,
+                piecePieceTypeRule,
+                startingCardsRule,
+                statusEffectRule,
+                tileEffectDuration,
+                new EnemyDoorOpeningDisabledRule(true));
+        }
+    }
+}


### PR DESCRIPTION
# 💣It's a Trap Ruleset💣

Build fiendiesh traps for your enemies and lure them to their deaths... but do try not to kill your friends. 

A new ruleset for HouseRules to keep things interesting.

* This new ruleset gives all of the players a 0-cost BoobyTrap which replenishes every turn. This is supplemented with plenty of Lamps, MagicBarrier and Vortex cards to allow for large scale chain-reaction trap sequences to be constructed.
* Torch and DetectEnemies/EyeOfAvalon pieces are no longer targetted by enemies and can be used to view enemy movements whilst you're planning your traps.
* Enemies cannot open doors for themselves.. they have to wait until you let them into your trap.
* TileEffect statuses such as Gas , Acid and Web have been extended to 10 rounds to allow greater destruction when traps are finally triggered. 
* The Assassin's Sneak ability has been extended to 5 turns to allow for lamps to be placed deeper into enemy territory - the Sneak card will also periodically get dealt to other players. 
* Players all start with 30HP. Healing, Strength and Speed Potions have 3x3 AoE. AltarsOfHealing are disabled and replaced with HealingBeacons to encourage regrouping.
* Different combinations of lamp-types used for each floor to keep trap construction techniques varied.

After quite a few different revisions, this ruleset has been playing well for the last couple of test games. It is probably ready for a wider audience now. It is certainly ready for other people to be testing it out.

Some notes.

I have only tested with 3-player config. I have tried to make each of the heros work in slightly different ways, but I generally prefer playing certain combos leaving others untested. I find that the ruleset plays well on the Elven map where the doors keep the enemies well contained. My favoured combo is Hunter + Sorcerer + Assassin. I don't think I've played a single game with the Bard in the party.

