### PR TITLE
v1.19_compatibility fixes

### DIFF
--- a/HouseRules_Essentials/Rules/LevelSequenceOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/LevelSequenceOverriddenRule.cs
@@ -100,7 +100,7 @@
             var newGameType =
                 Traverse.Create(__instance).Field<PostGameControllerBase>("postGameController").Value.gameType;
 
-            var gsmLevelSequence = gameContext.levelSequenceConfiguration.GetNewLevelSequence(-1, newGameType);
+            var gsmLevelSequence = gameContext.levelSequenceConfiguration.GetNewLevelSequence(-1, newGameType, LevelSequence.ControlType.OneHero);
             var originalSequence = Traverse.Create(gsmLevelSequence).Field<string[]>("levels").Value;
 
             Traverse.Create(gsmLevelSequence).Field<string[]>("levels").Value =


### PR DESCRIPTION
GetNewLevelSequence now requires an extra LevelSequence.Controltype to be passed as an argument.

There is now the choice of 'OneHero' or 'TwoHeroes' when generating a LevelSequence. I've pinned it to OneHero for now as that's what the rule was designed to work with.