### PR TITLE
Experimental approach for implementing a way to limit a rule particular adventures.

### DIFF
--- a/HouseRules_Essentials/Rules/LevelPropertiesModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/LevelPropertiesModifiedRule.cs
@@ -7,19 +7,25 @@
     using HarmonyLib;
     using HouseRules.Types;
 
-    public sealed class LevelPropertiesModifiedRule : Rule, IConfigWritable<Dictionary<string, int>>, IMultiplayerSafe
+    public sealed class LevelPropertiesModifiedRule : Rule, IConfigWritable<LevelPropertiesModifiedRule.ConfigData>, IMultiplayerSafe
     {
         public override string Description => "Level properties are modified";
 
         private const int DefaultDreadLevel = 1;
-        private readonly Dictionary<string, int> _levelProperties;
+        private readonly ConfigData _levelProperties;
 
-        public LevelPropertiesModifiedRule(Dictionary<string, int> levelProperties)
+        public struct ConfigData
+        {
+            public List<GameConfigType> Limit;
+            public Dictionary<string, int> Adjustments;
+        }
+
+        public LevelPropertiesModifiedRule(ConfigData levelProperties)
         {
             _levelProperties = levelProperties;
         }
 
-        public Dictionary<string, int> GetConfigObject() => _levelProperties;
+        public ConfigData GetConfigObject() => _levelProperties;
 
         protected override void OnDeactivate(GameContext gameContext)
         {
@@ -35,13 +41,19 @@
             var mergedDreadDataCollection = Traverse.Create(gameContext.playerDataController)
                 .Field<Dictionary<GameConfigType, PlayerDataController.MergedDreadData[]>>("mergedDreadDataCollection").Value;
 
-            foreach (var mergedDreadData in mergedDreadDataCollection.Values)
-            {
-                for (var i = 0; i < mergedDreadData.Length; i++)
+            EssentialsMod.Logger.Msg($"LevelProps {MotherbrainGlobalVars.CurrentConfig}");
+            EssentialsMod.Logger.Msg($"LevelProps {_levelProperties.Limit}");
+            if (_levelProperties.Limit.Contains(MotherbrainGlobalVars.CurrentConfig) || _levelProperties.Limit.Contains(Boardgame.GameConfigType.None))
                 {
-                    if (mergedDreadData[i].dto.DreadLevel == DefaultDreadLevel)
+                EssentialsMod.Logger.Msg($"Modifying props {_levelProperties.Limit}");
+                foreach (var mergedDreadData in mergedDreadDataCollection.Values)
+                {
+                    for (var i = 0; i < mergedDreadData.Length; i++)
                     {
-                        ModifyDreadMode(ref mergedDreadData[i].dto);
+                        if (mergedDreadData[i].dto.DreadLevel == DefaultDreadLevel)
+                        {
+                            ModifyDreadMode(ref mergedDreadData[i].dto);
+                        }
                     }
                 }
             }
@@ -49,8 +61,9 @@
 
         private void ModifyDreadMode(ref DreadLevelsDTO dreadLevelDto)
         {
-            foreach (var modification in _levelProperties)
+            foreach (var modification in _levelProperties.Adjustments)
             {
+                EssentialsMod.Logger.Msg($"{MotherbrainGlobalVars.CurrentConfig}: {modification.Key}: {modification.Value}");
                 AccessTools.StructFieldRefAccess<DreadLevelsDTO, int>(ref dreadLevelDto, modification.Key) = modification.Value;
             }
         }

--- a/HouseRules_Essentials/Rulesets/Arachnophobia.cs
+++ b/HouseRules_Essentials/Rulesets/Arachnophobia.cs
@@ -122,17 +122,20 @@
                 { AbilityKey.Sneak, false },
             });
 
-            var ints = new Dictionary<string, int>
+            var ints = new LevelPropertiesModifiedRule.ConfigData
             {
-                { "FloorOneGoldMaxAmount", 1200 },
-                { "FloorOneHealingFountains", 2 },
-                { "FloorOneLootChests", 12 },
-                { "FloorOneClassCardChests", 8 },
-                { "FloorTwoHealingFountains", 3 },
-                { "FloorTwoLootChests", 9 },
-                { "FloorTwoGoldMaxAmount", 1500 },
-                { "FloorThreeHealingFountains", 1 },
-                { "FloorThreeLootChests", 0 },
+                Adjustments = new Dictionary<string, int> {
+                    { "FloorOneGoldMaxAmount", 1200 },
+                    { "FloorOneHealingFountains", 2 },
+                    { "FloorOneLootChests", 12 },
+                    { "FloorOneClassCardChests", 8 },
+                    { "FloorTwoHealingFountains", 3 },
+                    { "FloorTwoLootChests", 9 },
+                    { "FloorTwoGoldMaxAmount", 1500 },
+                    { "FloorThreeHealingFountains", 1 },
+                    { "FloorThreeLootChests", 0 },
+                },
+                Limit = new List<Boardgame.GameConfigType> { Boardgame.GameConfigType.None },
             };
 
             var levelPropertiesRule = new LevelPropertiesModifiedRule(ints);

--- a/HouseRules_Essentials/Rulesets/BeatTheClockRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/BeatTheClockRuleset.cs
@@ -22,10 +22,14 @@
             });
             var recyclingRule = new CardEnergyFromRecyclingMultipliedRule(5);
             var roundLimitRule = new RoundCountLimitedRule(15);
-            var levelRule = new LevelPropertiesModifiedRule(new Dictionary<string, int>
+            var levelRule = new LevelPropertiesModifiedRule(new LevelPropertiesModifiedRule.ConfigData
             {
-                { "FloorOneLootChests", 15 },
-                { "FloorTwoLootChests", 15 },
+                Adjustments = new Dictionary<string, int>
+                {
+                    { "FloorOneLootChests", 15 },
+                    { "FloorTwoLootChests", 15 },
+                },
+                Limit = new List<Boardgame.GameConfigType> { Boardgame.GameConfigType.None },
             });
 
             return Ruleset.NewInstance(

--- a/HouseRules_Essentials/Rulesets/DemeoReloaded.cs
+++ b/HouseRules_Essentials/Rulesets/DemeoReloaded.cs
@@ -454,17 +454,21 @@
                 "SewersFloor07",
             });
 
-            var levelPropertiesRule = new LevelPropertiesModifiedRule(new Dictionary<string, int>
+            var levelPropertiesRule = new LevelPropertiesModifiedRule(new LevelPropertiesModifiedRule.ConfigData
             {
-                { "BigGoldPileChance", 30 },
-                { "FloorOneHealingFountains", 1 },
-                { "FloorOneLootChests", 2 },
-                { "FloorOneGoldMaxAmount", 550 },
-                { "FloorTwoHealingFountains", 1 },
-                { "FloorTwoLootChests", 4 },
-                { "FloorTwoGoldMaxAmount", 750 },
-                { "FloorThreeHealingFountains", 1 },
-                { "FloorThreeLootChests", 1 },
+                Adjustments = new Dictionary<string, int>
+                {
+                    { "BigGoldPileChance", 30 },
+                    { "FloorOneHealingFountains", 1 },
+                    { "FloorOneLootChests", 2 },
+                    { "FloorOneGoldMaxAmount", 550 },
+                    { "FloorTwoHealingFountains", 1 },
+                    { "FloorTwoLootChests", 4 },
+                    { "FloorTwoGoldMaxAmount", 750 },
+                    { "FloorThreeHealingFountains", 1 },
+                    { "FloorThreeLootChests", 1 },
+                },
+                Limit = new List<Boardgame.GameConfigType> { Boardgame.GameConfigType.None },
             });
 
             return Ruleset.NewInstance(

--- a/HouseRules_Essentials/Rulesets/DifficultyEasyRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/DifficultyEasyRuleset.cs
@@ -17,15 +17,19 @@
             var enemyDoorDisabled = new EnemyDoorOpeningDisabledRule(true);
             var enemyRespawnDisabled = new EnemyRespawnDisabledRule(true);
 
-            var levelPropertiesModified = new LevelPropertiesModifiedRule(new Dictionary<string, int>
+            var levelPropertiesModified = new LevelPropertiesModifiedRule(new LevelPropertiesModifiedRule.ConfigData
             {
-              { "BigGoldPileChance", 100 },
-              { "FloorOneHealingFountains", 2 },
-              { "FloorOneLootChests", 4 },
-              { "FloorTwoHealingFountains", 3 },
-              { "FloorTwoLootChests", 5 },
-              { "FloorThreeHealingFountains", 2 },
-              { "FloorThreeLootChests", 2 },
+                Adjustments = new Dictionary<string, int>
+                {
+                  { "BigGoldPileChance", 100 },
+                  { "FloorOneHealingFountains", 2 },
+                  { "FloorOneLootChests", 4 },
+                  { "FloorTwoHealingFountains", 3 },
+                  { "FloorTwoLootChests", 5 },
+                  { "FloorThreeHealingFountains", 2 },
+                  { "FloorThreeLootChests", 2 },
+                },
+                Limit = new List<Boardgame.GameConfigType> { Boardgame.GameConfigType.None },
             });
 
             return Ruleset.NewInstance(

--- a/HouseRules_Essentials/Rulesets/DifficultyHardRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/DifficultyHardRuleset.cs
@@ -16,17 +16,21 @@
             var enemyScaleHealth = new EnemyHealthScaledRule(1.8f);
             var enemyScaleAttack = new EnemyAttackScaledRule(1.5f);
 
-            var levelPropertiesModified = new LevelPropertiesModifiedRule(new Dictionary<string, int>
+            var levelPropertiesModified = new LevelPropertiesModifiedRule(new LevelPropertiesModifiedRule.ConfigData
             {
-              { "BigGoldPileChance", 30 },
-              { "FloorOneHealingFountains", 1 },
-              { "FloorOneLootChests", 2 },
-              { "FloorOneGoldMaxAmount", 672 },
-              { "FloorTwoHealingFountains", 1 },
-              { "FloorTwoLootChests", 2 },
-              { "FloorTwoGoldMaxAmount", 420 },
-              { "FloorThreeHealingFountains", 1 },
-              { "FloorThreeLootChests", 1 },
+                Adjustments = new Dictionary<string, int>
+                {
+                  { "BigGoldPileChance", 30 },
+                  { "FloorOneHealingFountains", 1 },
+                  { "FloorOneLootChests", 2 },
+                  { "FloorOneGoldMaxAmount", 672 },
+                  { "FloorTwoHealingFountains", 1 },
+                  { "FloorTwoLootChests", 2 },
+                  { "FloorTwoGoldMaxAmount", 420 },
+                  { "FloorThreeHealingFountains", 1 },
+                  { "FloorThreeLootChests", 1 },
+                },
+                Limit = new List<Boardgame.GameConfigType> { Boardgame.GameConfigType.None },
             });
 
             return Ruleset.NewInstance(

--- a/HouseRules_Essentials/Rulesets/DifficultyLegendaryRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/DifficultyLegendaryRuleset.cs
@@ -11,7 +11,9 @@
             const string name = "Difficulty: Legendary";
             const string description = "Increased game difficulty for those who want to be a legend.";
 
-            var levelProperties = new LevelPropertiesModifiedRule(new Dictionary<string, int>
+            var levelProperties = new LevelPropertiesModifiedRule(new LevelPropertiesModifiedRule.ConfigData
+            {
+                Adjustments = new Dictionary<string, int>
             {
                 { "BigGoldPileChance", 10 },
                 { "FloorOneHealingFountains", 0 },
@@ -22,6 +24,8 @@
                 { "FloorTwoGoldMaxAmount", 252 },
                 { "FloorThreeHealingFountains", 0 },
                 { "FloorThreeLootChests", 1 },
+            },
+                Limit = new List<Boardgame.GameConfigType> { Boardgame.GameConfigType.None },
             });
 
             var cardEnergyAttack = new CardEnergyFromAttackMultipliedRule(0.5f);

--- a/HouseRules_Essentials/Rulesets/HuntersParadiseRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/HuntersParadiseRuleset.cs
@@ -69,14 +69,18 @@
                 { BoardPieceId.HeroSorcerer, allowedCards },
             });
 
-            var levelPropertiesRule = new LevelPropertiesModifiedRule(new Dictionary<string, int>
+            var levelPropertiesRule = new LevelPropertiesModifiedRule(new LevelPropertiesModifiedRule.ConfigData
             {
-                { "FloorOneHealingFountains", 6 },
-                { "FloorOneLootChests", 6 },
-                { "FloorTwoHealingFountains", 6 },
-                { "FloorTwoLootChests", 12 },
-                { "FloorThreeHealingFountains", 6 },
-                { "FloorThreeLootChests", 12 },
+                Adjustments = new Dictionary<string, int>
+                {
+                    { "FloorOneHealingFountains", 6 },
+                    { "FloorOneLootChests", 6 },
+                    { "FloorTwoHealingFountains", 6 },
+                    { "FloorTwoLootChests", 12 },
+                    { "FloorThreeHealingFountains", 6 },
+                    { "FloorThreeLootChests", 12 },
+                },
+                Limit = new List<Boardgame.GameConfigType> { Boardgame.GameConfigType.None },
             });
 
             return Ruleset.NewInstance(

--- a/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
@@ -169,17 +169,38 @@
                 new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.Torch, Property = "VisionRange", Value = 40 },
             });
 
-            var levelPropertiesRule = new LevelPropertiesModifiedRule(new Dictionary<string, int>
+            var defaultPropertiesRule = new LevelPropertiesModifiedRule(new LevelPropertiesModifiedRule.ConfigData
             {
-                { "FloorOneHealingFountains", 0 },
-                { "FloorOneLootChests", 11 },
-                { "FloorTwoHealingFountains", 1 },
-                { "FloorTwoLootChests", 14 },
-                { "FloorThreeHealingFountains", 1 },
-                { "FloorThreeLootChests", 8 },
-                { "FloorOneEndZoneSpikeMaxBudget", 12 },
-                { "PacingSpikeSegmentFloorOneBudget", 12 },
+                Adjustments = new Dictionary<string, int>
+                {
+                    { "FloorOneHealingFountains", 0 },
+                    { "FloorOneLootChests", 11 },
+                    { "FloorTwoHealingFountains", 1 },
+                    { "FloorTwoLootChests", 14 },
+                    { "FloorThreeHealingFountains", 1 },
+                    { "FloorThreeLootChests", 8 },
+                    { "FloorOneEndZoneSpikeMaxBudget", 12 },
+                    { "PacingSpikeSegmentFloorOneBudget", 12 },
+                },
+                Limit = new List<Boardgame.GameConfigType> { Boardgame.GameConfigType.Elven, Boardgame.GameConfigType.Forest },
             });
+
+            var sewersPropertiesRule = new LevelPropertiesModifiedRule(new LevelPropertiesModifiedRule.ConfigData
+            {
+                Adjustments = new Dictionary<string, int>
+                {
+                    { "FloorOneHealingFountains", 5 },
+                    { "FloorOneLootChests", 25 },
+                    { "FloorTwoHealingFountains", 1 },
+                    { "FloorTwoLootChests", 14 },
+                    { "FloorThreeHealingFountains", 1 },
+                    { "FloorThreeLootChests", 8 },
+                    { "FloorOneEndZoneSpikeMaxBudget", 12 },
+                    { "PacingSpikeSegmentFloorOneBudget", 12 },
+                },
+                Limit = new List<Boardgame.GameConfigType> { Boardgame.GameConfigType.Sewers },
+            });
+
 
             var aoePotions = new AbilityAoeAdjustedRule(new Dictionary<AbilityKey, int>
             {
@@ -328,7 +349,8 @@
                 allowedCardsRule,
                 aoePotions,
                 lampTypesRule,
-                levelPropertiesRule,
+                defaultPropertiesRule,
+                sewersPropertiesRule,
                 piecesAdjustedRule,
                 piecePieceTypeRule,
                 startingCardsRule,

--- a/HouseRules_Essentials/Rulesets/LuckyDip.cs
+++ b/HouseRules_Essentials/Rulesets/LuckyDip.cs
@@ -150,14 +150,19 @@
                 { BoardPieceId.HeroSorcerer, sorcererImmunities },
             });
 
-            var levelPropertiesRule = new LevelPropertiesModifiedRule(new Dictionary<string, int>
+            var levelPropertiesRule = new LevelPropertiesModifiedRule(new LevelPropertiesModifiedRule.ConfigData
             {
-                { "FloorOneHealingFountains", 2 },
-                { "FloorOneLootChests", 11 },
-                { "FloorTwoHealingFountains", 4 },
-                { "FloorTwoLootChests", 14 },
-                { "FloorThreeHealingFountains", 4 },
-                { "FloorThreeLootChests", 12 },
+                Adjustments = new Dictionary<string, int>
+                {
+                    { "FloorOneHealingFountains", 2 },
+                    { "FloorOneLootChests", 11 },
+                    { "FloorTwoHealingFountains", 4 },
+                    { "FloorTwoLootChests", 14 },
+                    { "FloorThreeHealingFountains", 4 },
+                    { "FloorThreeLootChests", 12 },
+                },
+                Limit = new List<Boardgame.GameConfigType> { Boardgame.GameConfigType.None },
+
             });
 
             var hunterMarkRule = new PetsFocusHunterMarkRule(true);

--- a/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/TheSwirlRuleset.cs
@@ -64,14 +64,18 @@
                 new PieceConfigAdjustedRule.PieceProperty { Piece = BoardPieceId.HeroSorcerer, Property = "StartHealth", Value = 50 },
             });
 
-            var levelPropertiesRule = new LevelPropertiesModifiedRule(new Dictionary<string, int>
+            var levelPropertiesRule = new LevelPropertiesModifiedRule(new LevelPropertiesModifiedRule.ConfigData
             {
-                { "FloorOneHealingFountains", 2 },
-                { "FloorOneLootChests", 11 },
-                { "FloorTwoHealingFountains", 4 },
-                { "FloorTwoLootChests", 14 },
-                { "FloorThreeHealingFountains", 4 },
-                { "FloorThreeLootChests", 12 },
+                Adjustments = new Dictionary<string, int>
+                {
+                    { "FloorOneHealingFountains", 2 },
+                    { "FloorOneLootChests", 11 },
+                    { "FloorTwoHealingFountains", 4 },
+                    { "FloorTwoLootChests", 14 },
+                    { "FloorThreeHealingFountains", 4 },
+                    { "FloorThreeLootChests", 12 },
+                },
+                Limit = new List<Boardgame.GameConfigType> { Boardgame.GameConfigType.None },
             });
 
             var aoePotions = new AbilityAoeAdjustedRule(new Dictionary<AbilityKey, int>


### PR DESCRIPTION
I was in the mood for playing around with code, so I threw together a way of implementing #314 

This is most definitely a PR that should not be merged - it is purely for discussion.

I selected `LevelPropertiesModifiedRule` for my experiment as it is not an `IPatchable` one and created a `ConfigData` struct to contain both the `Adjustments` and the `Limit`. I then updated all of the rulesets that were using `LevelPropertiesModifiedRule` to enable things to compile. Finally I updated the `ItsATrap!` ruleset so that it would use different properties for Sewers than for others.

The change appears to function successfully, but I don't think this is necessarily the right approach to follow. I'll leave my reasons why on #314 where it can be a part of the discussion.
