### PR TITLE
Fix wrong download link for current RoomFinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ mods, or are interested in learning to build your own.
 |------------|--------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
 | HouseRules | [v1.5.0](https://github.com/orendain/DemeoMods/releases/tag/v1.5.0-houserules) | [HouseRules_1.5.0.zip](https://github.com/orendain/DemeoMods/releases/download/v1.5.0-houserules/HouseRules_1.5.0.zip) |
 | SkipInto   | [v1.4.0](https://github.com/orendain/DemeoMods/releases/tag/v1.4.0-skipintro)  | [SkipIntro_1.4.0.zip](https://github.com/orendain/DemeoMods/releases/download/v1.4.0-skipintro/SkipIntro_1.4.0.zip)    |
-| RoomFinder | [v1.6.0](https://github.com/orendain/DemeoMods/releases/tag/v1.6.0-roomfinder) | [RoomFinder_1.6.0.zip](https://github.com/orendain/DemeoMods/releases/download/v1.5.0-roomfinder/RoomFinder_1.5.0.zip) |
+| RoomFinder | [v1.6.0](https://github.com/orendain/DemeoMods/releases/tag/v1.6.0-roomfinder) | [RoomFinder_1.6.0.zip](https://github.com/orendain/DemeoMods/releases/download/v1.6.0-roomfinder/RoomFinder_1.6.0.zip) |
 | RoomCode   | [v1.2.0](https://github.com/orendain/DemeoMods/releases/tag/v1.2.0-roomcode)   | [RoomCode_1.2.0.zip](https://github.com/orendain/DemeoMods/releases/download/v1.2.0-roomcode/RoomCode_1.2.0.zip)       |
 
 ## Mods


### PR DESCRIPTION
Was listed as 1.6.0 but linked to 1.5.0 download.