### PR TITLE
Add a user-configurable amout of HP to target each time CourageShanty is cast.

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -23,6 +23,7 @@
             HR.Rulebook.Register(typeof(AbilityActionCostAdjustedRule));
             HR.Rulebook.Register(typeof(AbilityRandomPieceListRule));
             HR.Rulebook.Register(typeof(BackstabConfigOverriddenRule));
+            HR.Rulebook.Register(typeof(CourageShantyAddsHPRule));
             HR.Rulebook.Register(typeof(CardAdditionOverriddenRule));
             HR.Rulebook.Register(typeof(CardClassRestrictionOverriddenRule));
             HR.Rulebook.Register(typeof(CardEnergyFromAttackMultipliedRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Rules\AbilityHealOverriddenRule.cs" />
     <Compile Include="Rules\CardClassRestrictionOverriddenRule.cs" />
     <Compile Include="Rules\FreeAbilityOnCritRule.cs" />
+    <Compile Include="Rules\CourageShantyAddsHPRule.cs" />
     <Compile Include="Rules\RegroupAlliesRule.cs" />
     <Compile Include="Rules\TileEffectDurationOverriddenRule.cs" />
     <Compile Include="Rules\LampTypesOverriddenRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -277,6 +277,19 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
     },
   ```
 
+#### __CourageShantyAddsHP__: In addition to normal effects, Courage Shanty also adds HP
+  - To configure:
+    - Specify a decimal number for how many HP to add to the target each time CourageShanty is used.
+
+  ###### _Example JSON config for CourageShantyAddsHP_
+
+  ```json
+  {
+    "Rule": "CourageShantyAddsHP",
+    "Config": 2
+  },
+  ```
+
 #### __EnemyAttackScaled__: Enemy ⚔️attack⚔️ damage is scaled
   - To configure:
     - Specify a decimal number representing how enemy attack damage is multiplied.

--- a/HouseRules_Essentials/Rules/CourageShantyAddsHPRule.cs
+++ b/HouseRules_Essentials/Rules/CourageShantyAddsHPRule.cs
@@ -1,0 +1,51 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using Boardgame;
+    using Boardgame.BoardEntities;
+    using Boardgame.GameplayEffects;
+    using HarmonyLib;
+    using HouseRules.Types;
+
+    public sealed class CourageShantyAddsHPRule : Rule, IConfigWritable<int>, IPatchable, IMultiplayerSafe
+    {
+        public override string Description => "Courage Shanty also adds HP.";
+
+        private static int _globalAdjustments;
+        private static bool _isActivated;
+
+        private readonly int _adjustments;
+
+        public CourageShantyAddsHPRule(int adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        public int GetConfigObject() => _adjustments;
+
+        protected override void OnActivate(GameContext gameContext)
+        {
+            _globalAdjustments = _adjustments;
+            _isActivated = true;
+        }
+
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
+
+        private static void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(StrengthenCourage), "UpdateEffectsOnTarget"),
+                postfix: new HarmonyMethod(
+                    typeof(CourageShantyAddsHPRule),
+                    nameof(StrengthenCourager_UpdateEffectsOnTarget_Postfix)));
+        }
+
+        private static void StrengthenCourager_UpdateEffectsOnTarget_Postfix(Target target)
+        {
+            if (_isActivated)
+            {
+                target.piece.effectSink.Heal(_globalAdjustments);
+                HR.ScheduleBoardSync();
+            }
+        }
+    }
+}


### PR DESCRIPTION
A new rule to allow a user-configurable number of HP to be added to a target when CourageShanty is used.
I took a look into #332 and made a rule to implement it.

I'm wondering once again how we can make this kind of rule more flexible (as I was wondering with FreeAbilityOnCrit). Although this rule adds <int> HP, it would be just as reasonable for it to replenish armor, remove weakness, add strength/speed  or any number of other things that people might want. Maybe we should be implementing a generic method that can set any of the `Stats.Type` parmaters in the same way that we did for pieceConfig... Rules like this could then accept lists of Stat.Types and adjustments for them as config.

I added an `HR.ScheduleBoardSync` here because the clients would probably like to know about their extra HP sooner rather than later, but I'm wondering if it would be better to use `target.piece.effectSink.SyncStat(Stats.Type.Health, target.piece.GetHealth(), 1);` to trigger the sync instead. I tested this out with PC-Flatscreen as a client and it still took about 5 seconds for the newly changed Health stat to appear - I'm not sure if that is any better than a regular Boardsync, so left BoardSync in place for now.

Closes #322

## Testing
Add something like the following into a ruleset and give it a whirl.

```
                new CourageShantyAddsHPRule(3),
``` 