### PR TITLE
Define stealth damage for abilities

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -22,6 +22,7 @@
             HR.Rulebook.Register(typeof(AbilityHealOverriddenRule));
             HR.Rulebook.Register(typeof(AbilityActionCostAdjustedRule));
             HR.Rulebook.Register(typeof(AbilityRandomPieceListRule));
+            HR.Rulebook.Register(typeof(AbilityStealthDamageOverriddenRule));
             HR.Rulebook.Register(typeof(BackstabConfigOverriddenRule));
             HR.Rulebook.Register(typeof(CourageShantyAddsHpRule));
             HR.Rulebook.Register(typeof(CardAdditionOverriddenRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Rulesets\TheSwirlRuleset.cs" />
     <Compile Include="Rules\AbilityBackstabAdjustedRule.cs" />
     <Compile Include="Rules\AbilityDamageOverriddenRule.cs" />
+    <Compile Include="Rules\AbilityStealthDamageOverriddenRule.cs" />
     <Compile Include="Rules\AbilityHealOverriddenRule.cs" />
     <Compile Include="Rules\CardClassRestrictionOverriddenRule.cs" />
     <Compile Include="Rules\FreeAbilityOnCritRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -166,6 +166,27 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
   },
   ```
 
+#### __AbilityStealthDamageOverridden__: Ability stealthBonusDamage is overridden
+  - Can function for abilities which don't do damage. (You can make a FlashBomb hurt).
+  - To configure:
+    - Specify the [AbilityKey](../docs/SettingsReference.md#abilitykeys) of the ability to modify.
+    - Specify a positive integer for stealthBonusDamage E.g.: `"PlayerMelee": 2` adds 2 damage to a normal attack if stealthed.
+
+  ###### _Example JSON config for AbilityStealthDamageOverridden_
+
+  ```json
+  {
+    "Rule": "AbilityStealthDamageOverridden",
+    "Config":
+    {
+      "Blink": 4,
+      "DiseasedBite": 2,
+      "PoisonBomb": 1,
+      "CursedDagger": 3,
+      "PlayerMelee": 2
+    }
+  },
+  ```
 #### __BackstabConfigOverridden__: A list of Pieces may use 🔪Backstab🔪 instead of just the Assassin
   - Replaces the hardcoded default of HeroRogue with a configurable list.
   - Now everyone can benefit from Backstab bonus.

--- a/HouseRules_Essentials/Rules/AbilityStealthDamageOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityStealthDamageOverriddenRule.cs
@@ -1,0 +1,57 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System;
+    using System.Collections.Generic;
+    using Boardgame;
+    using Boardgame.BoardEntities.Abilities;
+    using DataKeys;
+    using HouseRules.Types;
+
+    public sealed class AbilityStealthDamageOverriddenRule : Rule, IConfigWritable<Dictionary<AbilityKey, int>>, IMultiplayerSafe
+    {
+        public override string Description => "Ability stealth bonus damage values are overridden";
+
+        private readonly Dictionary<AbilityKey, int> _adjustments;
+        private Dictionary<AbilityKey, int> _originals;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AbilityStealthDamageOverriddenRule"/> class.
+        /// </summary>
+        /// <param name="adjustments">Key-value pairs of abilityKey and extra stealth damage.</param>
+        public AbilityStealthDamageOverriddenRule(Dictionary<AbilityKey, int> adjustments)
+        {
+            _adjustments = adjustments;
+            _originals = new Dictionary<AbilityKey, int>();
+        }
+
+        public Dictionary<AbilityKey, int> GetConfigObject() => _adjustments;
+
+        protected override void OnPreGameCreated(GameContext gameContext)
+        {
+            _originals = ReplaceAbilities(_adjustments);
+        }
+
+        protected override void OnDeactivate(GameContext gameContext)
+        {
+            ReplaceAbilities(_originals);
+        }
+
+        private static Dictionary<AbilityKey, int> ReplaceAbilities(Dictionary<AbilityKey, int> replacements)
+        {
+            var originals = new Dictionary<AbilityKey, int>();
+
+            foreach (var replacement in replacements)
+            {
+                if (!AbilityFactory.TryGetAbility(replacement.Key, out var ability))
+                {
+                    throw new InvalidOperationException($"AbilityKey [{replacement.Key}] does not have a corresponding ability.");
+                }
+
+                originals[replacement.Key] = ability.stealthBonusDamage;
+                ability.stealthBonusDamage = replacement.Value;
+            }
+
+            return originals;
+        }
+    }
+}


### PR DESCRIPTION
Allows the user to set/change the stealth bonus damage for specified abilities.
For example, allowing PlayerMelee to add 2 damage from stealth.
Tested extensively online and works great in multiplayer.

Sample code:
   {
      "Rule": "AbilityStealthDamageOverridden",
      "Config":
      {
        "Blink": 4,
        "DiseasedBite": 2,
        "PoisonBomb": 1,
        "CursedDagger": 3,
        "PlayerMelee": 2
      }
    },