### PR TITLE
Update RoomFinder to be compatible with Demeo v1.19.

### DIFF
--- a/RoomFinder/BuildVersion.cs
+++ b/RoomFinder/BuildVersion.cs
@@ -2,7 +2,7 @@
 {
     public static class BuildVersion
     {
-        public const string Version = "1.5.0";
-        public const string MajorMinorVersion = "1.5";
+        public const string Version = "1.6.0";
+        public const string MajorMinorVersion = "1.6";
     }
 }

--- a/RoomFinder/Patcher.cs
+++ b/RoomFinder/Patcher.cs
@@ -1,12 +1,8 @@
 ﻿namespace RoomFinder
 {
-    using System.Collections.ObjectModel;
     using System.Reflection;
     using Boardgame;
-    using Boardgame.Ui.LobbyMenu;
-    using Common.UI;
     using HarmonyLib;
-    using RGCommon;
 
     internal static class Patcher
     {
@@ -27,10 +23,6 @@
                     .Inner(typeof(GameStateMachine), "MatchMakingState").GetTypeInfo()
                     .GetDeclaredMethod("FindGame"),
                 prefix: new HarmonyMethod(typeof(Patcher), nameof(MatchMakingState_FindGame_Prefix)));
-
-            harmony.Patch(
-                original: AccessTools.Method(typeof(Lobby), "HideMenu"),
-                prefix: new HarmonyMethod(typeof(Patcher), nameof(Lobby_HideMenu_Prefix)));
         }
 
         private static void GameStartup_InitializeGame_Postfix(GameStartup __instance)
@@ -51,23 +43,6 @@
             }
 
             RoomFinderMod.SharedState.GameContext.gameStateMachine.goBackToMenuState = true;
-            return false;
-        }
-
-        private static bool Lobby_HideMenu_Prefix(Lobby __instance)
-        {
-            if (!Environments.IsPcEdition())
-            {
-                return true;
-            }
-
-            if (!RoomFinderMod.SharedState.IsRefreshingRoomList)
-            {
-                return true;
-            }
-
-            __instance.GetLobbyMenuController.view.ShowMainContent(LobbyMenuController.MenuContent.Play);
-            RoomFinderMod.SharedState.HasLoadingScreenClosed = true;
             return false;
         }
     }

--- a/RoomFinder/RoomFinderMod.cs
+++ b/RoomFinder/RoomFinderMod.cs
@@ -14,8 +14,6 @@
         internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("RoomFinder");
         internal static readonly SharedState SharedState = SharedState.NewInstance();
 
-        private GameObject _roomFinderUi;
-
         public override void OnApplicationStart()
         {
             var harmony = new Harmony("com.orendain.demeomods.roomfinder");
@@ -43,7 +41,7 @@
             }
 
             Logger.Msg("Recognized lobby in VR. Loading UI.");
-            _roomFinderUi = new GameObject("RoomFinderUiVr", typeof(RoomFinderUiVr));
+            _ = new GameObject("RoomFinderUiVr", typeof(RoomFinderUiVr));
         }
     }
 }

--- a/RoomFinder/SharedState.cs
+++ b/RoomFinder/SharedState.cs
@@ -10,8 +10,6 @@
 
         internal bool HasRoomListUpdated { get; set; }
 
-        internal bool HasLoadingScreenClosed { get; set; }
-
         internal static SharedState NewInstance()
         {
             return new SharedState();

--- a/RoomFinder/UI/RoomFinderUiNonVr.cs
+++ b/RoomFinder/UI/RoomFinderUiNonVr.cs
@@ -127,7 +127,11 @@
                 .Field<LobbyMenu.ILobbyMenuContext>("lobbyMenuContext")
                 .Value;
 
-            lobbyMenuContext.QuickPlay(LevelSequence.GameType.Invalid, LevelSequence.ControlType.OneHero, true, null);
+            lobbyMenuContext.QuickPlay(
+                LevelSequence.GameType.Invalid,
+                LevelSequence.ControlType.OneHero,
+                matchMakeAnyGame: true,
+                onError: null);
         }
 
         private void PopulateRoomList()

--- a/RoomFinder/UI/RoomFinderUiNonVr.cs
+++ b/RoomFinder/UI/RoomFinderUiNonVr.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using Boardgame;
+    using Boardgame.Ui.LobbyMenu;
     using Common.UI;
     using Common.UI.Element;
     using HarmonyLib;
@@ -53,14 +54,8 @@
                 return;
             }
 
-            if (!RoomFinderMod.SharedState.HasLoadingScreenClosed)
-            {
-                return;
-            }
-
             RoomFinderMod.SharedState.IsRefreshingRoomList = false;
             RoomFinderMod.SharedState.HasRoomListUpdated = false;
-            RoomFinderMod.SharedState.HasLoadingScreenClosed = false;
             PopulateRoomList();
         }
 
@@ -127,9 +122,12 @@
         private static void RefreshRoomList()
         {
             RoomFinderMod.SharedState.IsRefreshingRoomList = true;
-            Traverse.Create(RoomFinderMod.SharedState.GameContext.gameStateMachine.lobby.GetLobbyMenuController)
-                .Method("QuickPlay", LevelSequence.GameType.Invalid, true)
-                .GetValue();
+            var lobbyMenuContext = Traverse
+                .Create(RoomFinderMod.SharedState.GameContext.gameStateMachine.lobby.GetLobbyMenuController)
+                .Field<LobbyMenu.ILobbyMenuContext>("lobbyMenuContext")
+                .Value;
+
+            lobbyMenuContext.QuickPlay(LevelSequence.GameType.Invalid, LevelSequence.ControlType.OneHero, true, null);
         }
 
         private void PopulateRoomList()

--- a/RoomFinder/UI/RoomFinderUiVr.cs
+++ b/RoomFinder/UI/RoomFinderUiVr.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using Boardgame;
+    using Boardgame.Ui.LobbyMenu;
     using Common.UI;
     using Common.UI.Element;
     using HarmonyLib;
@@ -58,14 +59,8 @@
                 return;
             }
 
-            if (!RoomFinderMod.SharedState.HasLoadingScreenClosed)
-            {
-                return;
-            }
-
             RoomFinderMod.SharedState.IsRefreshingRoomList = false;
             RoomFinderMod.SharedState.HasRoomListUpdated = false;
-            RoomFinderMod.SharedState.HasLoadingScreenClosed = false;
             PopulateRoomList();
         }
 
@@ -102,9 +97,12 @@
         private static void RefreshRoomList()
         {
             RoomFinderMod.SharedState.IsRefreshingRoomList = true;
-            Traverse.Create(RoomFinderMod.SharedState.GameContext.gameStateMachine.lobby.GetLobbyMenuController)
-                .Method("QuickPlay", LevelSequence.GameType.Invalid, true)
-                .GetValue();
+            var lobbyMenuContext = Traverse
+                .Create(RoomFinderMod.SharedState.GameContext.gameStateMachine.lobby.GetLobbyMenuController)
+                .Field<LobbyMenu.ILobbyMenuContext>("lobbyMenuContext")
+                .Value;
+
+            lobbyMenuContext.QuickPlay(LevelSequence.GameType.Invalid, LevelSequence.ControlType.OneHero, true, null);
         }
 
         private void PopulateRoomList()

--- a/RoomFinder/UI/RoomFinderUiVr.cs
+++ b/RoomFinder/UI/RoomFinderUiVr.cs
@@ -102,7 +102,11 @@
                 .Field<LobbyMenu.ILobbyMenuContext>("lobbyMenuContext")
                 .Value;
 
-            lobbyMenuContext.QuickPlay(LevelSequence.GameType.Invalid, LevelSequence.ControlType.OneHero, true, null);
+            lobbyMenuContext.QuickPlay(
+                LevelSequence.GameType.Invalid,
+                LevelSequence.ControlType.OneHero,
+                matchMakeAnyGame: true,
+                onError: null);
         }
 
         private void PopulateRoomList()


### PR DESCRIPTION
Changes:
- Bumped minor version number for RoomFinder.
- Updated the invoked quickplay endpoint, which changed in Demeo v1.19.
- Removed need for `HasLoadingScreenClosed` check.
- Removed superfluous field.