### PR TITLE
Allow people to mod again!

### DIFF
--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -201,7 +201,7 @@
         private static void SyncBoard()
         {
             _isSyncScheduled = false;
-            _gameContext.serializableEventQueue.SendResponseEvent(SerializableEvent.CreateRecovery());
+            // _gameContext.serializableEventQueue.SendResponseEvent(SerializableEvent.CreateRecovery());
         }
     }
 }


### PR DESCRIPTION
Currently, calling CreateRecovery causes sync errors and makes mods unplayable.