### PR TITLE
[WIP] [On Pause] Show modded rooms via RoomFinder.

### DIFF
--- a/RoomFinder/UI/Room.cs
+++ b/RoomFinder/UI/Room.cs
@@ -5,6 +5,8 @@
 
     internal class Room
     {
+        private const string ModdedRoomPropertyKey = "modded";
+
         internal string Name { get; }
 
         internal LevelSequence.GameType GameType { get; }
@@ -15,11 +17,14 @@
 
         internal int MaxPlayers { get; }
 
+        internal bool IsModded { get; }
+
         internal static Room Parse(RoomInfo room)
         {
             var gameType = ExtractGameType(room);
             var floorIndex = ExtractFloorNumber(room);
-            return NewInstance(room.Name, gameType, floorIndex, room.PlayerCount, room.MaxPlayers);
+            var isModded = ExtractModdedStatus(room);
+            return NewInstance(room.Name, gameType, floorIndex, room.PlayerCount, room.MaxPlayers, isModded);
         }
 
         private static Room NewInstance(
@@ -27,18 +32,26 @@
             LevelSequence.GameType gameType,
             int floor,
             int currentPlayers,
-            int maxPlayers)
+            int maxPlayers,
+            bool isModded)
         {
-            return new Room(name, gameType, floor, currentPlayers, maxPlayers);
+            return new Room(name, gameType, floor, currentPlayers, maxPlayers, isModded);
         }
 
-        private Room(string name, LevelSequence.GameType gameType, int floor, int currentPlayers, int maxPlayers)
+        private Room(
+            string name,
+            LevelSequence.GameType gameType,
+            int floor,
+            int currentPlayers,
+            int maxPlayers,
+            bool isModded)
         {
             Name = name;
             GameType = gameType;
             Floor = floor;
             CurrentPlayers = currentPlayers;
             MaxPlayers = maxPlayers;
+            IsModded = isModded;
         }
 
         private static LevelSequence.GameType ExtractGameType(RoomInfo room)
@@ -51,6 +64,11 @@
         private static int ExtractFloorNumber(RoomInfo room)
         {
             return room.CustomProperties.TryGetValue("fi", out var obj) ? (int)obj : -1;
+        }
+
+        private static bool ExtractModdedStatus(RoomInfo room)
+        {
+            return room.CustomProperties.TryGetValue(ModdedRoomPropertyKey, out var obj) && (bool)obj;
         }
     }
 }

--- a/RoomFinder/UI/RoomListPanelNonVr.cs
+++ b/RoomFinder/UI/RoomListPanelNonVr.cs
@@ -135,6 +135,10 @@
             playersButton.transform.SetParent(container.transform, worldPositionStays: false);
             playersButton.transform.localPosition = new Vector2(175f, 0);
 
+            var moddedButton = CreateSortButton("Modded", () => SetSortOrderAndApply(r => r.IsModded));
+            moddedButton.transform.SetParent(container.transform, worldPositionStays: false);
+            moddedButton.transform.localPosition = new Vector2(275f, 0);
+
             return container;
         }
 
@@ -188,6 +192,10 @@
             var playersLabel = _elementCreator.CreateNormalText($"{room.CurrentPlayers}/{room.MaxPlayers}");
             playersLabel.transform.SetParent(container.transform, worldPositionStays: false);
             playersLabel.transform.localPosition = new Vector2(162.5f, 0);
+
+            var moddedLabel = _elementCreator.CreateNormalText(room.IsModded ? "Yes" : "-");
+            moddedLabel.transform.SetParent(container.transform, worldPositionStays: false);
+            moddedLabel.transform.localPosition = new Vector2(262.5f, 0);
 
             return container;
         }


### PR DESCRIPTION
My thinking was that I could somehow get a listing of all private rooms.  Unfortunately, that's not possible.  This looks to be a design of the underlying multiplayer network (Photon).

After a bit of digging into the photon network room options, I don't see an alternative using what's built into the game.

---

An alternative, that may be more trouble than it's worth:

We maintain some external registry of modded rooms.  For example, when someone starts a room, we publish information about the room to some simple web service.  RoomFinder can then retrieve that list.

Lots of work just to get RoomFinder to list private HouseRules rooms, but figured I'd share these findings for thoroughness before putting a pin on this feature from my end.