### PR TITLE
Introduce a RoomFinder UI for the PC Edition.

### DIFF
--- a/Common/UI/PageStack.cs
+++ b/Common/UI/PageStack.cs
@@ -85,6 +85,11 @@ namespace Common.UI
 
         private void UpdatePageVisibility()
         {
+            if (_pages.Count < 1)
+            {
+                return;
+            }
+
             _pages.ForEach(p => p.SetActive(false));
             _pages[_currentPageIndex].SetActive(true);
         }

--- a/Common/UI/Resource/NonVrResourceTable.cs
+++ b/Common/UI/Resource/NonVrResourceTable.cs
@@ -53,7 +53,6 @@
         internal static bool IsReady()
         {
             return Resources.FindObjectsOfTypeAll<Sprite>().Any(x => x.name == "ButtonMenuBlue")
-                   && Resources.FindObjectsOfTypeAll<Sprite>().Any(x => x.name == "ButtonMenuGreen")
                    && Resources.FindObjectsOfTypeAll<Sprite>().Any(x => x.name == "ButtonMenuRed")
                    && Resources.FindObjectsOfTypeAll<Sprite>().Any(x => x.name == "PaperDecorated")
                    && Resources.FindObjectsOfTypeAll<GameObject>().Any(x => x.name == "DesktopMainMenu(Clone)")
@@ -64,7 +63,6 @@
         private void Refresh()
         {
             ButtonBlueNormal = Resources.FindObjectsOfTypeAll<Sprite>().First(x => x.name == "ButtonMenuBlue");
-            ButtonGreenNormal = Resources.FindObjectsOfTypeAll<Sprite>().First(x => x.name == "ButtonMenuGreen");
             ButtonRedNormal = Resources.FindObjectsOfTypeAll<Sprite>().First(x => x.name == "ButtonMenuRed");
             PaperDecorated = Resources.FindObjectsOfTypeAll<Sprite>().First(x => x.name == "PaperDecorated");
             AnchorDesktopMainMenu = Resources.FindObjectsOfTypeAll<GameObject>()

--- a/HouseRules_Configuration/UI/HouseRulesUiNonVr.cs
+++ b/HouseRules_Configuration/UI/HouseRulesUiNonVr.cs
@@ -1,6 +1,5 @@
 ﻿namespace HouseRules.Configuration.UI
 {
-    using System;
     using System.Collections;
     using Common.UI;
     using Common.UI.Element;
@@ -12,7 +11,6 @@
         private NonVrResourceTable _resourceTable;
         private IElementCreator _elementCreator;
         private RulesetSelectionPanelNonVr _rulesetPanel;
-
         private GameObject _page;
         private bool _pageVisible;
 

--- a/HouseRules_Configuration/UI/RulesetSelectionPanelNonVr.cs
+++ b/HouseRules_Configuration/UI/RulesetSelectionPanelNonVr.cs
@@ -140,7 +140,7 @@
 
             var button = _elementCreator.CreateButton(SelectRulesetAction(ruleset.Name));
             button.transform.SetParent(container.transform, worldPositionStays: false);
-            button.transform.localScale = new Vector3(2.2f, 0.75f, 1f);
+            button.transform.localScale = new Vector3(2.2f, 0.75f);
             button.transform.localPosition = new Vector3(-225f, 0);
 
             var buttonText =

--- a/RoomFinder/Properties/AssemblyInfo.cs
+++ b/RoomFinder/Properties/AssemblyInfo.cs
@@ -39,5 +39,6 @@ using RoomFinder;
 // Melon Loader.
 [assembly: MelonInfo(typeof(RoomFinderMod), "RoomFinder", BuildVersion.Version, "Orendain", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
+[assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("566788")]
 [assembly: VerifyLoaderVersion("0.5.3", true)]

--- a/RoomFinder/RoomFinder.csproj
+++ b/RoomFinder/RoomFinder.csproj
@@ -79,6 +79,7 @@
     <Compile Include="..\Common\**\*.cs" Exclude="..\Common\Properties\AssemblyInfo.cs;..\Common\bin\**\*.*;..\Common\obj\**\*.*;..\Common\**\*.csproj;..\Common\**\*.user;..\Common\**\*.vstemplate">
       <Link>Common\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
+    <Compile Include="UI\RoomListPanelNonVr.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="CopyToModsDir" AfterTargets="Build">

--- a/RoomFinder/RoomFinder.csproj
+++ b/RoomFinder/RoomFinder.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Patcher.cs" />
     <Compile Include="SharedState.cs" />
     <Compile Include="UI\Room.cs" />
+    <Compile Include="UI\RoomFinderUiNonVr.cs" />
     <Compile Include="UI\RoomListPanel.cs" />
     <Compile Include="UI\RoomFinderUiVr.cs" />
     <Compile Include="..\Common\**\*.cs" Exclude="..\Common\Properties\AssemblyInfo.cs;..\Common\bin\**\*.*;..\Common\obj\**\*.*;..\Common\**\*.csproj;..\Common\**\*.user;..\Common\**\*.vstemplate">

--- a/RoomFinder/RoomFinderMod.cs
+++ b/RoomFinder/RoomFinderMod.cs
@@ -8,10 +8,11 @@
 
     internal class RoomFinderMod : MelonMod
     {
+        private const string DemeoPCEditionString = "Demeo PC Edition";
+        private const int LobbySceneIndex = 1;
+
         internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("RoomFinder");
         internal static readonly SharedState SharedState = SharedState.NewInstance();
-
-        private const int LobbySceneIndex = 1;
 
         private GameObject _roomFinderUi;
 
@@ -24,12 +25,25 @@
 
         public override void OnSceneWasInitialized(int buildIndex, string sceneName)
         {
+            if (MelonUtils.CurrentGameAttribute.Name == DemeoPCEditionString)
+            {
+                if (buildIndex != LobbySceneIndex)
+                {
+                    return;
+                }
+
+                Logger.Msg("Recognized lobby in PC. Loading UI.");
+                _ = new GameObject("RoomFinderUiNonVr", typeof(RoomFinderUiNonVr));
+                return;
+            }
+
             if (buildIndex != LobbySceneIndex)
             {
                 return;
             }
 
-            _roomFinderUi = new GameObject("RoomFinderUI", typeof(RoomFinderUiVr));
+            Logger.Msg("Recognized lobby in VR. Loading UI.");
+            _roomFinderUi = new GameObject("RoomFinderUiVr", typeof(RoomFinderUiVr));
         }
     }
 }

--- a/RoomFinder/UI/RoomFinderUiNonVr.cs
+++ b/RoomFinder/UI/RoomFinderUiNonVr.cs
@@ -15,7 +15,6 @@
     {
         private NonVrResourceTable _resourceTable;
         private NonVrElementCreator _elementCreator;
-        private GameObject _background;
         private RoomListPanelNonVr _roomListPanel;
         private GameObject _page;
         private bool _pageVisible;

--- a/RoomFinder/UI/RoomFinderUiNonVr.cs
+++ b/RoomFinder/UI/RoomFinderUiNonVr.cs
@@ -1,18 +1,22 @@
-﻿namespace HouseRules.Configuration.UI
+﻿namespace RoomFinder.UI
 {
-    using System;
     using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Boardgame;
     using Common.UI;
     using Common.UI.Element;
+    using HarmonyLib;
+    using Photon.Realtime;
     using UnityEngine;
     using UnityEngine.UI;
 
-    internal class HouseRulesUiNonVr : MonoBehaviour
+    internal class RoomFinderUiNonVr : MonoBehaviour
     {
         private NonVrResourceTable _resourceTable;
-        private IElementCreator _elementCreator;
-        private RulesetSelectionPanelNonVr _rulesetPanel;
-
+        private NonVrElementCreator _elementCreator;
+        private GameObject _background;
+        private RoomListPanelNonVr _roomListPanel;
         private GameObject _page;
         private bool _pageVisible;
 
@@ -25,25 +29,45 @@
         {
             while (!NonVrElementCreator.IsReady())
             {
-                ConfigurationMod.Logger.Msg("UI dependencies not yet ready. Waiting...");
+
+                RoomFinderMod.Logger.Msg("UI dependencies not yet ready. Waiting...");
                 yield return new WaitForSecondsRealtime(1);
             }
 
-            ConfigurationMod.Logger.Msg("UI dependencies ready. Proceeding with initialization.");
+            RoomFinderMod.Logger.Msg("UI dependencies ready. Proceeding with initialization.");
 
             _resourceTable = NonVrResourceTable.Instance();
             _elementCreator = NonVrElementCreator.Instance();
-            _rulesetPanel = RulesetSelectionPanelNonVr.NewInstance(HR.Rulebook, _elementCreator);
+            _roomListPanel = RoomListPanelNonVr.NewInstance(_elementCreator, RefreshRoomList);
 
             Initialize();
-            ConfigurationMod.Logger.Msg("Initialization complete.");
+
+            RoomFinderMod.Logger.Msg("Initialization complete.");
+        }
+
+        private void Update()
+        {
+            if (!RoomFinderMod.SharedState.IsRefreshingRoomList)
+            {
+                return;
+            }
+
+            if (!RoomFinderMod.SharedState.HasRoomListUpdated)
+            {
+                return;
+            }
+
+            RoomFinderMod.SharedState.IsRefreshingRoomList = false;
+            RoomFinderMod.SharedState.HasRoomListUpdated = false;
+
+            PopulateRoomList();
         }
 
         private void Initialize()
         {
             var navigation = CreateNavigationButton();
             navigation.transform.SetParent(_resourceTable.AnchorNavigationBar.transform, worldPositionStays: false);
-            navigation.transform.localPosition = new Vector3(725, -30);
+            navigation.transform.localPosition = new Vector3(725, -80);
 
             _page = CreatePage();
             _page.transform.SetParent(_resourceTable.AnchorDesktopMainMenu.transform, worldPositionStays: false);
@@ -52,13 +76,13 @@
 
         private GameObject CreateNavigationButton()
         {
-            var container = new GameObject("HouseRules");
+            var container = new GameObject("RoomFinder");
 
             var button = _elementCreator.CreateButton(TogglePage);
             button.transform.SetParent(container.transform, worldPositionStays: false);
             button.transform.localScale = new Vector2(1.75f, 0.65f);
 
-            var text = _elementCreator.CreateText("HouseRules", Color.white, NonVrElementCreator.DefaultLabelFontSize);
+            var text = _elementCreator.CreateText("RoomFinder", Color.white, NonVrElementCreator.DefaultLabelFontSize);
             text.transform.SetParent(container.transform, worldPositionStays: false);
             text.GetComponent<Graphic>().raycastTarget = false;
 
@@ -67,7 +91,7 @@
 
         private GameObject CreatePage()
         {
-            var page = new GameObject("HouseRulesPage");
+            var page = new GameObject("RoomFinderPage");
             var pageRectTransform = page.AddComponent<RectTransform>();
             pageRectTransform.pivot = new Vector2(0.5f, 1);
 
@@ -76,24 +100,17 @@
             paperContainer.AddComponent<Image>().sprite = _resourceTable.PaperDecorated;
             paperContainer.GetComponent<RectTransform>().sizeDelta = new Vector2(1576, 876);
 
-            var title = _elementCreator.CreateText("HouseRules", _resourceTable.ColorBrown, 36);
+            var title = _elementCreator.CreateText("RoomFinder", _resourceTable.ColorBrown, 36);
             title.transform.SetParent(page.transform, worldPositionStays: false);
             title.transform.localPosition = new Vector2(0, 310f);
 
-            var selectionPanel = _rulesetPanel.Panel;
+            var selectionPanel = _roomListPanel.Panel;
             selectionPanel.transform.SetParent(page.transform, worldPositionStays: false);
             selectionPanel.transform.localPosition = new Vector2(0, 230f);
 
             var versionText = _elementCreator.CreateNormalText($"v{BuildVersion.Version}");
             versionText.transform.SetParent(page.transform, worldPositionStays: false);
             versionText.transform.localPosition = new Vector2(-615, -400);
-
-            if (ConfigurationMod.IsUpdateAvailable)
-            {
-                var updateText = _elementCreator.CreateNormalText("NEW UPDATE AVAILABLE!");
-                updateText.transform.SetParent(page.transform, worldPositionStays: false);
-                updateText.transform.localPosition = new Vector2(-480f, -390);
-            }
 
             return page;
         }
@@ -110,6 +127,26 @@
             {
                 child.gameObject.SetActive(false);
             }
+        }
+
+        private static void RefreshRoomList()
+        {
+            RoomFinderMod.SharedState.IsRefreshingRoomList = true;
+            Traverse.Create(RoomFinderMod.SharedState.GameContext.gameStateMachine.lobby.GetLobbyMenuController)
+                .Method("QuickPlay", LevelSequence.GameType.Invalid, true)
+                .GetValue();
+        }
+
+        private void PopulateRoomList()
+        {
+            var cachedRooms =
+                Traverse.Create(RoomFinderMod.SharedState.GameContext.gameStateMachine)
+                    .Field<Dictionary<string, RoomInfo>>("cachedRoomList").Value;
+
+            RoomFinderMod.Logger.Msg($"Captured {cachedRooms.Count} rooms.");
+
+            var rooms = cachedRooms.Values.ToList().Select(Room.Parse).ToList();
+            _roomListPanel.UpdateRooms(rooms);
         }
     }
 }

--- a/RoomFinder/UI/RoomListPanelNonVr.cs
+++ b/RoomFinder/UI/RoomListPanelNonVr.cs
@@ -1,0 +1,278 @@
+﻿namespace RoomFinder.UI
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Boardgame;
+    using Common.UI;
+    using Common.UI.Element;
+    using HarmonyLib;
+    using UnityEngine;
+    using Object = UnityEngine.Object;
+
+    internal class RoomListPanelNonVr
+    {
+        private const int MaxRoomsPerPage = 10;
+
+        private readonly NonVrElementCreator _elementCreator;
+        private readonly Action _onRefresh;
+        private readonly PageStack _pageStack;
+        private Func<Room, object> _sortOrder;
+        private bool _isDescendingOrder;
+        private IEnumerable<Room> _rooms;
+        private GameObject _roomPages;
+
+        internal GameObject Panel { get; }
+
+        internal static RoomListPanelNonVr NewInstance(NonVrElementCreator elementCreator, Action onRefresh)
+        {
+            return new RoomListPanelNonVr(
+                elementCreator,
+                onRefresh,
+                PageStack.NewInstance(elementCreator),
+                new GameObject("RoomListPanelNonVr"));
+        }
+
+        private RoomListPanelNonVr(
+            NonVrElementCreator elementCreator,
+            Action onRefresh,
+            PageStack pageStack,
+            GameObject panel)
+        {
+            _elementCreator = elementCreator;
+            _onRefresh = onRefresh;
+            _pageStack = pageStack;
+            Panel = panel;
+
+            _sortOrder = r => r.CurrentPlayers;
+            _isDescendingOrder = true;
+            _rooms = new List<Room>();
+
+            Draw();
+        }
+
+        internal void UpdateRooms(IEnumerable<Room> rooms)
+        {
+            _rooms = rooms;
+            FilterValidRooms();
+            SortRooms();
+            DrawRoomPages();
+        }
+
+        private void Draw()
+        {
+            foreach (Transform child in Panel.transform)
+            {
+                Object.Destroy(child.gameObject);
+            }
+
+            var header = CreateHeader();
+            header.transform.SetParent(Panel.transform, worldPositionStays: false);
+
+            _roomPages = new GameObject("RoomPages");
+            _roomPages.transform.SetParent(Panel.transform, worldPositionStays: false);
+            _roomPages.transform.localPosition = new Vector2(0, -100f);
+
+            var navigation = CreateNavigation();
+            navigation.transform.SetParent(Panel.transform, worldPositionStays: false);
+            navigation.transform.localPosition = new Vector2(0, -610f);
+
+            DrawRoomPages();
+        }
+
+        private GameObject CreateNavigation()
+        {
+            var container = new GameObject("PageStackNavigation");
+
+            _pageStack.Navigation.PageStatus.transform.SetParent(container.transform, worldPositionStays: false);
+
+            _pageStack.Navigation.PreviousButton.transform.SetParent(container.transform, worldPositionStays: false);
+            _pageStack.Navigation.PreviousButton.transform.localScale = new Vector2(0.8f, 0.6f);
+            _pageStack.Navigation.PreviousButton.transform.localPosition = new Vector2(-80f, 0);
+
+            _pageStack.Navigation.PreviousButtonText.transform.SetParent(
+                container.transform,
+                worldPositionStays: false);
+            _pageStack.Navigation.PreviousButtonText.transform.localPosition = new Vector2(-80f, 0);
+
+            _pageStack.Navigation.NextButton.transform.SetParent(container.transform, worldPositionStays: false);
+            _pageStack.Navigation.NextButton.transform.localScale = new Vector2(0.8f, 0.6f);
+            _pageStack.Navigation.NextButton.transform.localPosition = new Vector2(80f, 0);
+
+            _pageStack.Navigation.NextButtonText.transform.SetParent(container.transform, worldPositionStays: false);
+            _pageStack.Navigation.NextButtonText.transform.localPosition = new Vector2(80f, 0);
+
+            return container;
+        }
+
+        private void DrawRoomPages()
+        {
+            _pageStack.Clear();
+
+            foreach (Transform child in _roomPages.transform)
+            {
+                Object.Destroy(child.gameObject);
+            }
+
+            var roomPartitions = PartitionRooms();
+            var roomPages = roomPartitions.Select(CreatePage).ToList();
+            foreach (var page in roomPages)
+            {
+                page.transform.SetParent(_roomPages.transform, worldPositionStays: false);
+                _pageStack.AddPage(page);
+            }
+        }
+
+        private GameObject CreateHeader()
+        {
+            var container = new GameObject("Header");
+
+            var refreshButton = _elementCreator.CreateButton(_onRefresh);
+            refreshButton.transform.SetParent(container.transform, worldPositionStays: false);
+            refreshButton.transform.localScale = new Vector2(2.2f, 0.75f);
+
+            var refreshText = _elementCreator.CreateButtonText("Refresh");
+            refreshText.transform.SetParent(container.transform, worldPositionStays: false);
+
+            var sortHeader = CreateSortHeader();
+            sortHeader.transform.SetParent(container.transform, worldPositionStays: false);
+            sortHeader.transform.localPosition = new Vector2(0, -55f);
+
+            return container;
+        }
+
+        private GameObject CreateSortHeader()
+        {
+            var container = new GameObject("SortHeader");
+
+            var sortLabel = _elementCreator.CreateNormalText("Sort by:");
+            sortLabel.transform.SetParent(container.transform, worldPositionStays: false);
+            sortLabel.transform.localPosition = new Vector2(-150f, 0);
+
+            var gameButton = CreateSortButton("Game", () => SetSortOrderAndApply(r => r.GameType));
+            gameButton.transform.SetParent(container.transform, worldPositionStays: false);
+            gameButton.transform.localPosition = new Vector2(-25f, 0);
+
+            var floorButton = CreateSortButton("Floor", () => SetSortOrderAndApply(r => r.Floor));
+            floorButton.transform.SetParent(container.transform, worldPositionStays: false);
+            floorButton.transform.localPosition = new Vector2(75f, 0);
+
+            var playersButton = CreateSortButton("Players", () => SetSortOrderAndApply(r => r.CurrentPlayers));
+            playersButton.transform.SetParent(container.transform, worldPositionStays: false);
+            playersButton.transform.localPosition = new Vector2(175f, 0);
+
+            return container;
+        }
+
+        /// <summary>
+        /// Partition rooms into groups based on the maximum allowed rooms per page.
+        /// </summary>
+        private IEnumerable<List<Room>> PartitionRooms()
+        {
+            return _rooms
+                .Select((value, index) => new { group = index / MaxRoomsPerPage,  value })
+                .GroupBy(pair => pair.group)
+                .Select(group => group.Select(g => g.value).ToList());
+        }
+
+        private GameObject CreatePage(IReadOnlyCollection<Room> rooms)
+        {
+            var container = new GameObject("RoomPage");
+
+            for (var i = 0; i < rooms.Count; i++)
+            {
+                var yOffset = i * -50f;
+                var roomRow = CreateRoomRow(rooms.ElementAt(i));
+                roomRow.transform.SetParent(container.transform, worldPositionStays: false);
+                roomRow.transform.localPosition = new Vector2(0, yOffset);
+            }
+
+            return container;
+        }
+
+        private GameObject CreateRoomRow(Room room)
+        {
+            var container = new GameObject(room.Name);
+
+            var joinButton = _elementCreator.CreateButton(JoinRoomAction(room.Name));
+            joinButton.transform.SetParent(container.transform, worldPositionStays: false);
+            joinButton.transform.localScale = new Vector2(1.2f, 0.65f);
+            joinButton.transform.localPosition = new Vector2(-150f, 0);
+
+            var joinText = _elementCreator.CreateText(room.Name, Color.white, NonVrElementCreator.DefaultLabelFontSize);
+            joinText.transform.SetParent(container.transform, worldPositionStays: false);
+            joinText.transform.localPosition = new Vector2(-150f, 0);
+
+            var gameLabel = _elementCreator.CreateNormalText(room.GameType.ToString());
+            gameLabel.transform.SetParent(container.transform, worldPositionStays: false);
+            gameLabel.transform.localPosition = new Vector2(-20f, 0);
+
+            var floorLabel = _elementCreator.CreateNormalText(room.Floor.ToString());
+            floorLabel.transform.SetParent(container.transform, worldPositionStays: false);
+            floorLabel.transform.localPosition = new Vector2(87.5f, 0);
+
+            var playersLabel = _elementCreator.CreateNormalText($"{room.CurrentPlayers}/{room.MaxPlayers}");
+            playersLabel.transform.SetParent(container.transform, worldPositionStays: false);
+            playersLabel.transform.localPosition = new Vector2(162.5f, 0);
+
+            return container;
+        }
+
+        private GameObject CreateSortButton(string text, Action action)
+        {
+            var container = new GameObject(text);
+
+            var button = _elementCreator.CreateButton(action);
+            button.transform.SetParent(container.transform, worldPositionStays: false);
+            button.transform.localScale = new Vector2(1.1f, 0.37f);
+
+            var buttonText = _elementCreator.CreateText(text, Color.white, NonVrElementCreator.DefaultLabelFontSize);
+            buttonText.transform.SetParent(container.transform, worldPositionStays: false);
+
+            return container;
+        }
+
+        private void SetSortOrderAndApply(Func<Room, object> sortOrder)
+        {
+            if (_sortOrder == sortOrder)
+            {
+                _isDescendingOrder = !_isDescendingOrder;
+            }
+
+            _sortOrder = sortOrder;
+            SortRooms();
+            DrawRoomPages();
+        }
+
+        /// <summary>
+        /// Filter out invalid rooms.
+        /// </summary>
+        private void FilterValidRooms()
+        {
+            _rooms = _rooms
+                .Where(room => room.GameType != LevelSequence.GameType.Invalid)
+                .Where(room => room.Floor >= 0);
+        }
+
+        /// <summary>
+        /// Sort rooms based on the sort order preference.
+        /// </summary>
+        private void SortRooms()
+        {
+            _rooms = _isDescendingOrder
+                ? _rooms.OrderByDescending(_sortOrder).ToList()
+                : _rooms.OrderBy(_sortOrder).ToList();
+        }
+
+        private static Action JoinRoomAction(string roomCode)
+        {
+            return () =>
+            {
+                RoomFinderMod.Logger.Msg($"Joining room [{roomCode}].");
+                Traverse.Create(RoomFinderMod.SharedState.GameContext.gameStateMachine.lobby.GetLobbyMenuController)
+                    .Method("JoinGame", roomCode, true)
+                    .GetValue();
+            };
+        }
+    }
+}


### PR DESCRIPTION
Introduce a RoomFinder UI for the PC Edition.

**Changes:**
- Added NonVr UIs in the form of `RoomListPanelNonVr` and `RoomFinderUiNonVr`.
- Added a patch (in `Patcher.cs`) for the PC edition so that the main menu showed up after refreshing the list of available rooms. Else, the client is stuck with the loading screen.  No patch is needed for the VR version, as the VR version properly "goes back" to the main menu.
- Removed some missed debug print statements from previous commits.