### PR TITLE
Ignore amendment-labelled PRs when generating changelogs.

### DIFF
--- a/HouseRules_Configuration/.github_changelog_generator
+++ b/HouseRules_Configuration/.github_changelog_generator
@@ -5,7 +5,7 @@ author=false
 compare-link=true
 issues=false
 pr-wo-labels=false
-exclude-labels=type: build,type: documentation
+exclude-labels=type: build,type: documentation,type: amendment
 
 add-sections={"chore":{"prefix":"**Chores:**","labels":["type: chore"]}}
 enhancement-label=**Features/Enhancements:**

--- a/HouseRules_Core/.github_changelog_generator
+++ b/HouseRules_Core/.github_changelog_generator
@@ -5,7 +5,7 @@ author=false
 compare-link=true
 issues=false
 pr-wo-labels=false
-exclude-labels=type: build,type: documentation
+exclude-labels=type: build,type: documentation,type: amendment
 
 add-sections={"chore":{"prefix":"**Chores:**","labels":["type: chore"]}}
 enhancement-label=**Features/Enhancements:**

--- a/HouseRules_Essentials/.github_changelog_generator
+++ b/HouseRules_Essentials/.github_changelog_generator
@@ -5,7 +5,7 @@ author=false
 compare-link=true
 issues=false
 pr-wo-labels=false
-exclude-labels=type: build,type: documentation
+exclude-labels=type: build,type: documentation,type: amendment
 
 add-sections={"chore":{"prefix":"**Chores:**","labels":["type: chore"]}}
 enhancement-label=**Features/Enhancements:**

--- a/RoomCode/.github_changelog_generator
+++ b/RoomCode/.github_changelog_generator
@@ -5,7 +5,7 @@ author=false
 compare-link=true
 issues=false
 pr-wo-labels=false
-exclude-labels=type: build,type: documentation
+exclude-labels=type: build,type: documentation,type: amendment
 
 add-sections={"chore":{"prefix":"**Chores:**","labels":["type: chore"]}}
 enhancement-label=**Features/Enhancements:**

--- a/RoomFinder/.github_changelog_generator
+++ b/RoomFinder/.github_changelog_generator
@@ -5,7 +5,7 @@ author=false
 compare-link=true
 issues=false
 pr-wo-labels=false
-exclude-labels=type: build,type: documentation
+exclude-labels=type: build,type: documentation,type: amendment
 
 add-sections={"chore":{"prefix":"**Chores:**","labels":["type: chore"]}}
 enhancement-label=**Features/Enhancements:**

--- a/SkipIntro/.github_changelog_generator
+++ b/SkipIntro/.github_changelog_generator
@@ -5,7 +5,7 @@ author=false
 compare-link=true
 issues=false
 pr-wo-labels=false
-exclude-labels=type: build,type: documentation
+exclude-labels=type: build,type: documentation,type: amendment
 
 add-sections={"chore":{"prefix":"**Chores:**","labels":["type: chore"]}}
 enhancement-label=**Features/Enhancements:**


### PR DESCRIPTION
Any PR labeled with `type: amendment` will be ignored by the changelog generator.