### PR TITLE
Added a board sync trigger to AbilityAoeAdjustedRule, to fix AoE potion changes not syncing across clients.

### DIFF
--- a/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityAOEAdjustedRule.cs
@@ -12,6 +12,8 @@
     {
         public override string Description => "Ability AOE Ranges are adjusted";
 
+        protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.StatusEffectDataModified;
+
         private readonly Dictionary<AbilityKey, int> _adjustments;
         private Dictionary<AbilityKey, int> _originals;
 


### PR DESCRIPTION
Added a board sync trigger to AbilityAoeAdjustedRule, to fix AoE potion changes not syncing across clients.