### PR TITLE
Fix Desert Merchant Loot

### DIFF
--- a/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
@@ -20,6 +20,7 @@
         private static Dictionary<BoardPieceId, List<AbilityKey>> _globalHeroCards;
         private static bool _isActivated;
         private static bool _isPotionStand;
+        private static int _numPlayers;
 
         private readonly Dictionary<BoardPieceId, List<AbilityKey>> _heroCards;
 
@@ -71,6 +72,7 @@
             Interactable whatIsit = gameContext.pieceAndTurnController.GetInteractableAtPosition(targetTile);
             if (whatIsit.type == Interactable.Type.PotionStand)
             {
+                _numPlayers = gameContext.pieceAndTurnController.GetNumberOfPlayerPieces();
                 _isPotionStand = true;
             }
         }
@@ -92,13 +94,20 @@
             if (_isPotionStand)
             {
                 // TODO: Add method to allow custom card loot for Potion Stands here
-                _isPotionStand = false;
+                if (_numPlayers > 1)
+                {
+                    _numPlayers--;
+                }
+                else
+                {
+                    _isPotionStand = false;
+                }
+
                 return;
             }
 
             var addCardToPieceEvent = (SerializableEventAddCardToPiece)request;
             var gameContext = Traverse.Create(__instance).Property<GameContext>("gameContext").Value;
-
             var pieceId = Traverse.Create(addCardToPieceEvent).Field<int>("pieceId").Value;
             var cardSource = Traverse.Create(addCardToPieceEvent).Field<int>("cardSource").Value;
 

--- a/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
@@ -4,8 +4,8 @@
     using System.Collections.Generic;
     using System.Linq;
     using Boardgame;
-    using Boardgame.Data;
     using Boardgame.BoardEntities;
+    using Boardgame.Data;
     using Boardgame.SerializableEvents;
     using DataKeys;
     using HarmonyLib;
@@ -19,7 +19,7 @@
         private static readonly Random Rnd = new Random();
         private static Dictionary<BoardPieceId, List<AbilityKey>> _globalHeroCards;
         private static bool _isActivated;
-        private static bool _isChest = true;
+        private static bool _isPotionStand;
 
         private readonly Dictionary<BoardPieceId, List<AbilityKey>> _heroCards;
 
@@ -67,10 +67,11 @@
                 return;
             }
 
+            _isPotionStand = false;
             Interactable whatIsit = gameContext.pieceAndTurnController.GetInteractableAtPosition(targetTile);
             if (whatIsit.type == Interactable.Type.PotionStand)
             {
-                _isChest = false;
+                _isPotionStand = true;
             }
         }
 
@@ -88,8 +89,9 @@
                 return;
             }
 
-            if (!_isChest)
+            if (_isPotionStand)
             {
+                // TODO: Add method to allow custom card loot for Potion Stands here
                 return;
             }
 
@@ -97,6 +99,13 @@
             var gameContext = Traverse.Create(__instance).Property<GameContext>("gameContext").Value;
 
             var pieceId = Traverse.Create(addCardToPieceEvent).Field<int>("pieceId").Value;
+            var cardSource = Traverse.Create(addCardToPieceEvent).Field<int>("cardSource").Value;
+
+            if (cardSource != (int)MotherTracker.Context.Energy && cardSource != (int)MotherTracker.Context.Chest)
+            {
+                return;
+            }
+
             if (!gameContext.pieceAndTurnController.TryGetPiece(pieceId, out var piece))
             {
                 return;

--- a/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
@@ -92,6 +92,7 @@
             if (_isPotionStand)
             {
                 // TODO: Add method to allow custom card loot for Potion Stands here
+                _isPotionStand = false;
                 return;
             }
 


### PR DESCRIPTION
Prevents CardAddition rule from affecting Jeweled Scarab turn-in to merchant
Might be a faster method than converting enum to int but I don't know it. Feel free to update!