### PR TITLE
Capitalisation was incorrect for CourageShantyAddsHp rule

### DIFF
--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -298,15 +298,15 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
     },
   ```
 
-#### __CourageShantyAddsHP__: In addition to normal effects, Courage Shanty also adds HP
+#### __CourageShantyAddsHp__: In addition to normal effects, Courage Shanty also adds HP
   - To configure:
     - Specify a decimal number for how many HP to add to the target each time CourageShanty is used.
 
-  ###### _Example JSON config for CourageShantyAddsHP_
+  ###### _Example JSON config for CourageShantyAddsHp_
 
   ```json
   {
-    "Rule": "CourageShantyAddsHP",
+    "Rule": "CourageShantyAddsHp",
     "Config": 2
   },
   ```


### PR DESCRIPTION
Single character typo fix as we changed the capitalisation in the CourageShantyAddsHp rule name, but forgot to update the docs accordingly.