### PR TITLE
New script for generatging SettingsRefernce.md

### DIFF
--- a/docs/SettingsReference.md
+++ b/docs/SettingsReference.md
@@ -14,8 +14,8 @@ A full list of all of the different parameter names used by HouseRules rules
 - ArbalestierBarrage
 - ArbalestierPoisonTip
 - Arrow
-- Banish
 - Bandage
+- Banish
 - Barrage
 - Barricade
 - BeastWhisperer
@@ -33,9 +33,9 @@ A full list of all of the different parameter names used by HouseRules rules
 - ChargeMove
 - CoinFlip
 - Corrupt
+- CorruptOneTurn
 - CorruptedDeathExplode
 - CorruptionBomb
-- CorruptOneTurn
 - CourageShanty
 - CursedDagger
 - DamageResistPotion
@@ -54,8 +54,8 @@ A full list of all of the different parameter names used by HouseRules rules
 - DiseasedBite
 - DiseasedBiteKnockback
 - DivineLight
-- DrainingKiss
 - DrainLife
+- DrainingKiss
 - DropChest
 - EarthShatter
 - Electricity
@@ -68,14 +68,14 @@ A full list of all of the different parameter names used by HouseRules rules
 - EnemyArrowSnipe
 - EnemyBossHandCharge
 - EnemyBossHandGoToHealingState
-- EnemyBossHandCharge
 - EnemyBossHandHeal
 - EnemyBossHandHealSelf
-- EnemyBossHandIntro
 - EnemyBossHandSmash
 - EnemyBossHandSpawnPiece
+- EnemyBossHandsIntro
 - EnemyDropStolenGoods
 - EnemyFireball
+- EnemyFlashbang
 - EnemyFrostball
 - EnemyHeal
 - EnemyHealOne
@@ -87,6 +87,7 @@ A full list of all of the different parameter names used by HouseRules rules
 - EnemyMelee
 - EnemyMeleeBleed
 - EnemyPikeMeleeAttack
+- EnemyRaiseBossHands
 - EnemySpawnLeftBossHand
 - EnemySpawnRightBossHand
 - EnemySplashWater
@@ -103,15 +104,17 @@ A full list of all of the different parameter names used by HouseRules rules
 - ExplodingGasLamp
 - ExplodingIceLamp
 - ExplodingLampPlaceholder
+- ExplodingOilLamp
 - ExplodingVortexLamp
 - ExplodingWaterLamp
 - Explosion
 - ExplosiveOrb
 - ExtraActionPotion
-- Fireball
 - FireImmunePotion
+- Fireball
 - FlashBomb
 - Freeze
+- FretsOfFire
 - GasLamp
 - GoblinBruteCharge
 - God
@@ -165,6 +168,19 @@ A full list of all of the different parameter names used by HouseRules rules
 - OneMoreThing
 - Overcharge
 - Overload
+- PVPAdamantPotion
+- PVPBarricade
+- PVPBeastWhisperer
+- PVPBlink
+- PVPCursedDagger
+- PVPGasLamp
+- PVPHuntersMark
+- PVPIceLamp
+- PVPOilLamp
+- PVPScrollOfCharm
+- PVPStealth
+- PVPSummonElemental
+- PVPVortexLamp
 - PanicFlip
 - PanicPowder
 - PanicPowderArrow
@@ -174,26 +190,17 @@ A full list of all of the different parameter names used by HouseRules rules
 - PlayerLeap
 - PlayerMelee
 - PoisonBomb
-- PoisonedTip
 - PoisonGas
+- PoisonedTip
 - Portal
-- PVPCursedDagger
-- PVPGasLamp
-- PVPHuntersMark
-- PVPIceLamp
-- PVPOilLamp
 - PvPReplenishArmor
-- PVPScrollOfCharm
-- PVPStealth
-- PVPSummonElemental
-- PVPVortexLamp
 - RaiseRoots
 - Rally
 - RalmasRevenge
 - RatBomb
 - RatFrenzy
-- RatsNest
 - RatWhisperer
+- RatsNest
 - Regroup
 - Rejuvenation
 - ReleaseEnergy
@@ -228,7 +235,7 @@ A full list of all of the different parameter names used by HouseRules rules
 - SpawnExplodingBarrel
 - SpawnGiantRat
 - SpawnGiantSlime
-- SpawnGiantBrute
+- SpawnGoblinBrute
 - SpawnGoblinRanger
 - SpawnGoldPile
 - SpawnJeweledScarab
@@ -237,8 +244,8 @@ A full list of all of the different parameter names used by HouseRules rules
 - SpawnMoreUnseenOnDeath
 - SpawnMushrooms
 - SpawnRandomLamp
-- SpawnScarabSandPile
 - SpawnRat
+- SpawnScarabSandPile
 - SpawnSlime
 - SpawnSnakeBossAgain
 - SpawnSnakeTailBossAgain
@@ -250,25 +257,25 @@ A full list of all of the different parameter names used by HouseRules rules
 - SpellPowerPotion
 - SpiderWebshot
 - SplittingArrow
-- StrengthenMinion
 - StrengthPotion
+- StrengthenMinion
 - SummonBossMinions
 - SummonElemental
 - SummonGreaterMonster
-- SummoningRiftFusion
 - SummonLesserMonster
 - SummonMediumMonster
 - SummonMinion
+- SummoningRiftFusion
 - SwiftnessPotion
 - SyncEmerge
 - TauntingScream
 - Telekinesis
 - TelekineticBurst
-- Teleportation
 - TeleportEnemy
 - TeleportLamp
 - TeleportRotateSit
 - TeleportToBattle
+- Teleportation
 - TheBehemoth
 - ThornPowder
 - TileBlock
@@ -292,6 +299,7 @@ A full list of all of the different parameter names used by HouseRules rules
 - WaterBottle
 - WaterDive
 - WaterExplosion
+- WaterLamp
 - Weaken
 - WeakeningShout
 - WebBomb
@@ -306,7 +314,6 @@ A full list of all of the different parameter names used by HouseRules rules
 - WizardBossZap
 - WoodenBone
 - Zap
-
 ## Behaviour(s)
 
 - AbilityBuildUp
@@ -314,6 +321,8 @@ A full list of all of the different parameter names used by HouseRules rules
 - AttackAndRetreat
 - AttackAndRetreatToOwner
 - AttackPlayer
+- AttackRandomTile
+- AvoidElvenKingAttacks
 - BurrowBehaviour
 - CastOnSelf
 - CastOnTeam
@@ -340,12 +349,14 @@ A full list of all of the different parameter names used by HouseRules rules
 - HealAOE
 - HealFromFOW
 - HostileTowardsEntangled
+- Invalid
 - Javelin
 - KeepDistance
 - LeechMelee
 - MadElvenKingHandBehaviour
 - MotherCyBossBehaviour
 - Patrol
+- PikeAttack
 - RangedAttackHighPrio
 - RangedSpellCaster
 - ReptileArcherBehaviour
@@ -353,7 +364,6 @@ A full list of all of the different parameter names used by HouseRules rules
 - RootLordBehaviour
 - RootWall
 - SandPileBehaviour
-- SellswordHeal
 - SlimeFusion
 - SnakeBossBehaviour
 - SpawnBuildUp
@@ -365,13 +375,14 @@ A full list of all of the different parameter names used by HouseRules rules
 - Swarm
 - TornadoCharge
 - TownBossBehaviour
+- TsunamiRangedAttackIfYouSeeThisAfterForestReleaseTellTomasToFixThisAndIfYouAreAModderIgnoreThis
 - Turret
 - UseBuildUpAbilityBehaviour
 - VerminFrenzy
 - VortexAbilityBehaviour
+- WaterDiveRangedAttackIfYouSeeThisAfterForestReleaseTellTomasToFixThisAndIfYouAreAModderIgnoreThis
 - WaterDiveRetreat
 - WizardBossBehaviour
-
 ## BoardPieceId(s)
 
 - AltarOfBlessing
@@ -503,6 +514,7 @@ A full list of all of the different parameter names used by HouseRules rules
 - TheUnseen
 - TheUnspoken
 - Thug
+- Tombstone
 - Torch
 - Tornado
 - TownBreakableWall
@@ -512,15 +524,15 @@ A full list of all of the different parameter names used by HouseRules rules
 - Verochka
 - VillagerFemaleTown
 - VillagerMaleTown
-- VortexDustChest
 - VortexLamp
 - WarlockMinion
 - WaterBottleChest
+- WaterLamp
 - WizardBoss
 - Wyvern
-
 ## EffectStateType(s)
 
+- AIDirectorAmbientEnemy
 - AbilityBlocked
 - AbilityBuildUp
 - ActionPreventedInfinite
@@ -537,9 +549,9 @@ A full list of all of the different parameter names used by HouseRules rules
 - BossHandHealState
 - BossHandIdleState
 - BossHandOnGroundState
-- BossHandsDeathCooldown
-- BossHandsSmashState
+- BossHandSmashState
 - BossHandSpawnableTarget
+- BossHandsDeathCooldown
 - CanaHunting
 - CanaStay
 - ChargeUp
@@ -604,14 +616,14 @@ A full list of all of the different parameter names used by HouseRules rules
 - MinionSummoned
 - Netted
 - Overcharge
+- PVPConfused
+- PVPHuntersMark
+- PVPStealthed
 - Panic
 - Petrified
 - PlayerBerserk
 - PlayerPanic
 - Portal
-- PVPConfused
-- PVPHuntersMark
-- PVPStealthed
 - Rally
 - Recovery
 - Resilience
@@ -627,8 +639,8 @@ A full list of all of the different parameter names used by HouseRules rules
 - StolenCard
 - StolenGold
 - StrengthInNumbers
-- Stunned
 - StunSelf
+- Stunned
 - SuddenDeath
 - SummoningRiftSpawn
 - SummoningSickness
@@ -644,7 +656,6 @@ A full list of all of the different parameter names used by HouseRules rules
 - TownBossHP60
 - TownBossHP80
 - TownBossThrone
-- Undefined
 - UnitLeader
 - UnitSpawnCounter
 - Untargetable
@@ -654,7 +665,6 @@ A full list of all of the different parameter names used by HouseRules rules
 - Weaken2Turns
 - Wet
 - WizardDoppelganger
-
 ## PieceType(s)
 
 - Beggar
@@ -663,10 +673,10 @@ A full list of all of the different parameter names used by HouseRules rules
 - Brittle
 - Canine
 - Corruption
+- Creature
 - DesertCreature
 - Downable
 - EndLevelChest
-- EnemyEggs
 - ExplodingLamp
 - Flying
 - ForestCreature
@@ -685,10 +695,10 @@ A full list of all of the different parameter names used by HouseRules rules
 - MadElvenKingHand
 - MagicWall
 - MiniBarricade
+- NPC
 - NonAttackable
 - NonGrabbable
 - NonTeleportable
-- NPC
 - Pickup
 - Player
 - Portal
@@ -707,8 +717,9 @@ A full list of all of the different parameter names used by HouseRules rules
 - SummoningRift
 - Thief
 - TooHeavyToGrapple
+- UNUSED_REMOVE_ME
+- Undefined
 - UpdateFogOfWar
 - UseLevelSequenceVisionRange
 - ValidCorruptionTarget
 - Villager
-

--- a/docs/scripts/settings_reference.sh
+++ b/docs/scripts/settings_reference.sh
@@ -10,7 +10,8 @@ if [ "$#" -eq 0 ]; then
 	# Environment variable is required if we're runnign without arguments.
 	if [ -z "${SOURCEDIR}" ]; then
 		echo "SOURCEDIR variable must be set if not using positional arguments"
-		echo "Usage: SOURCEDIR='./dnSpy Export v1.25/Assembly-CSharp' settings_reference.sh"
+		echo "Usage: SOURCEDIR=<ASSembly-CSharp_Dir_Path> ./scripts/settings_reference.sh"
+		echo "Example: SOURCEDIR='./dnSpy Export v1.25/Assembly-CSharp' settings_reference.sh"
 		echo "or   : ./settings_refrence.sh './dnSpy Export v1.25/Assembly-CSharp'"
 	        exit 1
 	fi
@@ -19,7 +20,6 @@ elif [ "$#" -eq 1 ]; then
 	SOURCEDIR="${1}"
 fi
 
-
 cat << 'EOF'
 # Demeo Parameter Names
 
@@ -27,12 +27,10 @@ A full list of all of the different parameter names used by HouseRules rules
 
 EOF
 
-
 for item in AbilityKey Behaviour BoardPieceId EffectStateType PieceType 
 do
 	echo "## ${item}(s)"
 	echo
-	#cat "${SOURCEDIR}/DataKeys/${item}.cs" | grep , | sed s/,// | sed s/^/-\ /
 	cat "${SOURCEDIR}/DataKeys/${item}.cs" | grep , | sort | awk '{print $1}' | sed 's/,//' | sed 's/^[[:space:]]*//' | sed 's/^/-\ /'
 
 done

--- a/docs/scripts/settings_reference.sh
+++ b/docs/scripts/settings_reference.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Simple bash script to scrape the HouseRules SettingsReference.md doc from the Demeo Source Code.
+# Usage: SOURCEDIR="./dnSpy Export v1.25/Assembly-CSharp" settings_reference.sh
+# Usage 2: settings_refrence.sh "./dnSpy Export v1.25/Assembly-CSharp"
+
+set -eo pipefail
+
+if [ "$#" -eq 0 ]; then
+	# Environment variable is required if we're runnign without arguments.
+	if [ -z "${SOURCEDIR}" ]; then
+		echo "SOURCEDIR variable must be set if not using positional arguments"
+		echo "Usage: SOURCEDIR='./dnSpy Export v1.25/Assembly-CSharp' settings_reference.sh"
+		echo "or   : ./settings_refrence.sh './dnSpy Export v1.25/Assembly-CSharp'"
+	        exit 1
+	fi
+
+elif [ "$#" -eq 1 ]; then
+	SOURCEDIR="${1}"
+fi
+
+
+cat << 'EOF'
+# Demeo Parameter Names
+
+A full list of all of the different parameter names used by HouseRules rules
+
+EOF
+
+
+for item in AbilityKey Behaviour BoardPieceId EffectStateType PieceType 
+do
+	echo "## ${item}(s)"
+	echo
+	#cat "${SOURCEDIR}/DataKeys/${item}.cs" | grep , | sed s/,// | sed s/^/-\ /
+	cat "${SOURCEDIR}/DataKeys/${item}.cs" | grep , | sort | awk '{print $1}' | sed 's/,//' | sed 's/^[[:space:]]*//' | sed 's/^/-\ /'
+
+done
+


### PR DESCRIPTION
A new script for autogenerating the docs/SettingsReference.md refrence documentation.

Script usage:
```
Usage: SOURCEDIR="$HOME/dnSpy Export v1.25/Assembly-CSharp" ./scripts/settings_reference.sh
Usage 2: ./scripts/settings_refrence.sh "./dnSpy Export v1.25/Assembly-CSharp"
```
