### PR TITLE
Remove `ButtonMenuGreen` as a required dependency for NonVR UIs.

### DIFF
--- a/Common/UI/Resource/NonVrResourceTable.cs
+++ b/Common/UI/Resource/NonVrResourceTable.cs
@@ -14,8 +14,6 @@
 
         public Sprite ButtonBlueNormal { get; private set; }
 
-        public Sprite ButtonGreenNormal { get; private set; }
-
         public Sprite ButtonRedNormal { get; private set; }
 
         public Sprite PaperDecorated { get; private set; }
@@ -53,7 +51,6 @@
         internal static bool IsReady()
         {
             return Resources.FindObjectsOfTypeAll<Sprite>().Any(x => x.name == "ButtonMenuBlue")
-                   && Resources.FindObjectsOfTypeAll<Sprite>().Any(x => x.name == "ButtonMenuGreen")
                    && Resources.FindObjectsOfTypeAll<Sprite>().Any(x => x.name == "ButtonMenuRed")
                    && Resources.FindObjectsOfTypeAll<Sprite>().Any(x => x.name == "PaperDecorated")
                    && Resources.FindObjectsOfTypeAll<GameObject>().Any(x => x.name == "DesktopMainMenu(Clone)")
@@ -64,7 +61,6 @@
         private void Refresh()
         {
             ButtonBlueNormal = Resources.FindObjectsOfTypeAll<Sprite>().First(x => x.name == "ButtonMenuBlue");
-            ButtonGreenNormal = Resources.FindObjectsOfTypeAll<Sprite>().First(x => x.name == "ButtonMenuGreen");
             ButtonRedNormal = Resources.FindObjectsOfTypeAll<Sprite>().First(x => x.name == "ButtonMenuRed");
             PaperDecorated = Resources.FindObjectsOfTypeAll<Sprite>().First(x => x.name == "PaperDecorated");
             AnchorDesktopMainMenu = Resources.FindObjectsOfTypeAll<GameObject>()


### PR DESCRIPTION
Remove `ButtonMenuGreen` as a required dependency for NonVR UIs.  For compatibility with the 1.16 patch on 2022-06-22.

We aren't using this sprite.  Was added as a preliminary measure for future UI work.