### PR TITLE
Fix RoomFinder getting stuck on Oculus PC edition.

### DIFF
--- a/RoomFinder/Patcher.cs
+++ b/RoomFinder/Patcher.cs
@@ -67,6 +67,7 @@
             }
 
             __instance.GetLobbyMenuController.view.ShowMainContent(LobbyMenuController.MenuContent.Play);
+            RoomFinderMod.SharedState.HasLoadingScreenClosed = true;
             return false;
         }
     }

--- a/RoomFinder/SharedState.cs
+++ b/RoomFinder/SharedState.cs
@@ -10,6 +10,8 @@
 
         internal bool HasRoomListUpdated { get; set; }
 
+        internal bool HasLoadingScreenClosed { get; set; }
+
         internal static SharedState NewInstance()
         {
             return new SharedState();

--- a/RoomFinder/UI/RoomFinderUiNonVr.cs
+++ b/RoomFinder/UI/RoomFinderUiNonVr.cs
@@ -53,9 +53,14 @@
                 return;
             }
 
+            if (!RoomFinderMod.SharedState.HasLoadingScreenClosed)
+            {
+                return;
+            }
+
             RoomFinderMod.SharedState.IsRefreshingRoomList = false;
             RoomFinderMod.SharedState.HasRoomListUpdated = false;
-
+            RoomFinderMod.SharedState.HasLoadingScreenClosed = false;
             PopulateRoomList();
         }
 

--- a/RoomFinder/UI/RoomFinderUiVr.cs
+++ b/RoomFinder/UI/RoomFinderUiVr.cs
@@ -12,10 +12,9 @@
 
     internal class RoomFinderUiVr : MonoBehaviour
     {
-        private bool _isInitialized;
         private VrResourceTable _resourceTable;
         private VrElementCreator _elementCreator;
-        private RoomListPanelVr _roomListPanelVr;
+        private RoomListPanelVr _roomListPanel;
         private Transform _anchor;
 
         private void Start()
@@ -38,7 +37,7 @@
 
             _resourceTable = VrResourceTable.Instance();
             _elementCreator = VrElementCreator.Instance();
-            _roomListPanelVr = RoomListPanelVr.NewInstance(_elementCreator, RefreshRoomList);
+            _roomListPanel = RoomListPanelVr.NewInstance(_elementCreator, RefreshRoomList);
             _anchor = Resources
                 .FindObjectsOfTypeAll<charactersoundlistener>()
                 .First(x => x.name == "MenuBox_BindPose").transform;
@@ -49,11 +48,6 @@
 
         private void Update()
         {
-            if (!_isInitialized)
-            {
-                return;
-            }
-
             if (!RoomFinderMod.SharedState.IsRefreshingRoomList)
             {
                 return;
@@ -64,8 +58,14 @@
                 return;
             }
 
+            if (!RoomFinderMod.SharedState.HasLoadingScreenClosed)
+            {
+                return;
+            }
+
             RoomFinderMod.SharedState.IsRefreshingRoomList = false;
             RoomFinderMod.SharedState.HasRoomListUpdated = false;
+            RoomFinderMod.SharedState.HasLoadingScreenClosed = false;
             PopulateRoomList();
         }
 
@@ -88,7 +88,7 @@
             headerText.transform.SetParent(transform, worldPositionStays: false);
             headerText.transform.localPosition = new Vector3(0, 2.375f, VrElementCreator.TextZShift);
 
-            var selectionPanel = _roomListPanelVr.Panel;
+            var selectionPanel = _roomListPanel.Panel;
             selectionPanel.transform.SetParent(transform, worldPositionStays: false);
 
             var versionText = _elementCreator.CreateNormalText($"v{BuildVersion.Version}");
@@ -97,8 +97,6 @@
 
             // TODO(orendain): Fix so that ray interacts with entire object.
             gameObject.AddComponent<BoxCollider>();
-
-            _isInitialized = true;
         }
 
         private static void RefreshRoomList()
@@ -118,7 +116,7 @@
             RoomFinderMod.Logger.Msg($"Captured {cachedRooms.Count} rooms.");
 
             var rooms = cachedRooms.Values.ToList().Select(Room.Parse).ToList();
-            _roomListPanelVr.UpdateRooms(rooms);
+            _roomListPanel.UpdateRooms(rooms);
         }
     }
 }


### PR DESCRIPTION
**Problem:**
There was a race condition between when the game closes the "Loading..." screen and when the RoomFinder UI determines that the game's room-refreshing process is complete.  This caused two issues:
- The loading screen would never close, causing most of the UI to be unresponsive.
- Instead of closing the loading screen, the game would proceed to connect to the last-connected room.

**Fix:**
As part of the logic for determining if the game's room-refreshing cycle is complete, explicitly wait for the game to exit the loading screen.

Additionally, this PR renames `_roomListPanelVr` -> `_roomListPanel` and removes `_isInitialized` field.