### PR TITLE
Re-add Pagestack.Clear method after removal in #370

### DIFF
--- a/Common/UI/PageStack.cs
+++ b/Common/UI/PageStack.cs
@@ -40,6 +40,19 @@ namespace Common.UI
             UpdatePageStatus();
         }
 
+        /// <summary>
+        /// Removes all pages from the stack.
+        /// </summary>
+        /// <remarks>
+        /// Note that this stops tracking all current pages, but does not explicitly destroy them.
+        /// </remarks>
+        public void Clear()
+        {
+            _pages.Clear();
+            _currentPageIndex = 0;
+            UpdatePageStatus();
+        }
+
         private void OnPreviousPageClick()
         {
             AdvancePageIndex(-1);


### PR DESCRIPTION
Roomfinder uses pagestack.clear - I suspect that the removal in #370 was in error. This PR adds it back again so that Roomfinder will compile again.