### PR TITLE
Remove unneeded logic in `CardLimitModifiedRule` as changes in Demeo 1.16 no longer require it.

### DIFF
--- a/HouseRules_Essentials/Rules/CardLimitModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/CardLimitModifiedRule.cs
@@ -1,7 +1,5 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
-    using System.Collections.Generic;
-    using System.Reflection.Emit;
     using Boardgame;
     using Boardgame.BoardEntities;
     using HarmonyLib;
@@ -11,7 +9,6 @@
     {
         public override string Description => "Card limit is modified";
 
-        private const int MaxLimit = 100;
         private static int _globalLimit;
         private static bool _isActivated;
 
@@ -39,43 +36,6 @@
                 postfix: new HarmonyMethod(
                     typeof(CardLimitModifiedRule),
                     nameof(Inventory_MaxNumberOfCards_Prefix)));
-
-            harmony.Patch(
-                original: AccessTools.Method(typeof(CardHandView), "InitializeCardHolders"),
-                transpiler: new HarmonyMethod(typeof(CardLimitModifiedRule), nameof(CardHandView_InitializeCardHolders_Transpiler)));
-
-            // TODO(orendain): Tweak if necessary. Adjusts position and rotation of cards.
-            // harmony.Patch(
-            //     original: AccessTools.Method(typeof(CardHandView), "CalculateCardSlots"),
-            //     transpiler: new HarmonyMethod(typeof(CardLimitModifiedRule), nameof(CardHandView_CalculateCardSlots_Transpiler)));
-        }
-
-        private static IEnumerable<CodeInstruction> CardHandView_InitializeCardHolders_Transpiler(IEnumerable<CodeInstruction> instructions)
-        {
-            foreach (var instruction in instructions)
-            {
-                if (instruction.opcode == OpCodes.Ldc_I4_S && instruction.operand.ToString().Contains("11"))
-                {
-                    yield return new CodeInstruction(OpCodes.Ldc_I4_S, MaxLimit);
-                    continue;
-                }
-
-                yield return instruction;
-            }
-        }
-
-        private static IEnumerable<CodeInstruction> CardHandView_CalculateCardSlots_Transpiler(IEnumerable<CodeInstruction> instructions)
-        {
-            foreach (var instruction in instructions)
-            {
-                if (instruction.opcode == OpCodes.Ldc_R4 && instruction.operand.ToString().Contains("11"))
-                {
-                    yield return new CodeInstruction(OpCodes.Ldc_R4, (float)MaxLimit);
-                    continue;
-                }
-
-                yield return instruction;
-            }
         }
 
         private static void Inventory_MaxNumberOfCards_Prefix(ref int __result)


### PR DESCRIPTION
Remove unneeded logic in `CardLimitModifiedRule` as changes in Demeo 1.16 no longer require it.