### PR TITLE
Make Roomcode compatible with v1.20 of Demeo.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/ee723cfe2c3c9ee6004fbb0554fca4cc3557de0e/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/e64e10fad357fcb71f490802a2b4d5c83332968a/ws.zip
           7z x ws.zip 
 
       - name: Build HouseRules_Core
@@ -68,7 +68,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/ee723cfe2c3c9ee6004fbb0554fca4cc3557de0e/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/e64e10fad357fcb71f490802a2b4d5c83332968a/ws.zip
           7z x ws.zip
 
       - name: Build RoomFinder
@@ -95,7 +95,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/ee723cfe2c3c9ee6004fbb0554fca4cc3557de0e/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/e64e10fad357fcb71f490802a2b4d5c83332968a/ws.zip
           7z x ws.zip
 
       - name: Build SkipIntro
@@ -122,7 +122,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/ee723cfe2c3c9ee6004fbb0554fca4cc3557de0e/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/e64e10fad357fcb71f490802a2b4d5c83332968a/ws.zip
           7z x ws.zip
 
       - name: Build RoomCode

--- a/RoomCode/ModPatcher.cs
+++ b/RoomCode/ModPatcher.cs
@@ -15,9 +15,7 @@
                 prefix: new HarmonyMethod(typeof(ModPatcher), nameof(GameStateMachine_GetRandomRoomCode_Prefix)));
 
             harmony.Patch(
-                original: AccessTools
-                    .Inner(typeof(GameStateMachine), "CreatingGameState").GetTypeInfo()
-                    .GetDeclaredMethod("OnJoinedRoom"),
+                original: AccessTools.Method(typeof(CreatingGameState), "OnJoinedRoom"),
                 prefix: new HarmonyMethod(typeof(ModPatcher), nameof(CreatingGameState_OnJoinedRoom_Prefix)));
         }
 


### PR DESCRIPTION
CreatingGameState is no longer part of GameStateMachine, but has instead been moved into it's own class.

Updated patcher to reflect this change. Tested it on the PC version and it got my user-defined roomcode OK.