### PR TITLE
New rule for Electricity damage between party members.

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -42,6 +42,7 @@
             HR.Rulebook.Register(typeof(LevelPropertiesModifiedRule));
             HR.Rulebook.Register(typeof(LevelSequenceOverriddenRule));
             HR.Rulebook.Register(typeof(MonsterDeckOverriddenRule));
+            HR.Rulebook.Register(typeof(PartyElectricityDamageOverriddenRule));
             HR.Rulebook.Register(typeof(PetsFocusHunterMarkRule));
             HR.Rulebook.Register(typeof(PieceConfigAdjustedRule));
             HR.Rulebook.Register(typeof(PieceImmunityListAdjustedRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Rules\AbilityStealthDamageOverriddenRule.cs" />
     <Compile Include="Rules\AbilityHealOverriddenRule.cs" />
     <Compile Include="Rules\CardClassRestrictionOverriddenRule.cs" />
+    <Compile Include="Rules\PartyElectricityDamageOverriddenRule.cs" />
     <Compile Include="Rules\FreeAbilityOnCritRule.cs" />
     <Compile Include="Rules\CourageShantyAddsHPRule.cs" />
     <Compile Include="Rules\TileEffectDurationOverriddenRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -552,6 +552,19 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
   },
   ```
 
+#### __PartyElectricityDamageOverridden__: Electrical damage between players is zeroed
+  - Electricity Damage from friendly fire is zeroed
+  - To configure:
+    - Specify `true` to remove player on player electrical damage.
+
+  ###### _Example JSON config for PartyElectricityDamageOverridden_
+
+  ```json
+    {
+      "Rule": "PartyElectricityDamageOverridden",
+      "Config": true
+    },
+  ```
 
 #### __PetsFocusHunterMark__: Pets focus on hunter marked enemies
   - To configure:

--- a/HouseRules_Essentials/Rules/PartyElectricityDamageOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PartyElectricityDamageOverriddenRule.cs
@@ -58,6 +58,7 @@
 
             if (attacker.IsPlayer() && targetPiece.IsPlayer() && damage.HasTag(DamageTag.Electricity))
             {
+                targetPiece.effectSink.SubtractHealth(0);
                 var localizedText = Traverse.Create(damage).Method("GetLocalizedText", paramTypes: new[] { typeof(string), typeof(bool) }, arguments: new object[] { "Ui/pieceUi/notification/damage/noDamage", false }).GetValue<string>();
                 Notification.ShowGoldenText(new Target(targetPiece).gameObject, localizedText);
 

--- a/HouseRules_Essentials/Rules/PartyElectricityDamageOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PartyElectricityDamageOverriddenRule.cs
@@ -1,0 +1,104 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using Boardgame;
+    using Boardgame.BoardEntities;
+    using Boardgame.BoardEntities.Abilities;
+    using Boardgame.GameplayEffects;
+    using Boardgame.SerializableEvents;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Types;
+    using UnityEngine;
+    using System.IO;
+
+    public sealed class PartyElectricityDamageOverriddenRule : Rule, IConfigWritable<bool>, IPatchable,
+        IMultiplayerSafe
+    {
+        public override string Description => "Player on player electricity damage is zero.";
+
+        private static bool _globalAdjustments;
+        private static bool _isActivated;
+
+        private readonly bool _adjustments;
+        private static GameContext _gameContext;
+
+        public PartyElectricityDamageOverriddenRule(bool adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        public bool GetConfigObject() => _adjustments;
+
+        protected override void OnActivate(GameContext gameContext)
+        {
+            _globalAdjustments = _adjustments;
+            _isActivated = true;
+            _gameContext = gameContext;
+        }
+
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
+
+        private static void Patch(Harmony harmony)
+        {
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(ProjectileHitSequence), "OnStarted"),
+                prefix: new HarmonyMethod(
+                    typeof(PartyElectricityDamageOverriddenRule),
+                    nameof(ProjectileHitSequence_OnStarted_Prefix)));
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(SerializableEventQueue), "ValidateSerializableEvent"),
+                prefix: new HarmonyMethod(
+                    typeof(PartyElectricityDamageOverriddenRule),
+                    nameof(SerializableEventQueue_ValidateSerializableEvent_Postfix)));
+        }
+
+        private static bool ProjectileHitSequence_OnStarted_Prefix(ref ProjectileHitSequence __instance)
+        {
+            if (!_isActivated)
+            {
+                return true;
+            }
+
+            var targetPiece = Traverse.Create(__instance).Field("targetPiece").GetValue<Piece>();
+            var abilityContext = Traverse.Create(__instance).Field("abilityContext").GetValue<AbilityContext>();
+            var damage = Traverse.Create(abilityContext).Field("damage").GetValue<Damage>();
+            var attackerTarget = Traverse.Create(abilityContext).Field("attacker").GetValue<Target>();
+            var attacker = Traverse.Create(attackerTarget).Field("piece").GetValue<Piece>();
+
+            if (attacker.IsPlayer() && targetPiece.IsPlayer() && damage.HasTag(DamageTag.Electricity))
+            {
+                var localizedText = Traverse.Create(damage).Method("GetLocalizedText", paramTypes: new[] { typeof(string), typeof(bool) }, arguments: new object[] { "Ui/pieceUi/notification/damage/noDamage", false }).GetValue<string>();
+                Notification.ShowGoldenText(new Target(targetPiece).gameObject, localizedText);
+                _gameContext.serializableEventQueue.SendEventRequest(new SerializeableEventSetStatusEffects(targetPiece.networkID, new EffectStateType[] { }, new EffectStateType[] { EffectStateType.Stunned }));
+
+                return false; // Don't run the original OnStarted method.
+            }
+
+            return true;
+        }
+
+        private static bool SerializableEventQueue_ValidateSerializableEvent_Postfix(byte[] serializableEventData, ref SerializableEvent __result)
+        {
+            if (!_isActivated)
+            {
+                return true;
+            }
+
+            if (__result == null)
+            {
+                SerializableEvent action = SerializableEvent.Deserialize(new BinaryReader(new MemoryStream(serializableEventData)));
+                if (action.type == SerializableEvent.Type.SetStatusEffects)
+                {
+                    EssentialsMod.Logger.Msg($"Bypassing Validate for {action.type}");
+                    __result = action;
+                    return false; // Don't run the original OnStarted method.
+                }
+            }
+
+            return true;
+        }
+
+    }
+}

--- a/HouseRules_Essentials/Rules/PartyElectricityDamageOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PartyElectricityDamageOverriddenRule.cs
@@ -4,12 +4,9 @@
     using Boardgame.BoardEntities;
     using Boardgame.BoardEntities.Abilities;
     using Boardgame.GameplayEffects;
-    using Boardgame.SerializableEvents;
     using DataKeys;
     using HarmonyLib;
     using HouseRules.Types;
-    using UnityEngine;
-    using System.IO;
 
     public sealed class PartyElectricityDamageOverriddenRule : Rule, IConfigWritable<bool>, IPatchable,
         IMultiplayerSafe
@@ -20,7 +17,6 @@
         private static bool _isActivated;
 
         private readonly bool _adjustments;
-        private static GameContext _gameContext;
 
         public PartyElectricityDamageOverriddenRule(bool adjustments)
         {
@@ -33,7 +29,6 @@
         {
             _globalAdjustments = _adjustments;
             _isActivated = true;
-            _gameContext = gameContext;
         }
 
         protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
@@ -46,12 +41,6 @@
                 prefix: new HarmonyMethod(
                     typeof(PartyElectricityDamageOverriddenRule),
                     nameof(ProjectileHitSequence_OnStarted_Prefix)));
-
-            harmony.Patch(
-                original: AccessTools.Method(typeof(SerializableEventQueue), "ValidateSerializableEvent"),
-                prefix: new HarmonyMethod(
-                    typeof(PartyElectricityDamageOverriddenRule),
-                    nameof(SerializableEventQueue_ValidateSerializableEvent_Postfix)));
         }
 
         private static bool ProjectileHitSequence_OnStarted_Prefix(ref ProjectileHitSequence __instance)
@@ -71,34 +60,11 @@
             {
                 var localizedText = Traverse.Create(damage).Method("GetLocalizedText", paramTypes: new[] { typeof(string), typeof(bool) }, arguments: new object[] { "Ui/pieceUi/notification/damage/noDamage", false }).GetValue<string>();
                 Notification.ShowGoldenText(new Target(targetPiece).gameObject, localizedText);
-                _gameContext.serializableEventQueue.SendEventRequest(new SerializeableEventSetStatusEffects(targetPiece.networkID, new EffectStateType[] { }, new EffectStateType[] { EffectStateType.Stunned }));
 
                 return false; // Don't run the original OnStarted method.
             }
 
             return true;
         }
-
-        private static bool SerializableEventQueue_ValidateSerializableEvent_Postfix(byte[] serializableEventData, ref SerializableEvent __result)
-        {
-            if (!_isActivated)
-            {
-                return true;
-            }
-
-            if (__result == null)
-            {
-                SerializableEvent action = SerializableEvent.Deserialize(new BinaryReader(new MemoryStream(serializableEventData)));
-                if (action.type == SerializableEvent.Type.SetStatusEffects)
-                {
-                    EssentialsMod.Logger.Msg($"Bypassing Validate for {action.type}");
-                    __result = action;
-                    return false; // Don't run the original OnStarted method.
-                }
-            }
-
-            return true;
-        }
-
     }
 }

--- a/HouseRules_Essentials/Rulesets/BetterSorcererRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/BetterSorcererRuleset.cs
@@ -10,7 +10,7 @@
         internal static Ruleset Create()
         {
             const string name = "Better Sorcerer";
-            const string description = "0 Action Cost for Sorcerer's Zap - No other changes. #STS";
+            const string description = "0 Action Cost for Sorcerer's Zap & prevent electricity based friendly-fire. #STS";
 
             var abilityActionCostRule = new AbilityActionCostAdjustedRule(new Dictionary<AbilityKey, bool>
             {
@@ -20,7 +20,8 @@
             return Ruleset.NewInstance(
                 name,
                 description,
-                abilityActionCostRule);
+                abilityActionCostRule,
+                new PartyElectricityDamageOverriddenRule(true));
         }
     }
 }


### PR DESCRIPTION
This is the same code which was in the `DontShockFriends` rule which I previously did a WIP PR for, but with the rule renamed to match our naming standards.

* Incorporated into the BetterSorcerer ruleset, because it makes the sorcerer better.

To test:
Use better-sorcerer ruleset.
Start a skirmish game with Sorcerer + others. 
Use overcharge on the sorc straight away, and then descned into the dungon.
Use overcharge again on the sorc to cause Overload, zapping all the party members whilst they're still on the entrance steps. 

Expected Outcome:
No damage or stun should be applied to any party members, and 'No Damage' text should be displayed on the Host's screen.
