### PR TITLE
Add new rulesets and update others for compatibility with HR1.4

### DIFF
--- a/docs/rulesets/(Custom) Arachnophobia.json
+++ b/docs/rulesets/(Custom) Arachnophobia.json
@@ -1,11 +1,14 @@
 {
   "Name": "(Custom) Arachnophobia",
-  "Description": "Money Spiders everywhere. On the walls and in my hair.",
+  "Description": "Money Spiders everywhere. On my face and in my hair.",
   "Rules": [
     {
-      "Rule": "AbilityDamageAdjusted",
+      "Rule": "AbilityDamageOverridden",
       "Config": {
-        "Zap": 1
+        "Zap": [
+          2,
+          4
+        ]
       }
     },
     {
@@ -14,127 +17,127 @@
         "HeroBard": [
           {
             "Card": "HealingPotion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "CourageShanty",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "IceLamp",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "SongOfRecovery",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "Sneak",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "HurricaneAnthem",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "ShatteringVoice",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           }
         ],
         "HeroGuardian": [
           {
             "Card": "HealingPotion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "ReplenishArmor",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "Bone",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "WhirlwindAttack",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "PiercingThrow",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "Sneak",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           }
         ],
         "HeroHunter": [
           {
             "Card": "HealingPotion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "Arrow",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "PoisonedTip",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "HailOfArrows",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "CallCompanion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "Sneak",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           }
         ],
         "HeroRogue": [
           {
             "Card": "HealingPotion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "Sneak",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "PanicPowder",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "BoobyTrap",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "PoisonBomb",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           }
         ],
         "HeroSorcerer": [
           {
             "Card": "HealingPotion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "Zap",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "OilLamp",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "HeavensFury",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "DetectEnemies",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           }
         ]
       }
@@ -249,17 +252,17 @@
         {
           "Piece": "RatKing",
           "Property": "StartHealth",
-          "Value": 45.0
-        },
-        {
-          "Piece": "RatKing",
-          "Property": "MoveRange",
-          "Value": 2.0
+          "Value": 50.0
         },
         {
           "Piece": "ElvenQueen",
           "Property": "StartHealth",
-          "Value": 35.0
+          "Value": 60.0
+        },
+        {
+          "Piece": "Gorgon",
+          "Property": "StartHealth",
+          "Value": 85.0
         }
       ]
     },
@@ -274,15 +277,15 @@
     {
       "Rule": "LevelPropertiesModified",
       "Config": {
-        "FloorOneHealingFountains": 4,
+        "FloorOneGoldMaxAmount": 1200,
+        "FloorOneHealingFountains": 2,
         "FloorOneLootChests": 12,
         "FloorOneClassCardChests": 8,
-        "FloorTwoHealingFountains": 4,
+        "FloorTwoHealingFountains": 3,
         "FloorTwoLootChests": 9,
-        "FloorTwoGoldMaxAmount": 2500,
-        "FloorThreeHealingFountains": 6,
-        "FloorThreeLootChests": 0,
-        "FloorOneGoldMaxAmount": 1500
+        "FloorTwoGoldMaxAmount": 1500,
+        "FloorThreeHealingFountains": 1,
+        "FloorThreeLootChests": 0
       }
     },
     {
@@ -307,41 +310,71 @@
           "Diseased"
         ],
         "RatKing": [
-          "Petrified"
+          "Petrified",
+          "Stunned",
+          "Panic",
+          "Frozen",
+          "Disoriented",
+          "Confused"
         ],
         "ElvenQueen": [
-          "Petrified"
+          "Petrified",
+          "Stunned",
+          "Disoriented",
+          "Confused"
+        ],
+        "Gorgon": [
+          "Petrified",
+          "Stunned",
+          "Frozen",
+          "MarkOfAvalon",
+          "Panic",
+          "Disoriented",
+          "Confused"
         ]
       }
     },
     {
-      "Rule": "SpawnCategoryOverridden",
+      "Rule": "MonsterDeckOverridden",
       "Config": {
-        "Spider": [
-          200,
-          50,
-          1
-        ],
-        "SpiderEgg": [
-          20,
-          10,
-          1
-        ],
-        "GiantSpider": [
-          30,
-          10,
-          1
-        ],
-        "RatKing": [
-          1,
-          1,
-          1
-        ],
-        "ElvenQueen": [
-          1,
-          1,
-          2
-        ]
+        "EntranceDeckFloor1": {
+          "Spider": 0,
+          "SpiderEgg": 5,
+          "GiantSpider": 1,
+          "GiantSlime": 1
+        },
+        "ExitDeckFloor1": {
+          "Spider": 0,
+          "SpiderEgg": 2,
+          "GiantSpider": 3,
+          "ElvenQueen": 1
+        },
+        "EntranceDeckFloor2": {
+          "Spider": 0,
+          "SpiderEgg": 2,
+          "GiantSpider": 3,
+          "DruidArcher": 4
+        },
+        "ExitDeckFloor2": {
+          "Spider": 0,
+          "SpiderEgg": 3,
+          "GiantSpider": 2,
+          "RatKing": 1
+        },
+        "BossDeck": {
+          "Spider": 0,
+          "GiantSpider": 4,
+          "TheUnseen": 0,
+          "TheUnheard": 0,
+          "TheUnspoken": 0,
+          "DruidArcher": 3,
+          "ElvenPriest": 3,
+          "ElvenMystic": 3,
+          "Sigataur": 2
+        },
+        "KeyHolderFloor1": "CavetrollBoss",
+        "KeyHolderFloor2": "Sigataur",
+        "Boss": "Gorgon"
       }
     },
     {
@@ -400,7 +433,7 @@
       "Rule": "PieceUseWhenKilledOverridden",
       "Config": {
         "Spider": [
-          "HealingPotion"
+          "EnemyDropStolenGoods"
         ]
       }
     },
@@ -440,6 +473,16 @@
         {
           "effectStateType": "Fearless",
           "durationTurns": 6,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "damagePerTurn": 0,
+          "clearOnNewLevel": false,
+          "damageTags": null,
+          "healPerTurn": 0
+        },
+        {
+          "effectStateType": "Invulnerable1",
+          "durationTurns": 2,
           "tickWhen": "EndTurn",
           "stacks": false,
           "damagePerTurn": 0,

--- a/docs/rulesets/(Custom) Demeo Reloaded.json
+++ b/docs/rulesets/(Custom) Demeo Reloaded.json
@@ -1,0 +1,880 @@
+{
+  "Name": "(Custom) Demeo Reloaded",
+  "Description": "MANY class changes. NEW enemies. BETTER loot. No respawns. Yet somehow challenging...",
+  "Rules": [
+    {
+      "Rule": "SpawnCategoryOverridden",
+      "Config": {
+        "Mimic": [
+          1,
+          1,
+          1
+        ],
+        "Wyvern": [
+          1,
+          1,
+          2
+        ],
+        "ChestGoblin": [
+          1,
+          1,
+          2
+        ],
+        "RootGolem": [
+          1,
+          0,
+          2
+        ],
+        "Brookmare": [
+          1,
+          0,
+          2
+        ],
+        "EarthElemental": [
+          2,
+          1,
+          2
+        ],
+        "Bandit": [
+          2,
+          0,
+          1
+        ],
+        "Cavetroll": [
+          1,
+          0,
+          1
+        ],
+        "DruidArcher": [
+          4,
+          0,
+          1
+        ],
+        "DruidHoundMaster": [
+          4,
+          1,
+          1
+        ],
+        "ElvenArcher": [
+          4,
+          1,
+          1
+        ],
+        "ElvenHound": [
+          4,
+          1,
+          1
+        ],
+        "ElvenMarauder": [
+          1,
+          0,
+          1
+        ],
+        "GoblinChieftan": [
+          4,
+          0,
+          1
+        ],
+        "GoblinMadUn": [
+          6,
+          1,
+          1
+        ],
+        "RootBeast": [
+          4,
+          0,
+          1
+        ],
+        "RootHound": [
+          4,
+          1,
+          1
+        ],
+        "ScabRat": [
+          3,
+          0,
+          1
+        ],
+        "TheUnspoken": [
+          3,
+          0,
+          1
+        ],
+        "Spider": [
+          6,
+          4,
+          1
+        ],
+        "SpiderEgg": [
+          6,
+          3,
+          1
+        ],
+        "GiantSpider": [
+          4,
+          0,
+          1
+        ],
+        "Rat": [
+          8,
+          6,
+          1
+        ],
+        "Slimeling": [
+          4,
+          1,
+          1
+        ],
+        "Thug": [
+          3,
+          1,
+          2
+        ],
+        "ElvenMystic": [
+          6,
+          0,
+          1
+        ],
+        "ElvenPriest": [
+          4,
+          0,
+          1
+        ],
+        "ElvenSkirmisher": [
+          4,
+          0,
+          1
+        ],
+        "FireElemental": [
+          3,
+          0,
+          1
+        ],
+        "GoblinFighter": [
+          6,
+          3,
+          1
+        ],
+        "GoblinRanger": [
+          6,
+          3,
+          1
+        ],
+        "Gorgon": [
+          1,
+          0,
+          2
+        ],
+        "IceElemental": [
+          2,
+          0,
+          1
+        ],
+        "KillerBee": [
+          8,
+          4,
+          1
+        ],
+        "RatNest": [
+          4,
+          2,
+          1
+        ],
+        "RootMage": [
+          4,
+          1,
+          1
+        ],
+        "SporeFungus": [
+          6,
+          2,
+          1
+        ],
+        "TheUnheard": [
+          3,
+          0,
+          1
+        ],
+        "SilentSentinel": [
+          1,
+          0,
+          2
+        ],
+        "GiantSlime": [
+          2,
+          0,
+          1
+        ]
+      }
+    },
+    {
+      "Rule": "StartCardsModified",
+      "Config": {
+        "HeroBard": [
+          {
+            "Card": "HealingPotion",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "HurricaneAnthem",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "SongOfRecovery",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "ShatteringVoice",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "CourageShanty",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "CourageShanty",
+            "IsReplenishable": 1
+          }
+        ],
+        "HeroGuardian": [
+          {
+            "Card": "HealingPotion",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "WhirlwindAttack",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "PiercingThrow",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Charge",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Grab",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "ReplenishArmor",
+            "IsReplenishable": 1
+          }
+        ],
+        "HeroHunter": [
+          {
+            "Card": "HealingPotion",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "HailOfArrows",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "PoisonedTip",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "CallCompanion",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "BeastWhisperer",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Arrow",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "Arrow",
+            "IsReplenishable": 1
+          }
+        ],
+        "HeroRogue": [
+          {
+            "Card": "Sneak",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "HealingPotion",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Blink",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "PoisonBomb",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "CursedDagger",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "DiseasedBite",
+            "IsReplenishable": 1
+          }
+        ],
+        "HeroSorcerer": [
+          {
+            "Card": "Zap",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "HealingPotion",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Fireball",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Freeze",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "SummonElemental",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Electricity",
+            "IsReplenishable": 1
+          }
+        ]
+      }
+    },
+    {
+      "Rule": "PieceConfigAdjusted",
+      "Config": [
+        {
+          "Piece": "HeroHunter",
+          "Property": "MoveRange",
+          "Value": 5.0
+        },
+        {
+          "Piece": "HeroRogue",
+          "Property": "MoveRange",
+          "Value": 5.0
+        },
+        {
+          "Piece": "HeroBard",
+          "Property": "StartHealth",
+          "Value": 13.0
+        },
+        {
+          "Piece": "HeroGuardian",
+          "Property": "StartHealth",
+          "Value": 14.0
+        },
+        {
+          "Piece": "HeroRogue",
+          "Property": "StartHealth",
+          "Value": 11.0
+        },
+        {
+          "Piece": "HeroHunter",
+          "Property": "StartHealth",
+          "Value": 12.0
+        },
+        {
+          "Piece": "HeroBard",
+          "Property": "AttackDamage",
+          "Value": 2.0
+        },
+        {
+          "Piece": "HeroSorcerer",
+          "Property": "AttackDamage",
+          "Value": 1.0
+        },
+        {
+          "Piece": "HeroGuardian",
+          "Property": "AttackDamage",
+          "Value": 4.0
+        },
+        {
+          "Piece": "HeroBard",
+          "Property": "CriticalHitDamage",
+          "Value": 5.0
+        },
+        {
+          "Piece": "HeroSorcerer",
+          "Property": "CriticalHitDamage",
+          "Value": 3.0
+        },
+        {
+          "Piece": "HeroGuardian",
+          "Property": "CriticalHitDamage",
+          "Value": 9.0
+        },
+        {
+          "Piece": "Mimic",
+          "Property": "BerserkBelowHealth",
+          "Value": 0.9
+        },
+        {
+          "Piece": "Mimic",
+          "Property": "StartArmor",
+          "Value": 5.0
+        },
+        {
+          "Piece": "Mimic",
+          "Property": "StartHealth",
+          "Value": 24.0
+        },
+        {
+          "Piece": "Mimic",
+          "Property": "MoveRange",
+          "Value": 3.0
+        },
+        {
+          "Piece": "Wyvern",
+          "Property": "BerserkBelowHealth",
+          "Value": 0.75
+        },
+        {
+          "Piece": "Wyvern",
+          "Property": "BarkArmor",
+          "Value": 2.0
+        },
+        {
+          "Piece": "Wyvern",
+          "Property": "MoveRange",
+          "Value": 4.0
+        },
+        {
+          "Piece": "KillerBee",
+          "Property": "WaterTrailChance",
+          "Value": 0.15
+        },
+        {
+          "Piece": "Rat",
+          "Property": "WaterTrailChance",
+          "Value": 0.15
+        }
+      ]
+    },
+    {
+      "Rule": "CardAdditionOverridden",
+      "Config": {
+        "HeroGuardian": [
+          "Antitoxin",
+          "Bone",
+          "Regroup",
+          "Rejuvenation",
+          "OneMoreThing",
+          "BottleOfLye",
+          "StrengthPotion",
+          "SwiftnessPotion",
+          "HeavensFury",
+          "AdamantPotion",
+          "HealingPotion",
+          "HealingWard",
+          "WhirlwindAttack",
+          "WarCry",
+          "TheBehemoth",
+          "PiercingThrow",
+          "Charge",
+          "HealingWard"
+        ],
+        "HeroBard": [
+          "WebBomb",
+          "Regroup",
+          "Rejuvenation",
+          "OneMoreThing",
+          "PanicPowder",
+          "BottleOfLye",
+          "Teleportation",
+          "StrengthPotion",
+          "SwiftnessPotion",
+          "HeavensFury",
+          "AdamantPotion",
+          "HealingPotion",
+          "SongOfRecovery",
+          "SongOfResilience",
+          "BlockAbilities",
+          "PiercingVoice",
+          "ShatteringVoice",
+          "HurricaneAnthem"
+        ],
+        "HeroHunter": [
+          "Antitoxin",
+          "BeastWhisperer",
+          "WebBomb",
+          "RepeatingBallista",
+          "Regroup",
+          "Rejuvenation",
+          "OneMoreThing",
+          "PanicPowder",
+          "Barricade",
+          "BottleOfLye",
+          "RevealPath",
+          "DetectEnemies",
+          "StrengthPotion",
+          "SwiftnessPotion",
+          "HeavensFury",
+          "AdamantPotion",
+          "HealingPotion",
+          "ScrollOfCharm",
+          "HailOfArrows",
+          "CallCompanion",
+          "PoisonedTip",
+          "HuntersMark",
+          "Lure"
+        ],
+        "HeroRogue": [
+          "WebBomb",
+          "Regroup",
+          "Rejuvenation",
+          "OneMoreThing",
+          "PanicPowder",
+          "Barricade",
+          "BottleOfLye",
+          "Bone",
+          "StrengthPotion",
+          "SwiftnessPotion",
+          "HeavensFury",
+          "AdamantPotion",
+          "HealingPotion",
+          "Blink",
+          "PoisonBomb",
+          "CoinFlip",
+          "CursedDagger",
+          "BoobyTrap",
+          "FlashBomb"
+        ],
+        "HeroSorcerer": [
+          "Bone",
+          "Antitoxin",
+          "Regroup",
+          "Rejuvenation",
+          "OneMoreThing",
+          "PanicPowder",
+          "BottleOfLye",
+          "Teleportation",
+          "StrengthPotion",
+          "SwiftnessPotion",
+          "HeavensFury",
+          "AdamantPotion",
+          "HealingPotion",
+          "Banish",
+          "Fireball",
+          "Freeze",
+          "MagicShield",
+          "MagicBarrier",
+          "Vortex"
+        ]
+      }
+    },
+    {
+      "Rule": "StatusEffectConfig",
+      "Config": [
+        {
+          "effectStateType": "HealingSong",
+          "durationTurns": 5,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "damagePerTurn": 0,
+          "clearOnNewLevel": false,
+          "damageTags": null,
+          "healPerTurn": 0
+        },
+        {
+          "effectStateType": "Recovery",
+          "durationTurns": 5,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "damagePerTurn": 0,
+          "clearOnNewLevel": false,
+          "damageTags": null,
+          "healPerTurn": 0
+        },
+        {
+          "effectStateType": "Courageous",
+          "durationTurns": 3,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "damagePerTurn": 0,
+          "clearOnNewLevel": false,
+          "damageTags": null,
+          "healPerTurn": 0
+        },
+        {
+          "effectStateType": "Heroic",
+          "durationTurns": 4,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "damagePerTurn": 0,
+          "clearOnNewLevel": false,
+          "damageTags": null,
+          "healPerTurn": 0
+        },
+        {
+          "effectStateType": "Fearless",
+          "durationTurns": 5,
+          "tickWhen": "EndTurn",
+          "stacks": false,
+          "damagePerTurn": 0,
+          "clearOnNewLevel": false,
+          "damageTags": null,
+          "healPerTurn": 0
+        }
+      ]
+    },
+    {
+      "Rule": "PieceAbilityListOverridden",
+      "Config": {
+        "EarthElemental": [
+          "EnemyMelee",
+          "EnemyKnockbackMelee",
+          "EarthShatter",
+          "EnemyJavelin"
+        ],
+        "Mimic": [
+          "EnemyMelee",
+          "AcidSpit"
+        ],
+        "RootMage": [
+          "EnemyMelee",
+          "TeleportEnemy"
+        ],
+        "KillerBee": [
+          "EnemyMelee",
+          "ThornPowder"
+        ]
+      }
+    },
+    {
+      "Rule": "PieceBehavioursListOverridden",
+      "Config": {
+        "EarthElemental": [
+          "FollowPlayerMeleeAttacker",
+          "AttackPlayer",
+          "EarthShatter",
+          "RangedAttackHighPrio"
+        ],
+        "Mimic": [
+          "FollowPlayerMeleeAttacker",
+          "AttackPlayer",
+          "RangedAttackHighPrio"
+        ],
+        "RootMage": [
+          "FollowPlayerMeleeAttacker",
+          "AttackPlayer",
+          "CastOnTeam"
+        ],
+        "KillerBee": [
+          "FollowPlayerMeleeAttacker",
+          "AttackPlayer",
+          "RangedAttackHighPrio"
+        ]
+      }
+    },
+    {
+      "Rule": "PieceImmunityListAdjusted",
+      "Config": {
+        "HeroSorcerer": [
+          "Stunned",
+          "Frozen"
+        ],
+        "HeroHunter": [
+          "Tangled",
+          "Petrified"
+        ],
+        "HeroGuardian": [
+          "Stunned",
+          "Weaken"
+        ],
+        "HeroBard": [
+          "Diseased"
+        ],
+        "HeroRogue": [
+          "Tangled",
+          "Diseased"
+        ],
+        "Mimic": [
+          "Panic",
+          "Stunned",
+          "Weaken",
+          "Diseased"
+        ],
+        "Wyvern": [
+          "Panic",
+          "Tangled",
+          "Frozen",
+          "Diseased",
+          "Tangled"
+        ],
+        "KillerBee": [
+          "Tangled",
+          "Diseased"
+        ],
+        "EarthElemental": [
+          "Stunned",
+          "Diseased",
+          "Panic",
+          "Tangled",
+          "Weaken"
+        ]
+      }
+    },
+    {
+      "Rule": "TileEffectDurationOverridden",
+      "Config": {
+        "Gas": 3,
+        "Acid": 4,
+        "Web": 4,
+        "Water": 3,
+        "Target": 0
+      }
+    },
+    {
+      "Rule": "AbilityActionCostAdjusted",
+      "Config": {
+        "Zap": false,
+        "Sneak": false,
+        "Grab": false,
+        "BeastWhisperer": false
+      }
+    },
+    {
+      "Rule": "AbilityHealOverridden",
+      "Config": {
+        "HealingPotion": 12,
+        "Rejuvenation": 12,
+        "AltarHeal": 12
+      }
+    },
+    {
+      "Rule": "AbilityAoeAdjusted",
+      "Config": {
+        "SongOfRecovery": 2,
+        "SongOfResilience": 2,
+        "FlashBomb": 1,
+        "WebBomb": 1,
+        "PoisonBomb": 1,
+        "HailOfArrows": 1,
+        "WarCry": 1,
+        "WhirlwindAttack": 1,
+        "Fireball": 1,
+        "Freeze": 1
+      }
+    },
+    {
+      "Rule": "AbilityDamageOverridden",
+      "Config": {
+        "Zap": [
+          3,
+          8
+        ],
+        "Fireball": [
+          12,
+          25
+        ],
+        "Freeze": [
+          7,
+          15
+        ],
+        "WhirlwindAttack": [
+          4,
+          9
+        ],
+        "Charge": [
+          4,
+          12
+        ],
+        "PiercingThrow": [
+          5,
+          11
+        ],
+        "Blink": [
+          7,
+          17
+        ],
+        "CursedDagger": [
+          4,
+          12
+        ],
+        "PoisonedTip": [
+          6,
+          13
+        ],
+        "HailOfArrows": [
+          5,
+          11
+        ],
+        "Arrow": [
+          4,
+          11
+        ],
+        "Electricity": [
+          2,
+          5
+        ],
+        "DiseasedBite": [
+          2,
+          5
+        ]
+      }
+    },
+    {
+      "Rule": "BackstabConfigOverridden",
+      "Config": [
+        "HeroBard",
+        "HeroRogue"
+      ]
+    },
+    {
+      "Rule": "PetsFocusHunterMark",
+      "Config": true
+    },
+    {
+      "Rule": "EnemyRespawnDisabled",
+      "Config": true
+    },
+    {
+      "Rule": "CardEnergyFromAttackMultiplied",
+      "Config": 0.75
+    },
+    {
+      "Rule": "CardEnergyFromRecyclingMultiplied",
+      "Config": 0.75
+    },
+    {
+      "Rule": "EnemyAttackScaled",
+      "Config": 1.25
+    },
+    {
+      "Rule": "EnemyHealthScaled",
+      "Config": 1.334
+    },
+    {
+      "Rule": "LevelSequenceOverridden",
+      "Config": [
+        "SewersFloor12",
+        "ShopFloor02",
+        "ElvenFloor02",
+        "ForestShopFloor",
+        "ForestFloor02"
+      ]
+    },
+    {
+      "Rule": "LevelPropertiesModified",
+      "Config": {
+        "BigGoldPileChance": 30,
+        "FloorOneHealingFountains": 1,
+        "FloorOneLootChests": 1,
+        "FloorOneClassCardChests": 2,
+        "FloorOneGoldMaxAmount": 600,
+        "FloorTwoHealingFountains": 1,
+        "FloorTwoLootChests": 2,
+        "FloorTwoClassCardChests": 3,
+        "FloorTwoGoldMaxAmount": 800,
+        "FloorThreeHealingFountains": 1,
+        "FloorThreeLootChests": 1
+      }
+    }
+  ]
+}

--- a/docs/rulesets/(Custom) Earth Wind & Fire.json
+++ b/docs/rulesets/(Custom) Earth Wind & Fire.json
@@ -1,0 +1,450 @@
+{
+  "Name": "(Custom) Earth Wind & Fire",
+  "Description": "Not the band. Let's get Elemental",
+  "Rules": [
+    {
+      "Rule": "AbilityDamageOverridden",
+      "Config": {
+        "Zap": [
+          2,
+          5
+        ]
+      }
+    },
+    {
+      "Rule": "StartCardsModified",
+      "Config": {
+        "HeroGuardian": [
+          {
+            "Card": "HealingPotion",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "HurricaneAnthem",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "Electricity",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "Fireball",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Fireball",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Sneak",
+            "IsReplenishable": 0
+          }
+        ],
+        "HeroHunter": [
+          {
+            "Card": "HealingPotion",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "HurricaneAnthem",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "Electricity",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "Fireball",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Fireball",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Sneak",
+            "IsReplenishable": 0
+          }
+        ],
+        "HeroRogue": [
+          {
+            "Card": "HealingPotion",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "HurricaneAnthem",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "Electricity",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "Fireball",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Fireball",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Sneak",
+            "IsReplenishable": 0
+          }
+        ],
+        "HeroSorcerer": [
+          {
+            "Card": "HealingPotion",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "HurricaneAnthem",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "Electricity",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "Fireball",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Fireball",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Sneak",
+            "IsReplenishable": 0
+          }
+        ],
+        "HeroBard": [
+          {
+            "Card": "HealingPotion",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "HurricaneAnthem",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "Electricity",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "Fireball",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Fireball",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Sneak",
+            "IsReplenishable": 0
+          }
+        ]
+      }
+    },
+    {
+      "Rule": "CardAdditionOverridden",
+      "Config": {
+        "HeroGuardian": [
+          "Bone",
+          "Fireball",
+          "Teleportation",
+          "RevealPath",
+          "Freeze",
+          "StrengthPotion",
+          "SwiftnessPotion",
+          "CallCompanion",
+          "WhirlwindAttack",
+          "LetItRain",
+          "WaterDive",
+          "HeavensFury",
+          "AdamantPotion",
+          "HealingPotion",
+          "WoodenBone",
+          "Torch"
+        ],
+        "HeroHunter": [
+          "Bone",
+          "Fireball",
+          "Teleportation",
+          "RevealPath",
+          "Freeze",
+          "StrengthPotion",
+          "SwiftnessPotion",
+          "CallCompanion",
+          "WhirlwindAttack",
+          "LetItRain",
+          "WaterDive",
+          "HeavensFury",
+          "AdamantPotion",
+          "HealingPotion",
+          "WoodenBone",
+          "Torch"
+        ],
+        "HeroRogue": [
+          "Bone",
+          "Fireball",
+          "Teleportation",
+          "RevealPath",
+          "Freeze",
+          "StrengthPotion",
+          "SwiftnessPotion",
+          "CallCompanion",
+          "WhirlwindAttack",
+          "LetItRain",
+          "WaterDive",
+          "HeavensFury",
+          "AdamantPotion",
+          "HealingPotion",
+          "WoodenBone",
+          "Torch"
+        ],
+        "HeroSorcerer": [
+          "Bone",
+          "Fireball",
+          "Teleportation",
+          "RevealPath",
+          "Freeze",
+          "StrengthPotion",
+          "SwiftnessPotion",
+          "CallCompanion",
+          "WhirlwindAttack",
+          "LetItRain",
+          "WaterDive",
+          "HeavensFury",
+          "AdamantPotion",
+          "HealingPotion",
+          "WoodenBone",
+          "Torch"
+        ],
+        "HeroBard": [
+          "Bone",
+          "Fireball",
+          "Teleportation",
+          "RevealPath",
+          "Freeze",
+          "StrengthPotion",
+          "SwiftnessPotion",
+          "CallCompanion",
+          "WhirlwindAttack",
+          "LetItRain",
+          "WaterDive",
+          "HeavensFury",
+          "AdamantPotion",
+          "HealingPotion",
+          "WoodenBone",
+          "Torch"
+        ]
+      }
+    },
+    {
+      "Rule": "PieceConfigAdjusted",
+      "Config": [
+        {
+          "Piece": "HeroGuardian",
+          "Property": "StartArmor",
+          "Value": 0.0
+        },
+        {
+          "Piece": "Sigataur",
+          "Property": "StartHealth",
+          "Value": 38.0
+        },
+        {
+          "Piece": "Brookmare",
+          "Property": "StartHealth",
+          "Value": 75.0
+        },
+        {
+          "Piece": "Brookmare",
+          "Property": "StartArmor",
+          "Value": 5.0
+        },
+        {
+          "Piece": "HeroSorcerer",
+          "Property": "AttackDamage",
+          "Value": 3.0
+        }
+      ]
+    },
+    {
+      "Rule": "BackstabConfigOverridden",
+      "Config": [
+        "HeroGuardian",
+        "HeroSorcerer",
+        "HeroRogue",
+        "HeroBard"
+      ]
+    },
+    {
+      "Rule": "AbilityBackstabAdjusted",
+      "Config": {
+        "Zap": true,
+        "Arrow": true,
+        "PiercingThrow": true,
+        "PoisonedTip": true,
+        "Fireball": true,
+        "Freeze": true,
+        "Bone": true,
+        "WhirlwindAttack": true
+      }
+    },
+    {
+      "Rule": "MonsterDeckOverridden",
+      "Config": {
+        "EntranceDeckFloor1": {
+          "Spider": 0,
+          "IceElemental": 2,
+          "ChestGoblin": 3,
+          "FireElemental": 2
+        },
+        "ExitDeckFloor1": {
+          "Rat": 20,
+          "Spider": 20,
+          "IceElemental": 2,
+          "ChestGoblin": 3,
+          "Mimic": 1,
+          "GoblinMadUn": 1,
+          "DruidArcher": 1
+        },
+        "EntranceDeckFloor2": {
+          "Spider": 0,
+          "GoblinFighter": 0,
+          "ScabRat": 2,
+          "SporeFungus": 5,
+          "SpiderEgg": 3,
+          "FireElemental": 2,
+          "ElvenArcher": 2
+        },
+        "ExitDeckFloor2": {
+          "Spider": 20,
+          "Rat": 30,
+          "Bandit": 2,
+          "Mimic": 5,
+          "ElvenPriest": 4,
+          "ElvenMarauder": 2
+        },
+        "BossDeck": {
+          "SpiderEgg": 10,
+          "TheUnseen": 0,
+          "TheUnheard": 0,
+          "TheUnspoken": 0,
+          "Slimeling": 0,
+          "Sigataur": 2
+        },
+        "KeyHolderFloor1": "Cavetroll",
+        "KeyHolderFloor2": "Sigataur",
+        "Boss": "Brookmare"
+      }
+    },
+    {
+      "Rule": "AbilityAoeAdjusted",
+      "Config": {
+        "CourageShanty": 1,
+        "ReplenishArmor": 1,
+        "StrengthPotion": 1,
+        "SwiftnessPotion": 1,
+        "Antitoxin": 1,
+        "AdamantPotion": 1,
+        "HealingPotion": 1,
+        "OneMoreThing": 1
+      }
+    },
+    {
+      "Rule": "AbilityHealOverridden",
+      "Config": {
+        "HealingPotion": 3
+      }
+    },
+    {
+      "Rule": "RegainAbilityIfMaxxedOutOverridden",
+      "Config": {
+        "StrengthPotion": false,
+        "SwiftnessPotion": false
+      }
+    },
+    {
+      "Rule": "PieceUseWhenKilledOverridden",
+      "Config": {
+        "Spider": [
+          "HealingPotion",
+          "OneMoreThing"
+        ],
+        "IceElemental": [
+          "LetItRain"
+        ]
+      }
+    },
+    {
+      "Rule": "PieceAbilityListOverridden",
+      "Config": {
+        "HeroGuardian": [
+          "OneMoreThing",
+          "EarthShatter",
+          "Fireball",
+          "HurricaneAnthem",
+          "AbsorbMySoul"
+        ],
+        "HeroHunter": [
+          "OneMoreThing",
+          "EarthShatter",
+          "Fireball",
+          "HurricaneAnthem",
+          "AbsorbMySoul"
+        ],
+        "HeroSorcerer": [
+          "OneMoreThing",
+          "EarthShatter",
+          "Fireball",
+          "HurricaneAnthem",
+          "AbsorbMySoul"
+        ],
+        "HeroRogue": [
+          "OneMoreThing",
+          "EarthShatter",
+          "Fireball",
+          "HurricaneAnthem",
+          "AbsorbMySoul"
+        ],
+        "HeroBard": [
+          "OneMoreThing",
+          "EarthShatter",
+          "Fireball",
+          "HurricaneAnthem",
+          "AbsorbMySoul"
+        ]
+      }
+    },
+    {
+      "Rule": "EnemyRespawnDisabled",
+      "Config": true
+    },
+    {
+      "Rule": "LampTypesOverridden",
+      "Config": {
+        "1": [
+          "OilLamp",
+          "OilLamp",
+          "OilLamp",
+          "VortexLamp"
+        ],
+        "2": [
+          "GasLamp",
+          "GasLamp",
+          "GasLamp",
+          "VortexLamp"
+        ],
+        "3": [
+          "IceLamp",
+          "IceLamp",
+          "IceLamp",
+          "VortexLamp"
+        ]
+      }
+    }
+  ]
+}

--- a/docs/rulesets/(Custom) Hunter's Paradise.json
+++ b/docs/rulesets/(Custom) Hunter's Paradise.json
@@ -8,71 +8,71 @@
         "HeroBard": [
           {
             "Card": "CallCompanion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "SummonElemental",
-            "IsReplenishable": false
+            "IsReplenishable": 1
           },
           {
             "Card": "HuntersMark",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           }
         ],
         "HeroGuardian": [
           {
             "Card": "CallCompanion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "SummonElemental",
-            "IsReplenishable": false
+            "IsReplenishable": 1
           },
           {
             "Card": "HuntersMark",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           }
         ],
         "HeroHunter": [
           {
             "Card": "CallCompanion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "SummonElemental",
-            "IsReplenishable": false
+            "IsReplenishable": 1
           },
           {
             "Card": "HuntersMark",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           }
         ],
         "HeroRogue": [
           {
             "Card": "CallCompanion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "SummonElemental",
-            "IsReplenishable": false
+            "IsReplenishable": 1
           },
           {
             "Card": "HuntersMark",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           }
         ],
         "HeroSorcerer": [
           {
             "Card": "CallCompanion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "SummonElemental",
-            "IsReplenishable": false
+            "IsReplenishable": 1
           },
           {
             "Card": "HuntersMark",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           }
         ]
       }

--- a/docs/rulesets/(Custom) It's A Trap!.json
+++ b/docs/rulesets/(Custom) It's A Trap!.json
@@ -1,0 +1,398 @@
+{
+  "Name": "(Custom) It's A Trap!",
+  "Description": "Everything you need to build devious traps for your enemies, but try not to kill your friends.",
+  "Rules": [
+    {
+      "Rule": "AbilityActionCostAdjusted",
+      "Config": {
+        "BoobyTrap": false
+      }
+    },
+    {
+      "Rule": "CardAdditionOverridden",
+      "Config": {
+        "HeroBard": [
+          "PoisonBomb",
+          "MagicBarrier",
+          "OilLamp",
+          "GasLamp",
+          "IceLamp",
+          "TheBehemoth",
+          "RepeatingBallista",
+          "TheBehemoth",
+          "VortexLamp",
+          "HealingPotion",
+          "Torch",
+          "Sneak",
+          "Bone",
+          "DetectEnemies"
+        ],
+        "HeroGuardian": [
+          "PoisonBomb",
+          "MagicBarrier",
+          "Bone",
+          "HealingPotion",
+          "OilLamp",
+          "GasLamp",
+          "IceLamp",
+          "VortexLamp",
+          "RevealPath",
+          "Torch",
+          "Sneak",
+          "DetectEnemies"
+        ],
+        "HeroHunter": [
+          "PoisonBomb",
+          "MagicBarrier",
+          "HealingPotion",
+          "PoisonedTip",
+          "OilLamp",
+          "GasLamp",
+          "IceLamp",
+          "Torch",
+          "Sneak",
+          "DetectEnemies"
+        ],
+        "HeroRogue": [
+          "PoisonBomb",
+          "HealingPotion",
+          "OilLamp",
+          "GasLamp",
+          "IceLamp",
+          "Vortex",
+          "Torch",
+          "Bone",
+          "DetectEnemies",
+          "WebBomb",
+          "VortexLamp"
+        ],
+        "HeroSorcerer": [
+          "HealingPotion",
+          "OilLamp",
+          "GasLamp",
+          "IceLamp",
+          "Vortex",
+          "Torch",
+          "Sneak",
+          "DetectEnemies",
+          "Banish",
+          "Lure",
+          "WebBomb"
+        ]
+      }
+    },
+    {
+      "Rule": "AbilityAoeAdjusted",
+      "Config": {
+        "StrengthPotion": 1,
+        "SwiftnessPotion": 1,
+        "HealingPotion": 1
+      }
+    },
+    {
+      "Rule": "LampTypesOverridden",
+      "Config": {
+        "1": [
+          "GasLamp",
+          "OilLamp",
+          "VortexLamp",
+          "GasLamp",
+          "OilLamp",
+          "VortexLamp",
+          "OilLamp",
+          "OilLamp",
+          "HealingBeacon"
+        ],
+        "2": [
+          "GasLamp",
+          "GasLamp",
+          "GasLamp",
+          "GasLamp",
+          "GasLamp",
+          "GasLamp",
+          "GasLamp",
+          "OilLamp",
+          "OilLamp",
+          "HealingBeacon"
+        ],
+        "3": [
+          "OilLamp",
+          "IceLamp",
+          "VortexLamp",
+          "OilLamp",
+          "IceLamp",
+          "VortexLamp",
+          "HealingBeacon"
+        ]
+      }
+    },
+    {
+      "Rule": "LevelPropertiesModified",
+      "Config": {
+        "FloorOneHealingFountains": 0,
+        "FloorOneLootChests": 11,
+        "FloorTwoHealingFountains": 1,
+        "FloorTwoLootChests": 14,
+        "FloorThreeHealingFountains": 1,
+        "FloorThreeLootChests": 12,
+        "FloorOneEndZoneSpikeMaxBudget": 12,
+        "PacingSpikeSegmentFloorOneBudget": 12
+      }
+    },
+    {
+      "Rule": "PieceConfigAdjusted",
+      "Config": [
+        {
+          "Piece": "HeroBard",
+          "Property": "StartHealth",
+          "Value": 30.0
+        },
+        {
+          "Piece": "HeroGuardian",
+          "Property": "StartHealth",
+          "Value": 30.0
+        },
+        {
+          "Piece": "HeroHunter",
+          "Property": "StartHealth",
+          "Value": 30.0
+        },
+        {
+          "Piece": "HeroRogue",
+          "Property": "StartHealth",
+          "Value": 30.0
+        },
+        {
+          "Piece": "HeroSorcerer",
+          "Property": "StartHealth",
+          "Value": 30.0
+        },
+        {
+          "Piece": "Torch",
+          "Property": "VisionRange",
+          "Value": 40.0
+        }
+      ]
+    },
+    {
+      "Rule": "PiecePieceTypeListOverridden",
+      "Config": {
+        "Torch": [
+          "Prop",
+          "UpdateFogOfWar",
+          "ShowNameplate"
+        ],
+        "EyeOfAvalon": [
+          "Prop",
+          "UpdateFogOfWar",
+          "Immovable",
+          "ShowHealthbar",
+          "ShowNameplate"
+        ],
+        "HealingBeacon": [
+          "Prop",
+          "Bot",
+          "ShowNameplate"
+        ]
+      }
+    },
+    {
+      "Rule": "StartCardsModified",
+      "Config": {
+        "HeroBard": [
+          {
+            "Card": "BoobyTrap",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "CourageShanty",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "OilLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "GasLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "IceLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "Sneak",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "DetectEnemies",
+            "IsReplenishable": 0
+          }
+        ],
+        "HeroGuardian": [
+          {
+            "Card": "BoobyTrap",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "ReplenishArmor",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "OilLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "GasLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "IceLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "DetectEnemies",
+            "IsReplenishable": 0
+          }
+        ],
+        "HeroHunter": [
+          {
+            "Card": "BoobyTrap",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "Arrow",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "OilLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "GasLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "IceLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "DetectEnemies",
+            "IsReplenishable": 0
+          }
+        ],
+        "HeroRogue": [
+          {
+            "Card": "BoobyTrap",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "Sneak",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "OilLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "GasLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "IceLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "DetectEnemies",
+            "IsReplenishable": 0
+          }
+        ],
+        "HeroSorcerer": [
+          {
+            "Card": "BoobyTrap",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "Zap",
+            "IsReplenishable": 1
+          },
+          {
+            "Card": "OilLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "GasLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "IceLamp",
+            "IsReplenishable": 0
+          },
+          {
+            "Card": "DetectEnemies",
+            "IsReplenishable": 0
+          }
+        ]
+      }
+    },
+    {
+      "Rule": "StatusEffectConfig",
+      "Config": [
+        {
+          "effectStateType": "Stealthed",
+          "durationTurns": 5,
+          "tickWhen": "StartTurn",
+          "stacks": false,
+          "damagePerTurn": 0,
+          "clearOnNewLevel": false,
+          "damageTags": null,
+          "healPerTurn": 0
+        },
+        {
+          "effectStateType": "Courageous",
+          "durationTurns": 2,
+          "tickWhen": "StartTurn",
+          "stacks": false,
+          "damagePerTurn": 0,
+          "clearOnNewLevel": false,
+          "damageTags": null,
+          "healPerTurn": 0
+        },
+        {
+          "effectStateType": "Fearless",
+          "durationTurns": 2,
+          "tickWhen": "StartTurn",
+          "stacks": false,
+          "damagePerTurn": 0,
+          "clearOnNewLevel": false,
+          "damageTags": null,
+          "healPerTurn": 0
+        },
+        {
+          "effectStateType": "Heroic",
+          "durationTurns": 2,
+          "tickWhen": "StartTurn",
+          "stacks": false,
+          "damagePerTurn": 0,
+          "clearOnNewLevel": false,
+          "damageTags": null,
+          "healPerTurn": 0
+        }
+      ]
+    },
+    {
+      "Rule": "TileEffectDurationOverridden",
+      "Config": {
+        "Gas": 10,
+        "Acid": 1,
+        "Web": 10,
+        "Water": 10,
+        "Target": 0
+      }
+    },
+    {
+      "Rule": "EnemyDoorOpeningDisabled",
+      "Config": true
+    }
+  ]
+}

--- a/docs/rulesets/(Custom) LuckyDip.json
+++ b/docs/rulesets/(Custom) LuckyDip.json
@@ -3,9 +3,12 @@
   "Description": "Life is like a box of chocolates + AOE changes, so stay close to your allies",
   "Rules": [
     {
-      "Rule": "AbilityDamageAdjusted",
+      "Rule": "AbilityDamageOverridden",
       "Config": {
-        "Zap": 1
+        "Zap": [
+          2,
+          5
+        ]
       }
     },
     {
@@ -14,119 +17,119 @@
         "HeroBard": [
           {
             "Card": "HealingPotion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "CourageShanty",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "WebBomb",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "DropChest",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "DropChest",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "SongOfRecovery",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           }
         ],
         "HeroGuardian": [
           {
             "Card": "HealingPotion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "ReplenishArmor",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "Bone",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "DropChest",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "DropChest",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           }
         ],
         "HeroHunter": [
           {
             "Card": "HealingPotion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "Arrow",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "PoisonedTip",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "Sneak",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "DropChest",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "DropChest",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           }
         ],
         "HeroRogue": [
           {
             "Card": "HealingPotion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "Sneak",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "PanicPowder",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "DropChest",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "DropChest",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           }
         ],
         "HeroSorcerer": [
           {
             "Card": "HealingPotion",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "Zap",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "Torch",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "DropChest",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           },
           {
             "Card": "DropChest",
-            "IsReplenishable": false
+            "IsReplenishable": 0
           }
         ]
       }

--- a/docs/rulesets/(Custom) The Swirl.json
+++ b/docs/rulesets/(Custom) The Swirl.json
@@ -8,51 +8,51 @@
         "HeroBard": [
           {
             "Card": "Vortex",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "CourageShanty",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           }
         ],
         "HeroGuardian": [
           {
             "Card": "Vortex",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "ReplenishArmor",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           }
         ],
         "HeroHunter": [
           {
             "Card": "Vortex",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "Arrow",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           }
         ],
         "HeroRogue": [
           {
             "Card": "Vortex",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "Sneak",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           }
         ],
         "HeroSorcerer": [
           {
             "Card": "Vortex",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           },
           {
             "Card": "Zap",
-            "IsReplenishable": true
+            "IsReplenishable": 1
           }
         ]
       }


### PR DESCRIPTION
Some of the example rulesets in our docs directory were outdated and wouldn't have worked correctly with the current `main` branch. Some of the newer rulesets were missing.

This fixes that.
