### PR TITLE
It's A Trap ruleset tewaks.

### DIFF
--- a/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
@@ -280,6 +280,33 @@
                     clearOnNewLevel = false,
                     tickWhen = StatusEffectsConfig.TickWhen.StartTurn,
                 },
+                new StatusEffectData
+                {
+                    effectStateType = EffectStateType.Courageous,
+                    durationTurns = 2,
+                    damagePerTurn = 0,
+                    stacks = false,
+                    clearOnNewLevel = false,
+                    tickWhen = StatusEffectsConfig.TickWhen.StartTurn,
+                },
+                new StatusEffectData
+                {
+                    effectStateType = EffectStateType.Fearless,
+                    durationTurns = 2,
+                    damagePerTurn = 0,
+                    stacks = false,
+                    clearOnNewLevel = false,
+                    tickWhen = StatusEffectsConfig.TickWhen.StartTurn,
+                },
+                new StatusEffectData
+                {
+                    effectStateType = EffectStateType.Heroic,
+                    durationTurns = 2,
+                    damagePerTurn = 0,
+                    stacks = false,
+                    clearOnNewLevel = false,
+                    tickWhen = StatusEffectsConfig.TickWhen.StartTurn,
+                },
             });
 
             var tileEffectDuration = new TileEffectDurationOverriddenRule(new Dictionary<Boardgame.Board.TileEffect, int>

--- a/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
@@ -173,7 +173,7 @@
                 { "FloorTwoHealingFountains", 1 },
                 { "FloorTwoLootChests", 14 },
                 { "FloorThreeHealingFountains", 1 },
-                { "FloorThreeLootChests", 12 },
+                { "FloorThreeLootChests", 8 },
                 { "FloorOneEndZoneSpikeMaxBudget", 12 },
                 { "PacingSpikeSegmentFloorOneBudget", 12 },
             });

--- a/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
@@ -136,6 +136,7 @@
                         AbilityKey.DetectEnemies,
                         AbilityKey.WebBomb,
                         AbilityKey.VortexLamp,
+                        AbilityKey.Teleportation,
                     }
                 },
                 {
@@ -152,6 +153,8 @@
                         AbilityKey.Banish,
                         AbilityKey.Lure,
                         AbilityKey.WebBomb,
+                        AbilityKey.Teleportation,
+                        AbilityKey.Regroup,
                     }
                 },
             });


### PR DESCRIPTION
A few tweaks after having played It's A Trap! a few times.

* There were far too many chests on the boss level.
* Sorcerer had very limited selection of cards and received too many potions.
* Bard's buff is too overpowered for this ruleset, so reduced it's duration.

