### PR TITLE
Fix WaterBottleChest loot

### DIFF
--- a/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
@@ -20,6 +20,7 @@
         private static Dictionary<BoardPieceId, List<AbilityKey>> _globalHeroCards;
         private static bool _isActivated;
         private static bool _isPotionStand;
+        private static bool _isWaterBottleChest;
         private static int _numPlayers;
 
         private readonly Dictionary<BoardPieceId, List<AbilityKey>> _heroCards;
@@ -75,6 +76,11 @@
                 _numPlayers = gameContext.pieceAndTurnController.GetNumberOfPlayerPieces();
                 _isPotionStand = true;
             }
+            else if (whatIsit.type == Interactable.Type.WaterBottleChest)
+            {
+                _numPlayers = gameContext.pieceAndTurnController.GetNumberOfPlayerPieces();
+                _isWaterBottleChest = true;
+            }
         }
 
         private static void SerializableEventQueue_RespondToRequest_Prefix(
@@ -101,6 +107,20 @@
                 else
                 {
                     _isPotionStand = false;
+                }
+
+                return;
+            }
+            else if (_isWaterBottleChest)
+            {
+                // TODO: Add method to allow custom card loot for Water Bottle Chests here
+                if (_numPlayers > 1)
+                {
+                    _numPlayers--;
+                }
+                else
+                {
+                    _isWaterBottleChest = false;
                 }
 
                 return;


### PR DESCRIPTION
Allow original loot for WaterBottleChest object on Desert campaign.