### PR TITLE
Restore functionality for configurable replenish frequences and add support for Overcharge.

### DIFF
--- a/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
@@ -64,8 +64,9 @@
             for (int i = 0; i < piece.inventory.Items.Count; i++)
             {
                 Inventory.Item value = piece.inventory.Items[i];
-                var targetRefresh = (value.flags >> 5) & 7;
-                var countdown = (value.flags >> 2) & 7;
+                var targetRefresh = (value.flags >> 7) & 7;
+                var countdown = (value.flags >> 4) & 7;
+
                 if (piece.inventory.Items[i].IsReplenishing && (!piece.HasEffectState(EffectStateType.Stealthed) || piece.inventory.Items[i].abilityKey != AbilityKey.Sneak))
                 {
                     // If countdown was zero when we got called, then we need to set it.
@@ -82,8 +83,8 @@
                     }
 
                     countdown -= 1;
-                    value.flags &= 227; // Zero only the countdown bits using a bitmask
-                    value.flags |= countdown << 2; // OR with countdown to set them again.
+                    value.flags &= 911; // Zero only the countdown bits using a bitmask
+                    value.flags |= countdown << 4; // OR with countdown to set them again.
                     piece.inventory.Items[i] = value;
                     Traverse.Create(piece.inventory).Property<bool>("needSync").Value = true;
                 }
@@ -118,15 +119,17 @@
                 // flag bits
                 // 0 : isReplenishable
                 // 1 : isReplenishing
-                // 2-4 : ReplenishCounter - 3-bit range used by RestoreReplenishables for counting rounds.
-                // 5-7 : ReplenishFrequency - 3-bit number, user-configured target.
+                // 2 : abilityDisabledOnStatusEffect
+                // 3 : disableCooldown
+                // 4-6 : ReplenishCounter - 3-bit range used by RestoreReplenishables for counting rounds.
+                // 7-9 : ReplenishFrequency - 3-bit number, user-configured target.
                 int flags = 0;
                 if (card.ReplenishFrequency > 0)
                 {
                     Traverse.Create(inventory).Field<int>("numberOfReplenishableCards").Value += 1;
                     flags = 1;
                     int refreshFrequency = (card.ReplenishFrequency > 7) ? 7 : card.ReplenishFrequency; // Limit to max of 7 turns.
-                    flags |= refreshFrequency << 5; // logical or with refreshFrequency shifted 5 bits to the left to become ReplenishFrequency bits 5-7
+                    flags |= refreshFrequency << 7; // logical or with refreshFrequency shifted 7 bits to the left to become ReplenishFrequency bits 7-9
                 }
 
                 inventory.Items.Add(new Inventory.Item


### PR DESCRIPTION
# Restore functionality for configurable replenish frequences and add support for Overcharge.

The new Demeo release (1.16) adds an Overcharge mechanic to the Sorcerer's Zap which makes use of extra bits in the Ability `flags` register.

This PR moves the `ReplenishFrequency` and `countdown` to use higher bits `flags`, and also adds in the new code from `RestoreReplenishables` to account for abilities which have their replenish blocked by one or more status effects.

## Sample ruleset for testing.. 

I did my testing in 1-person skirmish with Wizard as my character). Heal and Zap replenish every turn, Fireball every 2 and Freeze every 3.

```
{
  "Name": "Test ",
  "Description": "Sorcerer gets 0AP Zap and a replenishable fireball, most buffs are 3x3 AOE.",
  "Rules": [
    {
      "Rule": "AbilityAoeAdjusted",
      "Config": {
        "CourageShanty": 1,
        "ReplenishArmor": 1,
        "StrengthPotion": 1,
        "SwiftnessPotion": 1,
        "Antitoxin": 1,
        "AdamantPotion": 1,
        "HealingPotion": 1
      }
    },
    {
      "Rule": "RegainAbilityIfMaxxedOutOverridden",
      "Config": {
        "StrengthPotion": false,
        "SwiftnessPotion": false
      }
    },
    {
      "Rule": "AbilityActionCostAdjusted",
      "Config": {
        "Zap": false
      }
    },
    {
      "Rule": "StartCardsModified",
      "Config": {
        "HeroSorcerer": [
          { "Card": "HealingPotion", "ReplenishFrequency": 1 },
          { "Card": "Zap", "ReplenishFrequency": 1 },
          { "Card": "Fireball", "ReplenishFrequency": 2 },
          { "Card": "Freeze", "ReplenishFrequency": 3 },
          { "Card": "Overcharge", "ReplenishFrequency": 1 }
         
        ]
      }
    }
  ]
}
```