### PR TITLE
Fix Ability Cooldowns

### DIFF
--- a/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
@@ -46,8 +46,81 @@
                 prefix: new HarmonyMethod(
                     typeof(StartCardsModifiedRule),
                     nameof(Piece_CreatePieceInternal_Prefix)));
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Inventory), "RestoreReplenishables"),
+                prefix: new HarmonyMethod(
+                    typeof(StartCardsModifiedRule),
+                    nameof(Inventory_RestoreReplenishables_Prefix)));
         }
 
+        private static bool Inventory_RestoreReplenishables_Prefix(ref bool __result, Piece piece)
+        {
+            if (!_isActivated)
+            {
+                return true;
+            }
+
+            __result = false;
+            for (int i = 0; i < piece.inventory.Items.Count; i++)
+            {
+                Inventory.Item value = piece.inventory.Items[i];
+
+                if (value.IsReplenishing)
+                {
+                    // Bypass problem with replenishCooldown somehow being set to -1 by Demeo
+                    foreach (var card in _globalHeroStartCards[piece.boardPieceId])
+                    {
+                        if (value.abilityKey == card.Card && card.ReplenishFrequency > 1 && value.replenishCooldown < 0)
+                        {
+                            value.replenishCooldown = card.ReplenishFrequency - 1;
+                            piece.inventory.Items[i] = value;
+                        }
+                    }
+
+                    bool skipReplenishing = false;
+                    if (!AbilityFactory.TryGetAbility(value.abilityKey, out Ability ability))
+                    {
+                        throw new Exception("Failed to get ability prefab from ability key while attempting to replenish hand!");
+                    }
+
+                    int j = 0;
+                    int count = ability.effectsPreventingReplenished.Count;
+                    while (j < count)
+                    {
+                        if (piece.HasEffectState(ability.effectsPreventingReplenished[j]))
+                        {
+                            skipReplenishing = true;
+                            break;
+                        }
+
+                        j++;
+                    }
+
+                    if (!skipReplenishing)
+                    {
+                        if (value.replenishCooldown > 0)
+                        {
+                            value.replenishCooldown -= 1;
+                            piece.inventory.Items[i] = value;
+                            // Force inventory sync to clients
+                            piece.AddGold(0);
+                        }
+                        else
+                        {
+                            // If we reached our desired turn count we can unset isReplenishing and return true
+                            value.flags &= -3; // unsets isReplenishing (bit1 ) allowing card to be used again.
+                            piece.inventory.Items[i] = value;
+                            __result = true;
+                            // Force inventory sync to clients
+                            piece.AddGold(0);
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
 
         private static void Piece_CreatePieceInternal_Prefix(PieceSpawnSettings spawnSettings)
         {


### PR DESCRIPTION
Fix abilities with cooldowns set greater than 1 turn
(Note: this works to fix the problem but the underlying cause of why cooldowns are being set to -1 should be looked into)