### PR TITLE
V1.20 & 1.21 houserules fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/ee723cfe2c3c9ee6004fbb0554fca4cc3557de0e/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/e64e10fad357fcb71f490802a2b4d5c83332968a/ws.zip
           7z x ws.zip 
 
       - name: Build HouseRules_Core
@@ -68,7 +68,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/ee723cfe2c3c9ee6004fbb0554fca4cc3557de0e/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/e64e10fad357fcb71f490802a2b4d5c83332968a/ws.zip
           7z x ws.zip
 
       - name: Build RoomFinder
@@ -95,7 +95,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/ee723cfe2c3c9ee6004fbb0554fca4cc3557de0e/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/e64e10fad357fcb71f490802a2b4d5c83332968a/ws.zip
           7z x ws.zip
 
       - name: Build SkipIntro
@@ -122,7 +122,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/ee723cfe2c3c9ee6004fbb0554fca4cc3557de0e/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/e64e10fad357fcb71f490802a2b4d5c83332968a/ws.zip
           7z x ws.zip
 
       - name: Build RoomCode

--- a/Common/UI/Environments.cs
+++ b/Common/UI/Environments.cs
@@ -32,7 +32,7 @@
 
         public static bool IsPcEdition()
         {
-            return MelonUtils.CurrentGameAttribute.Name == DemeoPCEditionString;
+            return MotherbrainGlobalVars.IsRunningOnDesktop;
         }
 
         public static bool IsInHangouts()

--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -64,6 +64,13 @@
                 postfix: new HarmonyMethod(
                     typeof(BoardSyncer),
                     nameof(EffectSink_AddStatusEffect_Postfix)));
+
+            // Workaround for a bug in Demeo v1.21 affecting board syncing. Can be removed after next Demeo patch is released as it includes fix from RG.
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Piece), "ForceSyncState"),
+                prefix: new HarmonyMethod(
+                typeof(BoardSyncer),
+                nameof(Piece_ForceSyncState_Prefix)));
         }
 
         private static void GameStartup_InitializeGame_Postfix(GameStartup __instance)
@@ -107,6 +114,12 @@
             {
                 _isSyncScheduled = true;
             }
+        }
+
+        private static bool Piece_ForceSyncState_Prefix(BoardModel boardModel, ref Piece __instance)
+        {
+            __instance.ReregisterPieceVisualStateHandlers();
+            return true;
         }
 
         private static bool CanRepresentNewSpawn(SerializableEvent serializableEvent)

--- a/HouseRules_Core/HangoutsGameRacer.cs
+++ b/HouseRules_Core/HangoutsGameRacer.cs
@@ -51,9 +51,7 @@
                 prefix: new HarmonyMethod(typeof(HangoutsGameRacer), nameof(SocialProviderParea_Constructor_Prefix)));
 
             harmony.Patch(
-                original: AccessTools
-                    .Inner(typeof(GameStateMachine), "CreatingGameState").GetTypeInfo()
-                    .GetDeclaredMethod("OnJoinedRoom"),
+                original: AccessTools.Method(typeof(CreatingGameState), "OnJoinedRoom"),
                 prefix: new HarmonyMethod(typeof(HangoutsGameRacer), nameof(CreatingGameState_OnJoinedRoom_Prefix)));
 
             harmony.Patch(

--- a/HouseRules_Core/LifecycleDirector.cs
+++ b/HouseRules_Core/LifecycleDirector.cs
@@ -28,15 +28,11 @@
                 postfix: new HarmonyMethod(typeof(LifecycleDirector), nameof(GameStartup_InitializeGame_Postfix)));
 
             harmony.Patch(
-                original: AccessTools
-                    .Inner(typeof(GameStateMachine), "CreatingGameState").GetTypeInfo()
-                    .GetDeclaredMethod("TryCreateRoom"),
+                original: AccessTools.Method(typeof(CreatingGameState), "TryCreateRoom"),
                 prefix: new HarmonyMethod(typeof(LifecycleDirector), nameof(CreatingGameState_TryCreateRoom_Prefix)));
 
             harmony.Patch(
-                original: AccessTools
-                    .Inner(typeof(GameStateMachine), "CreatingGameState").GetTypeInfo()
-                    .GetDeclaredMethod("OnJoinedRoom"),
+                original: AccessTools.Method(typeof(CreatingGameState), "OnJoinedRoom"),
                 prefix: new HarmonyMethod(typeof(LifecycleDirector), nameof(CreatingGameState_OnJoinedRoom_Prefix)));
 
             harmony.Patch(

--- a/HouseRules_Essentials/Rules/EnemyAttackScaledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyAttackScaledRule.cs
@@ -32,13 +32,13 @@
         private static void Patch(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.PropertyGetter(typeof(PieceConfig), "AttackDamage"),
+                original: AccessTools.PropertyGetter(typeof(PieceConfigData), "AttackDamage"),
                 postfix: new HarmonyMethod(
                     typeof(EnemyAttackScaledRule),
                     nameof(PieceConfig_AttackDamage_Postfix)));
         }
 
-        private static void PieceConfig_AttackDamage_Postfix(PieceConfig __instance, ref int __result)
+        private static void PieceConfig_AttackDamage_Postfix(PieceConfigData __instance, ref int __result)
         {
             if (!_isActivated)
             {

--- a/HouseRules_Essentials/Rules/EnemyDoorOpeningDisabledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyDoorOpeningDisabledRule.cs
@@ -23,7 +23,7 @@
         private static void Patch(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.PropertyGetter(typeof(PieceConfig), "CanOpenDoor"),
+                original: AccessTools.PropertyGetter(typeof(PieceConfigData), "CanOpenDoor"),
                 prefix: new HarmonyMethod(
                     typeof(EnemyDoorOpeningDisabledRule),
                     nameof(PieceConfig_CanOpenDoor_Prefix)));

--- a/HouseRules_Essentials/Rules/EnemyHealthScaledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyHealthScaledRule.cs
@@ -34,13 +34,13 @@
         private static void Patch(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.PropertyGetter(typeof(PieceConfig), "StartHealth"),
+                original: AccessTools.PropertyGetter(typeof(PieceConfigData), "StartHealth"),
                 postfix: new HarmonyMethod(
                     typeof(EnemyHealthScaledRule),
                     nameof(PieceConfig_StartHealth_Postfix)));
         }
 
-        private static void PieceConfig_StartHealth_Postfix(PieceConfig __instance, ref int __result)
+        private static void PieceConfig_StartHealth_Postfix(PieceConfigData __instance, ref int __result)
         {
             if (!_isActivated)
             {

--- a/HouseRules_Essentials/Rules/LevelPropertiesModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/LevelPropertiesModifiedRule.cs
@@ -49,12 +49,12 @@
             }
         }
 
-        private void ModifyDreadMode(ref DreadLevelsDTO dreadLevelDto)
+        private void ModifyDreadMode(ref DreadLevelsData dreadLevel)
         {
             foreach (var modification in _levelProperties)
             {
-                AccessTools.StructFieldRefAccess<DreadLevelsDTO, int>(ref dreadLevelDto, modification.Key) =
-                    modification.Value;
+                AccessTools.FieldRefAccess<DreadLevelsData, int>(dreadLevel, modification.Key) =
+                   modification.Value;
             }
         }
     }

--- a/HouseRules_Essentials/Rules/PieceAbilityListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceAbilityListOverriddenRule.cs
@@ -44,17 +44,15 @@
         private static Dictionary<BoardPieceId, List<AbilityKey>> ReplaceExistingProperties(
             Dictionary<BoardPieceId, List<AbilityKey>> pieceConfigChanges)
         {
-            var gameConfigPieceConfigs = Traverse.Create(typeof(GameDataAPI))
-                .Field<Dictionary<GameConfigType, Dictionary<BoardPieceId, PieceConfigDTO>>>("PieceConfigDTOdict")
-                .Value;
+            var gameContext = Traverse.Create(typeof(GameHub)).Field<GameContext>("gameContext").Value;
             var previousProperties = new Dictionary<BoardPieceId, List<AbilityKey>>();
 
             foreach (var item in pieceConfigChanges)
             {
-                var pieceConfigDto = gameConfigPieceConfigs[MotherbrainGlobalVars.CurrentConfig][item.Key];
+                var pieceConfigDto = gameContext.gameDataAPI.PieceConfig[MotherbrainGlobalVars.CurrentConfig][item.Key];
                 previousProperties[item.Key] = pieceConfigDto.Abilities.ToList();
                 pieceConfigDto.Abilities = item.Value.ToArray();
-                gameConfigPieceConfigs[MotherbrainGlobalVars.CurrentConfig][item.Key] = pieceConfigDto;
+                gameContext.gameDataAPI.PieceConfig[MotherbrainGlobalVars.CurrentConfig][item.Key] = pieceConfigDto;
             }
 
             return previousProperties;

--- a/HouseRules_Essentials/Rules/PieceBehavioursListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceBehavioursListOverriddenRule.cs
@@ -45,17 +45,15 @@
         private static Dictionary<BoardPieceId, List<Behaviour>> ReplaceExistingProperties(
             Dictionary<BoardPieceId, List<Behaviour>> pieceConfigChanges)
         {
-            var gameConfigPieceConfigs = Traverse.Create(typeof(GameDataAPI))
-                .Field<Dictionary<GameConfigType, Dictionary<BoardPieceId, PieceConfigDTO>>>("PieceConfigDTOdict")
-                .Value;
+            var gameContext = Traverse.Create(typeof(GameHub)).Field<GameContext>("gameContext").Value;
             var previousProperties = new Dictionary<BoardPieceId, List<Behaviour>>();
 
             foreach (var item in pieceConfigChanges)
             {
-                var pieceConfigDto = gameConfigPieceConfigs[MotherbrainGlobalVars.CurrentConfig][item.Key];
+                var pieceConfigDto = gameContext.gameDataAPI.PieceConfig[MotherbrainGlobalVars.CurrentConfig][item.Key];
                 previousProperties[item.Key] = pieceConfigDto.Behaviours.ToList();
                 pieceConfigDto.Behaviours = item.Value.ToArray();
-                gameConfigPieceConfigs[MotherbrainGlobalVars.CurrentConfig][item.Key] = pieceConfigDto;
+                gameContext.gameDataAPI.PieceConfig[MotherbrainGlobalVars.CurrentConfig][item.Key] = pieceConfigDto;
             }
 
             return previousProperties;

--- a/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceImmunityListAdjustedRule.cs
@@ -44,17 +44,15 @@
         private static Dictionary<BoardPieceId, List<EffectStateType>> ReplaceExistingProperties(
             Dictionary<BoardPieceId, List<EffectStateType>> pieceConfigChanges)
         {
-            var gameConfigPieceConfigs = Traverse.Create(typeof(GameDataAPI))
-                .Field<Dictionary<GameConfigType, Dictionary<BoardPieceId, PieceConfigDTO>>>("PieceConfigDTOdict")
-                .Value;
+            var gameContext = Traverse.Create(typeof(GameHub)).Field<GameContext>("gameContext").Value;
             var previousProperties = new Dictionary<BoardPieceId, List<EffectStateType>>();
 
             foreach (var item in pieceConfigChanges)
             {
-                var pieceConfigDto = gameConfigPieceConfigs[MotherbrainGlobalVars.CurrentConfig][item.Key];
+                var pieceConfigDto = gameContext.gameDataAPI.PieceConfig[MotherbrainGlobalVars.CurrentConfig][item.Key];
                 previousProperties[item.Key] = pieceConfigDto.ImmuneToStatusEffects.ToList();
                 pieceConfigDto.ImmuneToStatusEffects = item.Value.ToArray();
-                gameConfigPieceConfigs[MotherbrainGlobalVars.CurrentConfig][item.Key] = pieceConfigDto;
+                gameContext.gameDataAPI.PieceConfig[MotherbrainGlobalVars.CurrentConfig][item.Key] = pieceConfigDto;
             }
 
             return previousProperties;

--- a/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
@@ -44,17 +44,15 @@
         private static Dictionary<BoardPieceId, List<PieceType>> ReplaceExistingProperties(
             Dictionary<BoardPieceId, List<PieceType>> pieceConfigChanges)
         {
-            var gameConfigPieceConfigs = Traverse.Create(typeof(GameDataAPI))
-                .Field<Dictionary<GameConfigType, Dictionary<BoardPieceId, PieceConfigDTO>>>("PieceConfigDTOdict")
-                .Value;
+            var gameContext = Traverse.Create(typeof(GameHub)).Field<GameContext>("gameContext").Value; 
             var previousProperties = new Dictionary<BoardPieceId, List<PieceType>>();
 
             foreach (var item in pieceConfigChanges)
             {
-                var pieceConfigDto = gameConfigPieceConfigs[MotherbrainGlobalVars.CurrentConfig][item.Key];
+                var pieceConfigDto = gameContext.gameDataAPI.PieceConfig[MotherbrainGlobalVars.CurrentConfig][item.Key];
                 previousProperties[item.Key] = pieceConfigDto.PieceType.ToList();
                 pieceConfigDto.PieceType = item.Value.ToArray();
-                gameConfigPieceConfigs[MotherbrainGlobalVars.CurrentConfig][item.Key] = pieceConfigDto;
+                gameContext.gameDataAPI.PieceConfig[MotherbrainGlobalVars.CurrentConfig][item.Key] = pieceConfigDto;
             }
 
             return previousProperties;

--- a/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
@@ -49,17 +49,15 @@
         private static Dictionary<BoardPieceId, List<AbilityKey>> ReplaceExistingProperties(
             Dictionary<BoardPieceId, List<AbilityKey>> pieceConfigChanges)
         {
-            var gameConfigPieceConfigs = Traverse.Create(typeof(GameDataAPI))
-                .Field<Dictionary<GameConfigType, Dictionary<BoardPieceId, PieceConfigDTO>>>("PieceConfigDTOdict")
-                .Value;
+            var gameContext = Traverse.Create(typeof(GameHub)).Field<GameContext>("gameContext").Value;
             var previousProperties = new Dictionary<BoardPieceId, List<AbilityKey>>();
 
             foreach (var item in pieceConfigChanges)
             {
-                var pieceConfigDto = gameConfigPieceConfigs[MotherbrainGlobalVars.CurrentConfig][item.Key];
+                var pieceConfigDto = gameContext.gameDataAPI.PieceConfig[MotherbrainGlobalVars.CurrentConfig][item.Key];
                 previousProperties[item.Key] = pieceConfigDto.UseWhenKilled.ToList();
                 pieceConfigDto.UseWhenKilled = item.Value.ToArray();
-                gameConfigPieceConfigs[MotherbrainGlobalVars.CurrentConfig][item.Key] = pieceConfigDto;
+                gameContext.gameDataAPI.PieceConfig[MotherbrainGlobalVars.CurrentConfig][item.Key] = pieceConfigDto;
             }
 
             return previousProperties;

--- a/HouseRules_Essentials/Rules/SpawnCategoryOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/SpawnCategoryOverriddenRule.cs
@@ -39,8 +39,8 @@
 
         private static Dictionary<BoardPieceId, List<int>> UpdateSpawnCategories(Dictionary<BoardPieceId, List<int>> spawnModifications)
         {
-            var gameConfigSpawnCategories = Traverse.Create(typeof(GameDataAPI)).Field<Dictionary<GameConfigType, List<SpawnCategoryDTO>>>("SpawnCategoryDTOlist").Value;
-            var spawnCategories = gameConfigSpawnCategories[MotherbrainGlobalVars.CurrentConfig];
+            var gameContext = Traverse.Create(typeof(GameHub)).Field<GameContext>("gameContext").Value;
+            var spawnCategories = gameContext.gameDataAPI.SpawnCategory[MotherbrainGlobalVars.CurrentConfig];
             var previousConfigs = new Dictionary<BoardPieceId, List<int>>();
             var bpis = new List<BoardPieceId>();
             foreach (var nap in spawnModifications)
@@ -59,7 +59,7 @@
                         spawnCategories[i].FirstAllowedLevelIndex,
                     };
 
-                    spawnCategories[i] = new SpawnCategoryDTO
+                    spawnCategories[i] = new SpawnCategoryData
                     {
                         BoardPieceId = spawnCategories[i].BoardPieceId,
                         EnemyWeight = spawnCategories[i].EnemyWeight,
@@ -76,7 +76,7 @@
                 }
                 else
                 {
-                    spawnCategories[i] = new SpawnCategoryDTO
+                    spawnCategories[i] = new SpawnCategoryData
                     {
                         BoardPieceId = spawnCategories[i].BoardPieceId,
                         EnemyWeight = spawnCategories[i].EnemyWeight,

--- a/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
@@ -46,91 +46,8 @@
                 prefix: new HarmonyMethod(
                     typeof(StartCardsModifiedRule),
                     nameof(Piece_CreatePieceInternal_Prefix)));
-            harmony.Patch(
-                original: AccessTools.Method(typeof(Inventory), "RestoreReplenishables"),
-                prefix: new HarmonyMethod(
-                    typeof(StartCardsModifiedRule),
-                    nameof(Inventory_RestoreReplenishables_Prefix)));
         }
 
-        private static bool Inventory_RestoreReplenishables_Prefix(ref bool __result, Piece piece, EffectStateType[] previousEffects)
-        {
-            if (!_isActivated)
-            {
-                return true;
-            }
-
-            __result = false;
-            for (int i = 0; i < piece.inventory.Items.Count; i++)
-            {
-                Inventory.Item value = piece.inventory.Items[i];
-                var targetRefresh = (value.flags >> 7) & 7;
-                var countdown = (value.flags >> 4) & 7;
-
-                if (piece.inventory.Items[i].IsReplenishing)
-                {
-                    bool skipReplenishing = false;
-                    if (!AbilityFactory.TryGetAbility(value.abilityKey, out Ability ability))
-                    {
-                        throw new Exception("Failed to get ability prefab from ability key while attempting to replenish hand!");
-                    }
-
-                    if (piece.inventory.Items[i].abilityKey == AbilityKey.Sneak)
-                    {
-                        bool foundPreviousEffect = false;
-                        foreach (EffectStateType effect in previousEffects)
-                        {
-                            if (ability.effectsPreventingReplenished.Contains(effect))
-                            {
-                                foundPreviousEffect = true;
-                                break;
-                            }
-                        }
-
-                        if (foundPreviousEffect)
-                        {
-                            continue;
-                        }
-                    }
-
-                    int j = 0;
-                    int count = ability.effectsPreventingReplenished.Count;
-                    while (j < count)
-                    {
-                        if (piece.HasEffectState(ability.effectsPreventingReplenished[j]))
-                        {
-                            skipReplenishing = true;
-                        }
-
-                        j++;
-                    }
-
-                    if (!skipReplenishing)
-                    {
-                        // If countdown was zero when we got called, then we need to set it.
-                        if (countdown == 0)
-                        {
-                            countdown = targetRefresh;
-                        }
-
-                        // If we reached our desired turn count we can unset isReplenishing and return true
-                        if (countdown == 1)
-                        {
-                            value.flags &= -3; // unsets isReplenishing (bit1 ) allowing card to be used again.
-                            __result = true;
-                        }
-
-                        countdown -= 1;
-                        value.flags &= 911; // Zero only the countdown bits using a bitmask
-                        value.flags |= countdown << 4; // OR with countdown to set them again.
-                        piece.inventory.Items[i] = value;
-                        Traverse.Create(piece.inventory).Property<bool>("needSync").Value = true;
-                    }
-                }
-            }
-
-            return false;
-        }
 
         private static void Piece_CreatePieceInternal_Prefix(PieceSpawnSettings spawnSettings)
         {
@@ -160,15 +77,11 @@
                 // 1 : isReplenishing
                 // 2 : abilityDisabledOnStatusEffect
                 // 3 : disableCooldown
-                // 4-6 : ReplenishCounter - 3-bit range used by RestoreReplenishables for counting rounds.
-                // 7-9 : ReplenishFrequency - 3-bit number, user-configured target.
                 int flags = 0;
                 if (card.ReplenishFrequency > 0)
                 {
                     Traverse.Create(inventory).Field<int>("numberOfReplenishableCards").Value += 1;
                     flags = 1;
-                    int refreshFrequency = (card.ReplenishFrequency > 7) ? 7 : card.ReplenishFrequency; // Limit to max of 7 turns.
-                    flags |= refreshFrequency << 7; // logical or with refreshFrequency shifted 7 bits to the left to become ReplenishFrequency bits 7-9
                 }
 
                 inventory.Items.Add(new Inventory.Item
@@ -176,6 +89,7 @@
                     abilityKey = card.Card,
                     flags = flags,
                     originalOwner = -1,
+                    replenishCooldown = card.ReplenishFrequency,
                 });
             }
 

--- a/RoomFinder/Patcher.cs
+++ b/RoomFinder/Patcher.cs
@@ -3,6 +3,7 @@
     using System.Reflection;
     using Boardgame;
     using HarmonyLib;
+    using static UnityEngine.UI.Image;
 
     internal static class Patcher
     {
@@ -11,17 +12,12 @@
             harmony.Patch(
                 original: AccessTools.Method(typeof(GameStartup), "InitializeGame"),
                 postfix: new HarmonyMethod(typeof(Patcher), nameof(GameStartup_InitializeGame_Postfix)));
-
             harmony.Patch(
-                original: AccessTools
-                    .Inner(typeof(GameStateMachine), "MatchMakingState").GetTypeInfo()
-                    .GetDeclaredMethod("OnRoomListUpdated"),
+                original: AccessTools.Method(typeof(MatchMakingState), "OnRoomListUpdated"),
                 postfix: new HarmonyMethod(typeof(Patcher), nameof(MatchMakingState_OnRoomListUpdated_Postfix)));
 
             harmony.Patch(
-                original: AccessTools
-                    .Inner(typeof(GameStateMachine), "MatchMakingState").GetTypeInfo()
-                    .GetDeclaredMethod("FindGame"),
+                original: AccessTools.Method(typeof(MatchMakingState), "FindGame"),
                 prefix: new HarmonyMethod(typeof(Patcher), nameof(MatchMakingState_FindGame_Prefix)));
         }
 

--- a/RoomFinder/RoomFinderMod.cs
+++ b/RoomFinder/RoomFinderMod.cs
@@ -23,9 +23,9 @@
 
         public override void OnSceneWasInitialized(int buildIndex, string sceneName)
         {
-            if (MelonUtils.CurrentGameAttribute.Name == DemeoPCEditionString)
-            {
-                if (buildIndex != LobbySceneIndex)
+            if (MotherbrainGlobalVars.IsRunningOnDesktop)
+                {
+                    if (buildIndex != LobbySceneIndex)
                 {
                     return;
                 }


### PR DESCRIPTION
The v1.20 patch for Demeo replaced the old PieceConfigDTOdict, CardConfigDTOdict and other DTO structs with SmartObjects instead. Additionally a new Item.ReplenishCooldown has been added to allow for configurable cooldown periods (which we'd previously implemented for ourselves using the unused bits of the `flag` variable).

This PR updates all of the affected bits within HouseRules. Everything compiles cleanly. I haven't done very much testing, but I gave the Arachnophobia ruleset a brief test and things appear to be working pretty much as expected (can't really remember the details on that ruleset anymore).

