### PR TITLE
Gray Alien fixes to Demeo Reloaded Ruleset

### DIFF
--- a/HouseRules_Essentials/Rulesets/DemeoReloaded.cs
+++ b/HouseRules_Essentials/Rulesets/DemeoReloaded.cs
@@ -203,7 +203,6 @@
                         AbilityKey.PiercingVoice,
                         AbilityKey.ShatteringVoice,
                         AbilityKey.HurricaneAnthem,
-
                     }
                 },
                 {
@@ -231,7 +230,6 @@
                         AbilityKey.PoisonedTip,
                         AbilityKey.HuntersMark,
                         AbilityKey.Lure,
-
                     }
                 },
                 {
@@ -256,7 +254,6 @@
                         AbilityKey.CursedDagger,
                         AbilityKey.BoobyTrap,
                         AbilityKey.FlashBomb,
-
                     }
                 },
                 {
@@ -280,7 +277,6 @@
                         AbilityKey.MagicShield,
                         AbilityKey.MagicBarrier,
                         AbilityKey.Vortex,
-
                     }
                 },
             });
@@ -355,24 +351,24 @@
             var pieceBehavourListRule = new PieceBehavioursListOverriddenRule(new Dictionary<BoardPieceId, List<Behaviour>>
             {
                 { BoardPieceId.EarthElemental, new List<Behaviour> { Behaviour.Patrol, Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.EarthShatter, Behaviour.RangedAttackHighPrio } },
-                { BoardPieceId.Mimic, new List<Behaviour> {  Behaviour.Patrol, Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.RangedAttackHighPrio } },
-                { BoardPieceId.RootMage, new List<Behaviour> {  Behaviour.Patrol, Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.CastOnTeam } },
-                { BoardPieceId.KillerBee, new List<Behaviour> {  Behaviour.Patrol, Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.RangedAttackHighPrio } },
-                { BoardPieceId.ChestGoblin, new List<Behaviour> {  Behaviour.Patrol, Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackAndRetreat } },
+                { BoardPieceId.Mimic, new List<Behaviour> { Behaviour.Patrol, Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.RangedAttackHighPrio } },
+                { BoardPieceId.RootMage, new List<Behaviour> { Behaviour.Patrol, Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.CastOnTeam } },
+                { BoardPieceId.KillerBee, new List<Behaviour> { Behaviour.Patrol, Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.RangedAttackHighPrio } },
+                { BoardPieceId.ChestGoblin, new List<Behaviour> { Behaviour.Patrol, Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackAndRetreat } },
             });
 
             var pieceImmunityRule = new PieceImmunityListAdjustedRule(new Dictionary<BoardPieceId, List<EffectStateType>>
             {
-                { BoardPieceId.HeroSorcerer, new List<EffectStateType> {EffectStateType.Stunned, EffectStateType.Frozen } },
-                { BoardPieceId.HeroHunter, new List<EffectStateType> {EffectStateType.Tangled, EffectStateType.Petrified } },
-                { BoardPieceId.HeroGuardian, new List<EffectStateType> {EffectStateType.Stunned, EffectStateType.Weaken } },
-                { BoardPieceId.HeroBard, new List<EffectStateType> {EffectStateType.Diseased } },
-                { BoardPieceId.HeroRogue, new List<EffectStateType> {EffectStateType.Tangled, EffectStateType.Diseased } },
-                { BoardPieceId.Mimic, new List<EffectStateType> {EffectStateType.Panic, EffectStateType.Stunned, EffectStateType.Weaken, EffectStateType.Diseased } },
-                { BoardPieceId.Wyvern, new List<EffectStateType> {EffectStateType.Panic, EffectStateType.Tangled, EffectStateType.Frozen, EffectStateType.Diseased, EffectStateType.Tangled } },
-                { BoardPieceId.KillerBee, new List<EffectStateType> {EffectStateType.Tangled, EffectStateType.Diseased } },
-                { BoardPieceId.ChestGoblin, new List<EffectStateType> {EffectStateType.Stunned } },
-                { BoardPieceId.EarthElemental, new List<EffectStateType> {EffectStateType.Stunned, EffectStateType.Diseased, EffectStateType.Panic, EffectStateType.Tangled, EffectStateType.Weaken } },
+                { BoardPieceId.HeroSorcerer, new List<EffectStateType> { EffectStateType.Stunned, EffectStateType.Frozen } },
+                { BoardPieceId.HeroHunter, new List<EffectStateType> { EffectStateType.Tangled, EffectStateType.Petrified } },
+                { BoardPieceId.HeroGuardian, new List<EffectStateType> { EffectStateType.Stunned, EffectStateType.Weaken } },
+                { BoardPieceId.HeroBard, new List<EffectStateType> { EffectStateType.Diseased } },
+                { BoardPieceId.HeroRogue, new List<EffectStateType> { EffectStateType.Tangled, EffectStateType.Diseased } },
+                { BoardPieceId.Mimic, new List<EffectStateType> { EffectStateType.Panic, EffectStateType.Stunned, EffectStateType.Weaken, EffectStateType.Diseased } },
+                { BoardPieceId.Wyvern, new List<EffectStateType> { EffectStateType.Panic, EffectStateType.Tangled, EffectStateType.Frozen, EffectStateType.Diseased, EffectStateType.Tangled } },
+                { BoardPieceId.KillerBee, new List<EffectStateType> { EffectStateType.Tangled, EffectStateType.Diseased } },
+                { BoardPieceId.ChestGoblin, new List<EffectStateType> { EffectStateType.Stunned } },
+                { BoardPieceId.EarthElemental, new List<EffectStateType> { EffectStateType.Stunned, EffectStateType.Diseased, EffectStateType.Panic, EffectStateType.Tangled, EffectStateType.Weaken } },
             });
 
             var tileEffectDuration = new TileEffectDurationOverriddenRule(new Dictionary<Boardgame.Board.TileEffect, int>

--- a/HouseRules_Essentials/Rulesets/DemeoReloaded.cs
+++ b/HouseRules_Essentials/Rulesets/DemeoReloaded.cs
@@ -16,49 +16,55 @@
 
             var spawnCatetoriesRule = new SpawnCategoryOverriddenRule(new Dictionary<BoardPieceId, List<int>>
             {
-                { BoardPieceId.Mimic, new List<int> { 1, 1, 1 } },
-                { BoardPieceId.Wyvern, new List<int> { 1, 1, 2 } },
-                { BoardPieceId.ChestGoblin, new List<int> { 2, 1, 1 } },
-                { BoardPieceId.RootGolem, new List<int> { 1, 1, 2 } },
-                { BoardPieceId.Brookmare, new List<int> { 1, 1, 2 } },
-                { BoardPieceId.EarthElemental, new List<int> { 1, 1, 1 } },
-                { BoardPieceId.Bandit, new List<int> { 3, 2, 1 } },
-                { BoardPieceId.Cavetroll, new List<int> { 1, 1, 2 } },
-                { BoardPieceId.DruidArcher, new List<int> { 3, 2, 1 } },
-                { BoardPieceId.DruidHoundMaster, new List<int> { 3, 2, 1 } },
-                { BoardPieceId.ElvenArcher, new List<int> { 4, 2, 2 } },
-                { BoardPieceId.ElvenHound, new List<int> { 6, 3, 2 } },
-                { BoardPieceId.ElvenMarauder, new List<int> { 1, 1, 1 } },
-                { BoardPieceId.GoblinChieftan, new List<int> { 3, 2, 1 } },
-                { BoardPieceId.GoblinMadUn, new List<int> { 3, 2, 1 } },
-                { BoardPieceId.RootBeast, new List<int> { 2, 1, 1 } },
-                { BoardPieceId.RootHound, new List<int> { 6, 2, 2 } },
-                { BoardPieceId.ScabRat, new List<int> { 3, 2, 1 } },
-                { BoardPieceId.TheUnspoken, new List<int> { 3, 2, 1 } },
-                { BoardPieceId.Spider, new List<int> { 5, 2, 1 } },
-                { BoardPieceId.GiantSpider, new List<int> { 3, 1, 1 } },
-                { BoardPieceId.Rat, new List<int> { 8, 6, 1 } },
-                { BoardPieceId.Slimeling, new List<int> { 4, 1, 1 } },
-                { BoardPieceId.Thug, new List<int> { 3, 1, 2 } },
-                { BoardPieceId.ElvenMystic, new List<int> { 6, 2, 1 } },
-                { BoardPieceId.ElvenPriest, new List<int> { 3, 2, 1 } },
-                { BoardPieceId.ElvenSkirmisher, new List<int> { 3, 2, 1 } },
+                { BoardPieceId.Wyvern, new List<int> { 2, 1, 2 } },
+                { BoardPieceId.Cavetroll, new List<int> { 2, 1, 1 } },
+                { BoardPieceId.RootGolem, new List<int> { 3, 1, 2 } },
+                { BoardPieceId.Brookmare, new List<int> { 2, 1, 2 } },
+                { BoardPieceId.Gorgon, new List<int> { 2, 1, 2 } },
+                { BoardPieceId.SilentSentinel, new List<int> { 3, 1, 2 } },
+                { BoardPieceId.ElvenArcher, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.ElvenHound, new List<int> { 4, 3, 1 } },
+                { BoardPieceId.RootHound, new List<int> { 4, 3, 1 } },
+                { BoardPieceId.TheUnspoken, new List<int> { 4, 3, 1 } },
+                { BoardPieceId.Mimic, new List<int> { 2, 1, 1 } },
+                { BoardPieceId.EarthElemental, new List<int> { 2, 1, 1 } },
+                { BoardPieceId.Sigataur, new List<int> { 3, 1, 1 } },
+                { BoardPieceId.ChestGoblin, new List<int> { 3, 1, 1 } },
+                { BoardPieceId.CultMemberElder, new List<int> { 5, 2, 1 } },
+                { BoardPieceId.ElvenCultist, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.SpiderEgg, new List<int> { 5, 2, 1 } },
+                { BoardPieceId.TheUnseen, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.GiantSlime, new List<int> { 3, 1, 1 } },
                 { BoardPieceId.FireElemental, new List<int> { 3, 1, 1 } },
-                { BoardPieceId.GoblinFighter, new List<int> { 3, 2, 1 } },
-                { BoardPieceId.GoblinRanger, new List<int> { 3, 2, 1 } },
-                { BoardPieceId.Gorgon, new List<int> { 1, 1, 2 } },
+                { BoardPieceId.ElvenMarauder, new List<int> { 2, 1, 1 } },
                 { BoardPieceId.IceElemental, new List<int> { 2, 1, 1 } },
-                { BoardPieceId.KillerBee, new List<int> { 5, 2, 1 } },
-                { BoardPieceId.RatNest, new List<int> { 3, 1, 1 } },
-                { BoardPieceId.RootMage, new List<int> { 4, 2, 1 } },
-                { BoardPieceId.SporeFungus, new List<int> { 3, 1, 1 } },
-                { BoardPieceId.TheUnheard, new List<int> { 4, 2, 1 } },
-                { BoardPieceId.SilentSentinel, new List<int> { 1, 1, 2 } },
-                { BoardPieceId.GiantSlime, new List<int> { 2, 1, 1 } },
+                { BoardPieceId.GiantSpider, new List<int> { 3, 1, 1 } },
+                { BoardPieceId.Bandit, new List<int> { 5, 3, 1 } },
+                { BoardPieceId.DruidArcher, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.DruidHoundMaster, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.GoblinChieftan, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.GoblinMadUn, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.RootBeast, new List<int> { 5, 2, 1 } },
+                { BoardPieceId.ScabRat, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.Spider, new List<int> { 5, 2, 1 } },
+                { BoardPieceId.Rat, new List<int> { 5, 2, 1 } },
+                { BoardPieceId.TheUnheard, new List<int> { 3, 2, 2 } },
+                { BoardPieceId.Slimeling, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.Thug, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.ElvenMystic, new List<int> { 5, 3, 1 } },
+                { BoardPieceId.ElvenPriest, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.ElvenSkirmisher, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.GoblinFighter, new List<int> { 5, 2, 1 } },
+                { BoardPieceId.GoblinRanger, new List<int> { 5, 2, 1 } },
+                { BoardPieceId.KillerBee, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.RatNest, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.RootMage, new List<int> { 4, 3, 1 } },
+                { BoardPieceId.SporeFungus, new List<int> { 5, 2, 1 } },
             });
 
             var bardCards = new List<StartCardsModifiedRule.CardConfig>
             {
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Torch, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HurricaneAnthem, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.SongOfRecovery, ReplenishFrequency = 0 },
@@ -69,6 +75,7 @@
             };
             var guardianCards = new List<StartCardsModifiedRule.CardConfig>
             {
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Torch, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.WhirlwindAttack, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PiercingThrow, ReplenishFrequency = 0 },
@@ -78,6 +85,7 @@
             };
             var hunterCards = new List<StartCardsModifiedRule.CardConfig>
             {
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Torch, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HailOfArrows, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.PoisonedTip, ReplenishFrequency = 0 },
@@ -88,6 +96,7 @@
             };
             var assassinCards = new List<StartCardsModifiedRule.CardConfig>
             {
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Torch, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Sneak, ReplenishFrequency = 1 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Blink, ReplenishFrequency = 0 },
@@ -97,6 +106,7 @@
             };
             var sorcererCards = new List<StartCardsModifiedRule.CardConfig>
             {
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Torch, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Zap, ReplenishFrequency = 1 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.HealingPotion, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.Fireball, ReplenishFrequency = 0 },
@@ -129,13 +139,19 @@
                 new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroGuardian, Property = "CriticalHitDamage", Value = 9 },
                 new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Mimic, Property = "BerserkBelowHealth", Value = 0.9f },
                 new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Mimic, Property = "StartArmor", Value = 5 },
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Mimic, Property = "StartHealth", Value = 24 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Mimic, Property = "StartHealth", Value = 20 },
                 new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Mimic, Property = "MoveRange", Value = 3 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Mimic, Property = "AttackDamage", Value = 5 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.ChestGoblin, Property = "AttackDamage", Value = 3 },
                 new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.ChestGoblin, Property = "StartHealth", Value = 18 },
                 new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.ChestGoblin, Property = "MoveRange", Value = 3 },
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Wyvern, Property = "BerserkBelowHealth", Value = 0.75f },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Wyvern, Property = "BerserkBelowHealth", Value = 0.65f },
                 new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Wyvern, Property = "BarkArmor", Value = 2 },
-                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Wyvern, Property = "MoveRange", Value = 4 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Wyvern, Property = "MoveRange", Value = 3 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Wyvern, Property = "AttackDamage", Value = 5 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Wyvern, Property = "StartHealth", Value = 28 },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Bandit, Property = "WaterTrailChance", Value = 0.15f },
+                new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Thug, Property = "WaterTrailChance", Value = 0.15f },
                 new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.KillerBee, Property = "WaterTrailChance", Value = 0.15f },
                 new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Rat, Property = "WaterTrailChance", Value = 0.15f },
                 new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Spider, Property = "WaterTrailChance", Value = 0.15f },
@@ -147,7 +163,6 @@
                 {
                     BoardPieceId.HeroGuardian, new List<AbilityKey>
                     {
-                        AbilityKey.Antitoxin,
                         AbilityKey.Bone,
                         AbilityKey.Regroup,
                         AbilityKey.Rejuvenation,
@@ -194,7 +209,6 @@
                 {
                     BoardPieceId.HeroHunter, new List<AbilityKey>
                     {
-                        AbilityKey.Antitoxin,
                         AbilityKey.BeastWhisperer,
                         AbilityKey.WebBomb,
                         AbilityKey.RepeatingBallista,
@@ -249,7 +263,6 @@
                     BoardPieceId.HeroSorcerer, new List<AbilityKey>
                     {
                         AbilityKey.Bone,
-                        AbilityKey.Antitoxin,
                         AbilityKey.Regroup,
                         AbilityKey.Rejuvenation,
                         AbilityKey.OneMoreThing,
@@ -274,6 +287,15 @@
 
             var statusEffectRule = new StatusEffectConfigRule(new List<StatusEffectData>
             {
+                new StatusEffectData
+                {
+                    effectStateType = EffectStateType.TorchPlayer,
+                    durationTurns = 25,
+                    damagePerTurn = 0,
+                    stacks = false,
+                    clearOnNewLevel = false,
+                    tickWhen = StatusEffectsConfig.TickWhen.EndTurn,
+                },
                 new StatusEffectData
                 {
                     effectStateType = EffectStateType.HealingSong,
@@ -326,16 +348,17 @@
                 { BoardPieceId.EarthElemental, new List<AbilityKey> { AbilityKey.EnemyMelee, AbilityKey.EnemyKnockbackMelee, AbilityKey.EarthShatter, AbilityKey.EnemyJavelin } },
                 { BoardPieceId.Mimic, new List<AbilityKey> { AbilityKey.EnemyMelee, AbilityKey.AcidSpit } },
                 { BoardPieceId.RootMage, new List<AbilityKey> { AbilityKey.EnemyMelee, AbilityKey.TeleportEnemy } },
+                { BoardPieceId.ChestGoblin, new List<AbilityKey> { AbilityKey.EnemyMelee, AbilityKey.EnemyStealGold } },
                 { BoardPieceId.KillerBee, new List<AbilityKey> { AbilityKey.EnemyMelee, AbilityKey.ThornPowder } },
             });
 
             var pieceBehavourListRule = new PieceBehavioursListOverriddenRule(new Dictionary<BoardPieceId, List<Behaviour>>
             {
-                { BoardPieceId.EarthElemental, new List<Behaviour> { Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.EarthShatter, Behaviour.RangedAttackHighPrio } },
-                { BoardPieceId.Mimic, new List<Behaviour> { Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.RangedAttackHighPrio } },
-                { BoardPieceId.RootMage, new List<Behaviour> { Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.CastOnTeam } },
-                { BoardPieceId.KillerBee, new List<Behaviour> { Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.RangedAttackHighPrio } },
-                { BoardPieceId.ChestGoblin, new List<Behaviour> { Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackAndRetreat } },
+                { BoardPieceId.EarthElemental, new List<Behaviour> { Behaviour.Patrol, Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.EarthShatter, Behaviour.RangedAttackHighPrio } },
+                { BoardPieceId.Mimic, new List<Behaviour> {  Behaviour.Patrol, Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.RangedAttackHighPrio } },
+                { BoardPieceId.RootMage, new List<Behaviour> {  Behaviour.Patrol, Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.CastOnTeam } },
+                { BoardPieceId.KillerBee, new List<Behaviour> {  Behaviour.Patrol, Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackPlayer, Behaviour.RangedAttackHighPrio } },
+                { BoardPieceId.ChestGoblin, new List<Behaviour> {  Behaviour.Patrol, Behaviour.FollowPlayerMeleeAttacker, Behaviour.AttackAndRetreat } },
             });
 
             var pieceImmunityRule = new PieceImmunityListAdjustedRule(new Dictionary<BoardPieceId, List<EffectStateType>>
@@ -348,6 +371,7 @@
                 { BoardPieceId.Mimic, new List<EffectStateType> {EffectStateType.Panic, EffectStateType.Stunned, EffectStateType.Weaken, EffectStateType.Diseased } },
                 { BoardPieceId.Wyvern, new List<EffectStateType> {EffectStateType.Panic, EffectStateType.Tangled, EffectStateType.Frozen, EffectStateType.Diseased, EffectStateType.Tangled } },
                 { BoardPieceId.KillerBee, new List<EffectStateType> {EffectStateType.Tangled, EffectStateType.Diseased } },
+                { BoardPieceId.ChestGoblin, new List<EffectStateType> {EffectStateType.Stunned } },
                 { BoardPieceId.EarthElemental, new List<EffectStateType> {EffectStateType.Stunned, EffectStateType.Diseased, EffectStateType.Panic, EffectStateType.Tangled, EffectStateType.Weaken } },
             });
 
@@ -366,6 +390,7 @@
                 { AbilityKey.Sneak, false },
                 { AbilityKey.Grab, false },
                 { AbilityKey.BeastWhisperer, false },
+                { AbilityKey.CallCompanion, false },
             });
 
             var abilityHealOverriddenRule = new AbilityHealOverriddenRule(new Dictionary<AbilityKey, int>
@@ -394,6 +419,7 @@
                 { AbilityKey.Zap, new List<int> { 3, 8 } },
                 { AbilityKey.Fireball, new List<int> { 12, 25 } },
                 { AbilityKey.Freeze, new List<int> { 7, 15 } },
+                { AbilityKey.Vortex, new List<int> { 3, 8 } },
                 { AbilityKey.WhirlwindAttack, new List<int> { 4, 9 } },
                 { AbilityKey.Charge, new List<int> { 4, 12 } },
                 { AbilityKey.PiercingThrow, new List<int> { 5, 11 } },
@@ -409,30 +435,28 @@
             var backstabConfigRule = new BackstabConfigOverriddenRule(new List<BoardPieceId> { BoardPieceId.HeroBard, BoardPieceId.HeroRogue });
             var petsFocusHuntersMarkRule = new PetsFocusHunterMarkRule(true);
             var enemyRespawnDisabledRule = new EnemyRespawnDisabledRule(true);
-            var cardEnergyFromAttackRule = new CardEnergyFromAttackMultipliedRule(0.75f);
-            var cardEnergyFromRecyclingRule = new CardEnergyFromRecyclingMultipliedRule(0.75f);
-            var enemyAttackScaledRule = new EnemyAttackScaledRule(1.25f);
-            var enemyHealthScaledRule = new EnemyHealthScaledRule(1.334f);
+            var cardEnergyFromAttackRule = new CardEnergyFromAttackMultipliedRule(0.8f);
+            var cardEnergyFromRecyclingRule = new CardEnergyFromRecyclingMultipliedRule(0.8f);
+            var enemyAttackScaledRule = new EnemyAttackScaledRule(1.2f);
+            var enemyHealthScaledRule = new EnemyHealthScaledRule(1.2f);
 
             var levelSequenceOverriddenRule = new LevelSequenceOverriddenRule(new List<string>
             {
-                "SewersFloor12",
-                "ShopFloor02",
-                "ElvenFloor02",
+                "ForestFloor01",
                 "ForestShopFloor",
-                "ForestFloor02",
+                "ElvenFloor08",
+                "ShopFloor02",
+                "SewersFloor09",
             });
 
             var levelPropertiesRule = new LevelPropertiesModifiedRule(new Dictionary<string, int>
             {
                 { "BigGoldPileChance", 30 },
                 { "FloorOneHealingFountains", 1 },
-                { "FloorOneLootChests", 1 },
-                { "FloorOneClassCardChests", 2 },
+                { "FloorOneLootChests", 3 },
                 { "FloorOneGoldMaxAmount", 600 },
                 { "FloorTwoHealingFountains", 1 },
-                { "FloorTwoLootChests", 2 },
-                { "FloorTwoClassCardChests", 3 },
+                { "FloorTwoLootChests", 5 },
                 { "FloorTwoGoldMaxAmount", 800 },
                 { "FloorThreeHealingFountains", 1 },
                 { "FloorThreeLootChests", 1 },

--- a/HouseRules_Essentials/Rulesets/DemeoReloaded.cs
+++ b/HouseRules_Essentials/Rulesets/DemeoReloaded.cs
@@ -18,27 +18,27 @@
             {
                 { BoardPieceId.Wyvern, new List<int> { 2, 1, 2 } },
                 { BoardPieceId.Cavetroll, new List<int> { 2, 1, 1 } },
-                { BoardPieceId.RootGolem, new List<int> { 3, 1, 2 } },
+                { BoardPieceId.RootGolem, new List<int> { 2, 1, 2 } },
                 { BoardPieceId.Brookmare, new List<int> { 2, 1, 2 } },
                 { BoardPieceId.Gorgon, new List<int> { 2, 1, 2 } },
-                { BoardPieceId.SilentSentinel, new List<int> { 3, 1, 2 } },
+                { BoardPieceId.SilentSentinel, new List<int> { 2, 1, 2 } },
                 { BoardPieceId.ElvenArcher, new List<int> { 4, 2, 1 } },
-                { BoardPieceId.ElvenHound, new List<int> { 4, 3, 1 } },
-                { BoardPieceId.RootHound, new List<int> { 4, 3, 1 } },
+                { BoardPieceId.ElvenHound, new List<int> { 5, 3, 1 } },
+                { BoardPieceId.RootHound, new List<int> { 5, 3, 1 } },
                 { BoardPieceId.TheUnspoken, new List<int> { 4, 3, 1 } },
                 { BoardPieceId.Mimic, new List<int> { 2, 1, 1 } },
                 { BoardPieceId.EarthElemental, new List<int> { 2, 1, 1 } },
-                { BoardPieceId.Sigataur, new List<int> { 3, 1, 1 } },
-                { BoardPieceId.ChestGoblin, new List<int> { 3, 1, 1 } },
+                { BoardPieceId.Sigataur, new List<int> { 2, 1, 1 } },
+                { BoardPieceId.ChestGoblin, new List<int> { 2, 1, 1 } },
                 { BoardPieceId.CultMemberElder, new List<int> { 5, 2, 1 } },
-                { BoardPieceId.ElvenCultist, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.ElvenCultist, new List<int> { 5, 2, 1 } },
                 { BoardPieceId.SpiderEgg, new List<int> { 5, 2, 1 } },
                 { BoardPieceId.TheUnseen, new List<int> { 4, 2, 1 } },
-                { BoardPieceId.GiantSlime, new List<int> { 3, 1, 1 } },
+                { BoardPieceId.GiantSlime, new List<int> { 2, 1, 1 } },
                 { BoardPieceId.FireElemental, new List<int> { 3, 1, 1 } },
                 { BoardPieceId.ElvenMarauder, new List<int> { 2, 1, 1 } },
                 { BoardPieceId.IceElemental, new List<int> { 2, 1, 1 } },
-                { BoardPieceId.GiantSpider, new List<int> { 3, 1, 1 } },
+                { BoardPieceId.GiantSpider, new List<int> { 2, 1, 1 } },
                 { BoardPieceId.Bandit, new List<int> { 5, 3, 1 } },
                 { BoardPieceId.DruidArcher, new List<int> { 4, 2, 1 } },
                 { BoardPieceId.DruidHoundMaster, new List<int> { 4, 2, 1 } },
@@ -49,7 +49,7 @@
                 { BoardPieceId.Spider, new List<int> { 5, 2, 1 } },
                 { BoardPieceId.Rat, new List<int> { 5, 2, 1 } },
                 { BoardPieceId.TheUnheard, new List<int> { 3, 2, 2 } },
-                { BoardPieceId.Slimeling, new List<int> { 4, 2, 1 } },
+                { BoardPieceId.Slimeling, new List<int> { 5, 2, 1 } },
                 { BoardPieceId.Thug, new List<int> { 4, 2, 1 } },
                 { BoardPieceId.ElvenMystic, new List<int> { 5, 3, 1 } },
                 { BoardPieceId.ElvenPriest, new List<int> { 4, 2, 1 } },
@@ -58,7 +58,7 @@
                 { BoardPieceId.GoblinRanger, new List<int> { 5, 2, 1 } },
                 { BoardPieceId.KillerBee, new List<int> { 4, 2, 1 } },
                 { BoardPieceId.RatNest, new List<int> { 4, 2, 1 } },
-                { BoardPieceId.RootMage, new List<int> { 4, 3, 1 } },
+                { BoardPieceId.RootMage, new List<int> { 5, 3, 1 } },
                 { BoardPieceId.SporeFungus, new List<int> { 5, 2, 1 } },
             });
 
@@ -70,7 +70,7 @@
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.SongOfRecovery, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.ShatteringVoice, ReplenishFrequency = 0 },
                 new StartCardsModifiedRule.CardConfig { Card = AbilityKey.CourageShanty, ReplenishFrequency = 1 },
-                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.CourageShanty, ReplenishFrequency = 1 },
+                new StartCardsModifiedRule.CardConfig { Card = AbilityKey.TurretHealProjectile, ReplenishFrequency = 1 },
 
             };
             var guardianCards = new List<StartCardsModifiedRule.CardConfig>
@@ -380,6 +380,12 @@
                 { TileEffect.Target, 0 },
             });
 
+            var pieceUseWhenKilledRule = new PieceUseWhenKilledOverriddenRule(new Dictionary<BoardPieceId, List<AbilityKey>>
+            {
+                { BoardPieceId.ChestGoblin, new List<AbilityKey> { AbilityKey.EnemyDropStolenGoods, AbilityKey.DropChest } },
+                { BoardPieceId.EarthElemental, new List<AbilityKey> { AbilityKey.DeathDropJavelin } },
+            });
+
             var abilityActionCostRule = new AbilityActionCostAdjustedRule(new Dictionary<AbilityKey, bool>
             {
                 { AbilityKey.Zap, false },
@@ -387,6 +393,7 @@
                 { AbilityKey.Grab, false },
                 { AbilityKey.BeastWhisperer, false },
                 { AbilityKey.CallCompanion, false },
+                { AbilityKey.CourageShanty, false },
             });
 
             var abilityHealOverriddenRule = new AbilityHealOverriddenRule(new Dictionary<AbilityKey, int>
@@ -431,10 +438,10 @@
             var backstabConfigRule = new BackstabConfigOverriddenRule(new List<BoardPieceId> { BoardPieceId.HeroBard, BoardPieceId.HeroRogue });
             var petsFocusHuntersMarkRule = new PetsFocusHunterMarkRule(true);
             var enemyRespawnDisabledRule = new EnemyRespawnDisabledRule(true);
-            var cardEnergyFromAttackRule = new CardEnergyFromAttackMultipliedRule(0.8f);
-            var cardEnergyFromRecyclingRule = new CardEnergyFromRecyclingMultipliedRule(0.8f);
-            var enemyAttackScaledRule = new EnemyAttackScaledRule(1.2f);
-            var enemyHealthScaledRule = new EnemyHealthScaledRule(1.2f);
+            var cardEnergyFromAttackRule = new CardEnergyFromAttackMultipliedRule(0.667f);
+            var cardEnergyFromRecyclingRule = new CardEnergyFromRecyclingMultipliedRule(0.667f);
+            var enemyAttackScaledRule = new EnemyAttackScaledRule(1.334f);
+            var enemyHealthScaledRule = new EnemyHealthScaledRule(1.334f);
 
             var levelSequenceOverriddenRule = new LevelSequenceOverriddenRule(new List<string>
             {
@@ -449,11 +456,11 @@
             {
                 { "BigGoldPileChance", 30 },
                 { "FloorOneHealingFountains", 1 },
-                { "FloorOneLootChests", 3 },
-                { "FloorOneGoldMaxAmount", 600 },
+                { "FloorOneLootChests", 2 },
+                { "FloorOneGoldMaxAmount", 550 },
                 { "FloorTwoHealingFountains", 1 },
-                { "FloorTwoLootChests", 5 },
-                { "FloorTwoGoldMaxAmount", 800 },
+                { "FloorTwoLootChests", 4 },
+                { "FloorTwoGoldMaxAmount", 750 },
                 { "FloorThreeHealingFountains", 1 },
                 { "FloorThreeLootChests", 1 },
             });
@@ -470,6 +477,7 @@
                 pieceBehavourListRule,
                 pieceImmunityRule,
                 tileEffectDuration,
+                pieceUseWhenKilledRule,
                 abilityActionCostRule,
                 abilityHealOverriddenRule,
                 aoeAdjustmentedRule,


### PR DESCRIPTION
Fixed extra space warnings on build

Adjusted some spawns

Change Shanty to 0 AP

Replace second Shanty with single target heal that can only be used every 3 turns

Fix special enemies weren't dropping cards/loot

Fix too easy! Increased enemy damage/health and removed some gold, some chests and, lowered mana gain