### PR TITLE
V1.25 fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/a18488125ab3d34aaca7b39350d4e6119b6371fc/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/69d8617a0eeb247eb43f802f20d00fac0fb94de2/ws.zip
           7z x ws.zip 
 
       - name: Build HouseRules_Core
@@ -68,7 +68,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/a18488125ab3d34aaca7b39350d4e6119b6371fc/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/69d8617a0eeb247eb43f802f20d00fac0fb94de2/ws.zip
           7z x ws.zip
 
       - name: Build RoomFinder
@@ -95,7 +95,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/a18488125ab3d34aaca7b39350d4e6119b6371fc/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/69d8617a0eeb247eb43f802f20d00fac0fb94de2/ws.zip
           7z x ws.zip
 
       - name: Build SkipIntro
@@ -122,7 +122,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/a18488125ab3d34aaca7b39350d4e6119b6371fc/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/69d8617a0eeb247eb43f802f20d00fac0fb94de2/ws.zip
           7z x ws.zip
 
       - name: Build RoomCode

--- a/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
@@ -5,11 +5,13 @@
     using System.Linq;
     using Boardgame;
     using Boardgame.BoardEntities;
+    using Boardgame.BoardEntities.AI;
     using Boardgame.Data;
     using Boardgame.SerializableEvents;
     using DataKeys;
     using HarmonyLib;
     using HouseRules.Types;
+
 
     public sealed class CardAdditionOverriddenRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<AbilityKey>>>,
         IPatchable, IMultiplayerSafe
@@ -42,7 +44,7 @@
         private static void Patch(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(Interactable), "OnInteraction"),
+                original: AccessTools.Method(typeof(Interactable), "OnInteraction", new Type[] { typeof(int), typeof(IntPoint2D), typeof(GameContext), typeof(int) }),
                 prefix: new HarmonyMethod(
                     typeof(CardAdditionOverriddenRule),
                     nameof(Interactable_OnInteraction_Prefix)));

--- a/HouseRules_Essentials/Rules/EnemyAttackScaledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyAttackScaledRule.cs
@@ -46,17 +46,17 @@
                 return;
             }
 
-            if (config.PieceName.Contains("HRA_"))
+            if (config.PieceNameLocalizationKey.Contains("HRA_"))
             {
                 return;
             }
 
-            if (config.HasPieceType(PieceType.Player) || config.HasPieceType(PieceType.Bot) || config.HasPieceType(PieceType.Interactable) || config.PieceName.Contains("Lamp"))
+            if (config.HasPieceType(PieceType.Player) || config.HasPieceType(PieceType.Bot) || config.HasPieceType(PieceType.Interactable) || config.PieceNameLocalizationKey.Contains("Lamp"))
             {
                 return;
             }
 
-            config.PieceName = "HRA_" + config.PieceName;
+            config.PieceNameLocalizationKey = "HRA_" + config.PieceNameLocalizationKey;
             config.AttackDamage = (int)(config.AttackDamage * _globalMultiplier);
         }
     }

--- a/HouseRules_Essentials/Rules/EnemyHealthScaledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyHealthScaledRule.cs
@@ -48,17 +48,17 @@
                 return;
             }
 
-            if (config.PieceName.Contains("HRH_"))
+            if (config.PieceNameLocalizationKey.Contains("HRH_"))
             {
                 return;
             }
 
-            if (config.HasPieceType(PieceType.Player) || config.HasPieceType(PieceType.Bot) || config.HasPieceType(PieceType.Interactable) || config.PieceName.Contains("Lamp"))
+            if (config.HasPieceType(PieceType.Player) || config.HasPieceType(PieceType.Bot) || config.HasPieceType(PieceType.Interactable) || config.PieceNameLocalizationKey.Contains("Lamp"))
             {
                 return;
             }
 
-            config.PieceName = "HRH_" + config.PieceName;
+            config.PieceNameLocalizationKey = "HRH_" + config.PieceNameLocalizationKey;
             config.StartHealth = (int)(config.StartHealth * _globalMultiplier);
         }
     }

--- a/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
@@ -109,7 +109,7 @@
                         else
                         {
                             // If we reached our desired turn count we can unset isReplenishing and return true
-                            value.flags &= -3; // unsets isReplenishing (bit1 ) allowing card to be used again.
+                            value.flags &= (Inventory.ItemFlag)(-3); // unsets isReplenishing (bit1 ) allowing card to be used again.
                             piece.inventory.Items[i] = value;
                             __result = true;
                             // Force inventory sync to clients
@@ -150,17 +150,17 @@
                 // 1 : isReplenishing
                 // 2 : abilityDisabledOnStatusEffect
                 // 3 : disableCooldown
-                int flags = 0;
+                Inventory.ItemFlag flags = 0;
                 if (card.ReplenishFrequency > 0)
                 {
                     Traverse.Create(inventory).Field<int>("numberOfReplenishableCards").Value += 1;
-                    flags = 1;
+                    flags = (Inventory.ItemFlag)1;
                 }
 
                 inventory.Items.Add(new Inventory.Item
                 {
                     abilityKey = card.Card,
-                    flags = flags,
+                    flags = (Inventory.ItemFlag)flags,
                     originalOwner = -1,
                     replenishCooldown = card.ReplenishFrequency,
                 });

--- a/HouseRules_Essentials/Rulesets/DemeoReloaded.cs
+++ b/HouseRules_Essentials/Rulesets/DemeoReloaded.cs
@@ -538,7 +538,7 @@ namespace HouseRules.Essentials.Rulesets
             {
                 { BoardPieceId.HeroSorcerer, new List<EffectStateType> { EffectStateType.Frozen } },
                 { BoardPieceId.HeroHunter, new List<EffectStateType> { EffectStateType.Petrified } },
-                { BoardPieceId.HeroGuardian, new List<EffectStateType> { EffectStateType.Weaken } },
+                { BoardPieceId.HeroGuardian, new List<EffectStateType> { EffectStateType.Weaken1Turn, EffectStateType.Weaken2Turns } },
                 { BoardPieceId.HeroBard, new List<EffectStateType> { EffectStateType.Diseased } },
                 { BoardPieceId.HeroRogue, new List<EffectStateType> { EffectStateType.Tangled } },
                 { BoardPieceId.HeroWarlock, new List<EffectStateType> { EffectStateType.CorruptedRage } },

--- a/HouseRules_Essentials/Rulesets/LuckyDip.cs
+++ b/HouseRules_Essentials/Rulesets/LuckyDip.cs
@@ -148,7 +148,7 @@
                 { BoardPieceId.HeroSorcerer, allowedSorcererCards },
             });
 
-            var bardImmunities = new List<EffectStateType> { EffectStateType.Weaken, EffectStateType.MarkOfAvalon };
+            var bardImmunities = new List<EffectStateType> { EffectStateType.Weaken1Turn, EffectStateType.Weaken2Turns, EffectStateType.MarkOfAvalon };
             var guardianImmunities = new List<EffectStateType> { EffectStateType.Diseased, EffectStateType.Stunned, EffectStateType.Frozen, EffectStateType.Tangled, EffectStateType.Petrified };
             var hunterImmunities = new List<EffectStateType> { EffectStateType.Diseased, EffectStateType.Frozen, EffectStateType.Petrified };
             var rogueImmunities = new List<EffectStateType> { EffectStateType.Frozen, EffectStateType.Petrified };


### PR DESCRIPTION
# Demeo v1.25 fixes
Here are some fixes for making HouseRules compile against v1.25. They're largely untested aside from making sure that they compile and that I can launch a game with a few different rulesets. Actually playing a game has not been attempted with these 'fixes'

## Changes:
* `Interactable` now has an added override method for OnInteractable which was causing `Harmony.patch` to complain about an Ambiguous method being used in EnemyHealthScaledRule - The fix for this was to specify an array of the type parameters which are being accepted by the method we want to patch.
* `Inventory.flags` has been changed from an `int` to an `enum` meaning that CardAdditionOverriddenRule was complaing about being unable to use boolean operations on an enum. I attmpetd to change the code to maniuplate the enum directly, but the numeric values that I'm using are still from the old boolean code - I think this is OK, but we really need to check that card replenishes are working correctly.
* The game has change from only having a single `weakened` state to having two different ones for 1 & 2 turn duration respectively. I updated the rulesets where we were giving immunity to weakened to apply both immunities.
* `PieceConfigData` no longer has a `PieceName` field. It does however have a `PieceNameLocalizationKey` which is hopefully the same thing - I updated the code accordingly and nothing crashed when I tested launching a few different rulesets.


