### PR TITLE
It's a trap rebalance

### DIFF
--- a/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
@@ -248,6 +248,33 @@
                     clearOnNewLevel = false,
                     tickWhen = StatusEffectsConfig.TickWhen.StartTurn,
                 },
+                new StatusEffectData
+                {
+                    effectStateType = EffectStateType.Courageous,
+                    durationTurns = 2,
+                    damagePerTurn = 0,
+                    stacks = false,
+                    clearOnNewLevel = false,
+                    tickWhen = StatusEffectsConfig.TickWhen.StartTurn,
+                },
+                new StatusEffectData
+                {
+                    effectStateType = EffectStateType.Fearless,
+                    durationTurns = 2,
+                    damagePerTurn = 0,
+                    stacks = false,
+                    clearOnNewLevel = false,
+                    tickWhen = StatusEffectsConfig.TickWhen.StartTurn,
+                },
+                new StatusEffectData
+                {
+                    effectStateType = EffectStateType.Heroic,
+                    durationTurns = 2,
+                    damagePerTurn = 0,
+                    stacks = false,
+                    clearOnNewLevel = false,
+                    tickWhen = StatusEffectsConfig.TickWhen.StartTurn,
+                },
             });
 
             var tileEffectDuration = new TileEffectDurationOverriddenRule(new Dictionary<Boardgame.Board.TileEffect, int>

--- a/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
@@ -134,6 +134,8 @@
                         AbilityKey.Torch,
                         AbilityKey.Bone,
                         AbilityKey.DetectEnemies,
+                        AbilityKey.WebBomb,
+                        AbilityKey.VortexLamp,
                     }
                 },
                 {
@@ -147,6 +149,9 @@
                         AbilityKey.Torch,
                         AbilityKey.Sneak,
                         AbilityKey.DetectEnemies,
+                        AbilityKey.Banish,
+                        AbilityKey.Lure,
+                        AbilityKey.WebBomb,
                     }
                 },
             });


### PR DESCRIPTION
The Gray Alien did a playtest with a character combo that hadn't been tested before and provided some great feedback. 

The Bard's Courage Shanty buff was too overpowered given the extended duration of poison gas, so this has now been reduced to 2 rounds instead of 3.
The Sorcerer was given too many heal cards and potions due to having a very small number of possible CardAdditions. His cards (and the rogues) have a couple of additions, bringing web-bomb into the mix.

