### PR TITLE
Fix Random Cards / Lockup / Update README

### DIFF
--- a/HouseRules_Core/BoardSyncer.cs
+++ b/HouseRules_Core/BoardSyncer.cs
@@ -30,7 +30,6 @@
         private static bool _updateNewPlayer;
         private static bool _isMove;
         private static bool _isGrab;
-        private static bool _skipOnMoved;
 
         /// <summary>
         /// Schedules a sync to be triggered at the next available opportunity.
@@ -129,18 +128,7 @@
 
                     return false;
                 case SerializableEvent.Type.OnMoved:
-                    if (_skipOnMoved)
-                    {
-                        return false;
-                    }
-
-                    var pieceId = Traverse.Create(serializableEvent).Field<int>("pieceId").Value;
-                    if (pieceId > 0 && _gameContext.pieceAndTurnController.IsPlayerControlled(pieceId))
-                    {
-                        _isGrab = true;
-                        return true;
-                    }
-
+                    _gameContext.serializableEventQueue.SendResponseEvent(new SerializableEventUpdateFog());
                     return false;
                 case SerializableEvent.Type.Move:
                 case SerializableEvent.Type.Interact:
@@ -151,7 +139,6 @@
                     }
 
                     return false;
-                case SerializableEvent.Type.Emerge:
                 case SerializableEvent.Type.SpawnPiece:
                 case SerializableEvent.Type.SetBoardPieceID:
                 case SerializableEvent.Type.SlimeFusion:
@@ -159,7 +146,6 @@
                     return true;
                 case SerializableEvent.Type.EndAction:
                 case SerializableEvent.Type.EndTurn:
-                    _skipOnMoved = false;
                     if (_isGrab)
                     {
                         _isGrab = false;
@@ -192,20 +178,6 @@
             var abilityKey = Traverse.Create(onAbilityUsedEvent).Field<AbilityKey>("abilityKey").Value;
             switch (abilityKey)
             {
-                case AbilityKey.TeleportLamp:
-                    _skipOnMoved = true;
-                    return false;
-                case AbilityKey.Vortex:
-                case AbilityKey.VortexLamp:
-                case AbilityKey.LeapHeavy:
-                case AbilityKey.WhirlwindAttack:
-                    if (_gameContext.pieceAndTurnController.IsPlayersTurn())
-                    {
-                        _skipOnMoved = true;
-                        return false;
-                    }
-
-                    return false;
                 case AbilityKey.Grab:
                     if (!_gameContext.pieceAndTurnController.IsPlayersTurn())
                     {

--- a/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
@@ -16,7 +16,6 @@
     {
         public override string Description => "Card additions are overridden";
 
-        private static readonly Random Rnd = new Random();
         private static Dictionary<BoardPieceId, List<AbilityKey>> _globalHeroCards;
         private static bool _isActivated;
         private static bool _isPotionStand;
@@ -151,7 +150,8 @@
                 return;
             }
 
-            var replacementAbilityKey = replacementAbilityKeys.ElementAt(Rnd.Next(replacementAbilityKeys.Count));
+            Random rand = new Random();
+            var replacementAbilityKey = replacementAbilityKeys.ElementAt(rand.Next(replacementAbilityKeys.Count));
             Traverse.Create(addCardToPieceEvent).Field<AbilityKey>("card").Value = replacementAbilityKey;
         }
     }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ mods, or are interested in learning to build your own.
 |------------|--------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
 | HouseRules | [v1.5.0](https://github.com/orendain/DemeoMods/releases/tag/v1.5.0-houserules) | [HouseRules_1.5.0.zip](https://github.com/orendain/DemeoMods/releases/download/v1.5.0-houserules/HouseRules_1.5.0.zip) |
 | SkipInto   | [v1.4.0](https://github.com/orendain/DemeoMods/releases/tag/v1.4.0-skipintro)  | [SkipIntro_1.4.0.zip](https://github.com/orendain/DemeoMods/releases/download/v1.4.0-skipintro/SkipIntro_1.4.0.zip)    |
-| RoomFinder | [v1.6.0](https://github.com/orendain/DemeoMods/releases/tag/v1.6.0-roomfinder) | [RoomFinder_1.6.0.zip](https://github.com/orendain/DemeoMods/releases/download/v1.5.0-roomfinder/RoomFinder_1.5.0.zip) |
+| RoomFinder | [v1.6.0](https://github.com/orendain/DemeoMods/releases/tag/v1.7.0-roomfinder) | [RoomFinder_1.7.0.zip](https://github.com/orendain/DemeoMods/releases/download/v1.7.0-roomfinder/RoomFinder_1.7.zip) |
 | RoomCode   | [v1.2.0](https://github.com/orendain/DemeoMods/releases/tag/v1.2.0-roomcode)   | [RoomCode_1.2.0.zip](https://github.com/orendain/DemeoMods/releases/download/v1.2.0-roomcode/RoomCode_1.2.0.zip)       |
 
 ## Mods


### PR DESCRIPTION
Fix a problem with lack of randomness of cards from chests/mana in CardAddition Rule.
Fix a lockup caused by a looping OnMoved event when board syncing.
Update README.md to show correct link to the latest RoomFinder