### PR TITLE
Gain a user-configured ability whenever a critical hit is scored.

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -33,6 +33,7 @@
             HR.Rulebook.Register(typeof(EnemyDoorOpeningDisabledRule));
             HR.Rulebook.Register(typeof(EnemyHealthScaledRule));
             HR.Rulebook.Register(typeof(EnemyRespawnDisabledRule));
+            HR.Rulebook.Register(typeof(FreeAbilityOnCritRule));
             HR.Rulebook.Register(typeof(GoldPickedUpMultipliedRule));
             HR.Rulebook.Register(typeof(LampTypesOverriddenRule));
             HR.Rulebook.Register(typeof(LevelExitLockedUntilAllEnemiesDefeatedRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Rules\AbilityDamageOverriddenRule.cs" />
     <Compile Include="Rules\AbilityHealOverriddenRule.cs" />
     <Compile Include="Rules\CardClassRestrictionOverriddenRule.cs" />
+    <Compile Include="Rules\FreeAbilityOnCritRule.cs" />
     <Compile Include="Rules\RegroupAlliesRule.cs" />
     <Compile Include="Rules\TileEffectDurationOverriddenRule.cs" />
     <Compile Include="Rules\LampTypesOverriddenRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -329,6 +329,27 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
   },
   ```
 
+#### __FreeAbilityOnCrit__: A Critical Hit rewards you with a free ability.
+  - Whenever you score a critical hit, a user-configured card is added to your inventory.
+  - Allows configuration of different abilities on a per-hero basis.
+  - To configure:
+    - Specify a Dictionary of [BoardPieceIds](../docs/SettingsReference.md#boardpieceids) and abilities.
+
+  ###### _Example JSON config for FreeAbilityOnCrit_
+
+  ```json
+  {
+    "Rule": "FreeAbilityOnCrit",
+    "Config": {
+      "HeroBard": "OneMoreThing",
+      "HeroHunter": "PoisonedTip",
+      "HeroSorcerer": "Fireball",
+      "HeroGuardian": "Bone",
+      "HeroRogue": "PoisonBomb"
+    }
+  },
+```  
+
 #### __GoldPickedUpMultiplied__: 💰Gold💰 picked up is multiplied
   - To configure:
     - Specify a decimal number representing how gold is multiplied.

--- a/HouseRules_Essentials/Rules/FreeAbilityOnCritRule.cs
+++ b/HouseRules_Essentials/Rules/FreeAbilityOnCritRule.cs
@@ -1,0 +1,63 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System.Collections.Generic;
+    using Boardgame;
+    using Boardgame.BoardEntities;
+    using Boardgame.BoardEntities.Abilities;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Types;
+
+    public sealed class FreeAbilityOnCritRule : Rule, IConfigWritable<Dictionary<BoardPieceId, AbilityKey>>, IPatchable, IMultiplayerSafe
+    {
+        public override string Description => "Critical Hit gives free card.";
+
+        private static Dictionary<BoardPieceId, AbilityKey> _globalAdjustments;
+        private static bool _isActivated;
+
+        private readonly Dictionary<BoardPieceId, AbilityKey> _adjustments;
+
+        public FreeAbilityOnCritRule(Dictionary<BoardPieceId, AbilityKey> adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        public Dictionary<BoardPieceId, AbilityKey> GetConfigObject() => _adjustments;
+
+        protected override void OnActivate(GameContext gameContext)
+        {
+            _globalAdjustments = _adjustments;
+            _isActivated = true;
+        }
+
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
+
+        private static void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Ability), "GenerateAttackDamage"),
+                prefix: new HarmonyMethod(
+                    typeof(FreeAbilityOnCritRule),
+                    nameof(Ability_GenerateAttackDamage_Prefix)));
+        }
+
+        private static bool Ability_GenerateAttackDamage_Prefix(Piece source, Dice.Outcome diceResult)
+        {
+            if (!_isActivated)
+            {
+                return true;
+            }
+
+            if (diceResult == Dice.Outcome.Crit)
+            {
+                if (source.IsPlayer() && _globalAdjustments.ContainsKey(source.boardPieceId))
+                {
+                    source.TryAddAbilityToInventory(_globalAdjustments[source.boardPieceId], isReplenishable: false);
+                    HR.ScheduleBoardSync();
+                }
+            }
+
+            return true; // Allow the regular GenerateAttackDamage function to run afterwards.
+        }
+    }
+}


### PR DESCRIPTION
This PR is a partial response to #262

I initially had this rule only awarding an extra AP after a critical strike, but realised that the config could be extended to give any card desired, and on a per-hero basis.

As with everything I PR, this has been poorly tested, but I think it should all be OK. I've made an attempt to sync after the inventory gets changed so hopefully this will function as expected in multiplayer too.

This is an extremely frustrating rule to test as you need to be rolling crits... It's amazing how long your can to without rolling one. I managed to complete the 1st floor of sewers without a single crit. 

For my testing, I added the following into one of the rulesets.

```
            var freeActionOnCrit = new FreeAbilityOnCritRule(new Dictionary<BoardPieceId, AbilityKey>
            {
                { BoardPieceId.HeroBard, AbilityKey.OneMoreThing },
                { BoardPieceId.HeroHunter, AbilityKey.PoisonedTip },
                { BoardPieceId.HeroSorcerer, AbilityKey.Fireball },
                { BoardPieceId.HeroGuardian, AbilityKey.Bone },
                { BoardPieceId.HeroRogue, AbilityKey.PoisonBomb },
            });

```