### PR TITLE
Two new rules for preventing player on player accidental damage.

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -32,6 +32,7 @@
             HR.Rulebook.Register(typeof(CardEnergyFromRecyclingMultipliedRule));
             HR.Rulebook.Register(typeof(CardLimitModifiedRule));
             HR.Rulebook.Register(typeof(CardSellValueMultipliedRule));
+            HR.Rulebook.Register(typeof(DontShockFriendsRule));
             HR.Rulebook.Register(typeof(EnemyAttackScaledRule));
             HR.Rulebook.Register(typeof(EnemyDoorOpeningDisabledRule));
             HR.Rulebook.Register(typeof(EnemyHealthScaledRule));

--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -24,6 +24,7 @@
             HR.Rulebook.Register(typeof(AbilityRandomPieceListRule));
             HR.Rulebook.Register(typeof(AbilityStealthDamageOverriddenRule));
             HR.Rulebook.Register(typeof(BackstabConfigOverriddenRule));
+            HR.Rulebook.Register(typeof(BlockFriendlyFireRule));
             HR.Rulebook.Register(typeof(CourageShantyAddsHpRule));
             HR.Rulebook.Register(typeof(CardAdditionOverriddenRule));
             HR.Rulebook.Register(typeof(CardClassRestrictionOverriddenRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Rules\AbilityDamageOverriddenRule.cs" />
     <Compile Include="Rules\AbilityStealthDamageOverriddenRule.cs" />
     <Compile Include="Rules\AbilityHealOverriddenRule.cs" />
+    <Compile Include="Rules\DontShockFriendsRule.cs" />
     <Compile Include="Rules\CardClassRestrictionOverriddenRule.cs" />
     <Compile Include="Rules\BlockFriendlyFireRule.cs" />
     <Compile Include="Rules\FreeAbilityOnCritRule.cs" />

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Rules\AbilityStealthDamageOverriddenRule.cs" />
     <Compile Include="Rules\AbilityHealOverriddenRule.cs" />
     <Compile Include="Rules\CardClassRestrictionOverriddenRule.cs" />
+    <Compile Include="Rules\BlockFriendlyFireRule.cs" />
     <Compile Include="Rules\FreeAbilityOnCritRule.cs" />
     <Compile Include="Rules\CourageShantyAddsHPRule.cs" />
     <Compile Include="Rules\TileEffectDurationOverriddenRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -202,6 +202,22 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
     },
   ```
 
+#### __BlockFriendlyFire__: Player on Player attack damage is blocked
+  - Players are added to the list of pieces who have blocked with armor when dealing player->player attack damage.
+  - Damage to party members is reduced to 1hp
+  - To configure:
+    - Specify `true` to reduce player on player damage to 1hp.
+
+  ###### _Example JSON config for BlockFriendlyFire_
+
+  ```json
+    {
+      "Rule": "BlockFriendlyFire",
+      "Config": true
+    },
+  ```
+
+
 #### __CardAdditionOverridden__: Overrides the lists of cards which players receive from chests & card energy.
   - The default card allocation mechanism is intercepted and changed to use a user-defined list of cards.
   - To configure:

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -327,6 +327,21 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
   },
   ```
 
+#### __DontShockFriends__: Electrical damage between players is zeroed
+  - Electricity Damage from friendly fire is zeroed
+  - To configure:
+    - Specify `true` to remove player on player electrical damage.
+
+  ###### _Example JSON config for DontShockFriends_
+
+  ```json
+    {
+      "Rule": "DontShockFriends",
+      "Config": true
+    },
+  ```
+
+
 #### __EnemyAttackScaled__: Enemy ⚔️attack⚔️ damage is scaled
   - To configure:
     - Specify a decimal number representing how enemy attack damage is multiplied.

--- a/HouseRules_Essentials/Rules/BlockFriendlyFireRule.cs
+++ b/HouseRules_Essentials/Rules/BlockFriendlyFireRule.cs
@@ -1,0 +1,81 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System;
+    using System.Collections.Generic;
+    using Boardgame;
+    using Boardgame.BoardEntities;
+    using Boardgame.BoardEntities.Abilities;
+    using Boardgame.Data;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Types;
+    using UnityEngine;
+
+    public sealed class BlockFriendlyFireRule : Rule, IConfigWritable<bool>, IPatchable,
+        IMultiplayerSafe
+    {
+        public override string Description => "Friendly fire is blocked.";
+
+        private static bool _globalAdjustments;
+        private static bool _isActivated;
+
+        private readonly bool _adjustments;
+
+        public BlockFriendlyFireRule(bool adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        public bool GetConfigObject() => _adjustments;
+
+        protected override void OnActivate(GameContext gameContext)
+        {
+            _globalAdjustments = _adjustments;
+            _isActivated = true;
+        }
+
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
+
+        private static void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Ability), "GenerateAttackDamage"),
+                prefix: new HarmonyMethod(
+                    typeof(BlockFriendlyFireRule),
+                    nameof(Ability_GenerateAttackDamage_Prefix)));
+        }
+
+        private static bool Ability_GenerateAttackDamage_Prefix(Ability __instance, Piece source, Piece mainTarget, Dice.Outcome diceResult, BoardModel boardModel, Piece[] targets, ref Damage __result)
+        {
+            if (!_isActivated)
+            {
+                return true;
+            }
+
+            bool isBackStab = false;
+            if (source != null && source.IsRogue() && __instance.enableBackstabBonus)
+            {
+                isBackStab = Traverse.Create(__instance).Method("IsBackstab", paramTypes: new[] { typeof(Piece), typeof(Piece), typeof(BoardModel) }, arguments: new object[] { source, mainTarget, boardModel }).GetValue<bool>();
+            }
+
+            if (source != null && targets.Length != 0)
+            {
+                List<Piece> list = new List<Piece>();
+                for (int i = 0; i < targets.Length; i++)
+                {
+                    var isBlockedFromFront = Traverse.Create(__instance).Method("IsBlockedFromFront", paramTypes: new[] { typeof(Piece), typeof(Piece), typeof(BoardModel) }, arguments: new object[] { source, targets[i], boardModel }).GetValue<bool>();
+                    if ((Enum.IsDefined(typeof(FrontBlockingPieces), (int)targets[i].boardPieceId) && isBlockedFromFront && __instance.isBlockable) || (source.IsPlayer() && targets[i].IsPlayer()))
+                    {
+                        list.Add(targets[i]);
+                    }
+                }
+
+                __result = new Damage(__instance, source, diceResult, isBackStab, list);
+                return false;
+            }
+
+            __result = new Damage(__instance, source, diceResult, isBackStab, null);
+            return false;
+        }
+    }
+}

--- a/HouseRules_Essentials/Rules/DontShockFriendsRule.cs
+++ b/HouseRules_Essentials/Rules/DontShockFriendsRule.cs
@@ -1,16 +1,15 @@
 ﻿namespace HouseRules.Essentials.Rules
 {
-    using System;
-    using System.Collections.Generic;
     using Boardgame;
     using Boardgame.BoardEntities;
     using Boardgame.BoardEntities.Abilities;
-    using Boardgame.Data;
     using Boardgame.GameplayEffects;
+    using Boardgame.SerializableEvents;
     using DataKeys;
     using HarmonyLib;
     using HouseRules.Types;
     using UnityEngine;
+    using System.IO;
 
     public sealed class DontShockFriendsRule : Rule, IConfigWritable<bool>, IPatchable,
         IMultiplayerSafe
@@ -21,6 +20,7 @@
         private static bool _isActivated;
 
         private readonly bool _adjustments;
+        private static GameContext _gameContext;
 
         public DontShockFriendsRule(bool adjustments)
         {
@@ -33,6 +33,7 @@
         {
             _globalAdjustments = _adjustments;
             _isActivated = true;
+            _gameContext = gameContext;
         }
 
         protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
@@ -45,6 +46,12 @@
                 prefix: new HarmonyMethod(
                     typeof(DontShockFriendsRule),
                     nameof(ProjectileHitSequence_OnStarted_Prefix)));
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(SerializableEventQueue), "ValidateSerializableEvent"),
+                prefix: new HarmonyMethod(
+                    typeof(DontShockFriendsRule),
+                    nameof(SerializableEventQueue_ValidateSerializableEvent_Postfix)));
         }
 
         private static bool ProjectileHitSequence_OnStarted_Prefix(ref ProjectileHitSequence __instance)
@@ -64,7 +71,30 @@
             {
                 var localizedText = Traverse.Create(damage).Method("GetLocalizedText", paramTypes: new[] { typeof(string), typeof(bool) }, arguments: new object[] { "Ui/pieceUi/notification/damage/noDamage", false }).GetValue<string>();
                 Notification.ShowGoldenText(new Target(targetPiece).gameObject, localizedText);
+                _gameContext.serializableEventQueue.SendEventRequest(new SerializeableEventSetStatusEffects(targetPiece.networkID, new EffectStateType[] { }, new EffectStateType[] { EffectStateType.Stunned }));
+
                 return false; // Don't run the original OnStarted method.
+            }
+
+            return true;
+        }
+
+        private static bool SerializableEventQueue_ValidateSerializableEvent_Postfix(byte[] serializableEventData, ref SerializableEvent __result)
+        {
+            if (!_isActivated)
+            {
+                return true;
+            }
+
+            if (__result == null)
+            {
+                SerializableEvent action = SerializableEvent.Deserialize(new BinaryReader(new MemoryStream(serializableEventData)));
+                if (action.type == SerializableEvent.Type.SetStatusEffects)
+                {
+                    EssentialsMod.Logger.Msg($"Bypassing Validate for {action.type}");
+                    __result = action;
+                    return false; // Don't run the original OnStarted method.
+                }
             }
 
             return true;

--- a/HouseRules_Essentials/Rules/DontShockFriendsRule.cs
+++ b/HouseRules_Essentials/Rules/DontShockFriendsRule.cs
@@ -1,0 +1,67 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System;
+    using System.Collections.Generic;
+    using Boardgame;
+    using Boardgame.BoardEntities;
+    using Boardgame.BoardEntities.Abilities;
+    using Boardgame.Data;
+    using Boardgame.GameplayEffects;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Types;
+    using UnityEngine;
+
+    public sealed class DontShockFriendsRule : Rule, IConfigWritable<bool>, IPatchable,
+        IMultiplayerSafe
+    {
+        public override string Description => "Player on player electricity damage is zero.";
+
+        private static bool _globalAdjustments;
+        private static bool _isActivated;
+
+        private readonly bool _adjustments;
+
+        public DontShockFriendsRule(bool adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        public bool GetConfigObject() => _adjustments;
+
+        protected override void OnActivate(GameContext gameContext)
+        {
+            _globalAdjustments = _adjustments;
+            _isActivated = true;
+        }
+
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
+
+        private static void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Damage), "DealDamage", parameters: new[] { typeof(Target), typeof(Damage), typeof(IntPoint2D), typeof(Target), typeof(PieceAndTurnController), typeof(BoardModel), typeof(OverkillController), typeof(bool) }),
+                prefix: new HarmonyMethod(
+                    typeof(DontShockFriendsRule),
+                    nameof(Ability_DealDamage_Prefix)));
+        }
+
+        private static bool Ability_DealDamage_Prefix(Target target, Damage damage, Target attacker, ref int __result)
+        {
+            if (!_isActivated)
+            {
+                return true;
+            }
+
+            if (attacker.piece.IsPlayer() && target.piece.IsPlayer() && damage.HasTag(DamageTag.Electricity))
+            {
+                var localizedText = Traverse.Create(damage).Method("GetLocalizedText", paramTypes: new[] { typeof(string), typeof(bool) }, arguments: new object[] { "Ui/pieceUi/notification/damage/noDamage", false }).GetValue<string>();
+                Notification.ShowGoldenText(target.gameObject, localizedText);
+                __result = 0;
+                return false;
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Before reviewing this PR:

Should I actually be raising this PR against `main`? This PR will be adding new rules to the README.md which won't work in the DLLs that we released yesterday. Maybe time to start using a `develop` branch?

# BlockFriendlyFireRule
Adds players to the list of targets who blocked an attack - damage is reduced to 1HP

This rule applies a prefix patch to `GenerateAttackDamage`. We already have a postfix patch on that method. Not sure if this might cause an issue?  

# DontShockFriendsRule
Zero all player on player electricial damage

This rule patches `DealDamage` (which was a challenge as it was an ambiguous match until I told it the param types) and will zero out player on player electrical damage only. This rule is probably a good candidate for the `Better Sorcerer` ruleset now that the Overcharge mechanic has been added to the game and zapping your friends is a common occurence.


