### PR TITLE
Fixes for PS5 update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/69d8617a0eeb247eb43f802f20d00fac0fb94de2/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/7563f9c2b2726c4c0d84dc5d4ba603df8e1e88d8/ws.zip
           7z x ws.zip 
 
       - name: Build HouseRules_Core
@@ -68,7 +68,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/69d8617a0eeb247eb43f802f20d00fac0fb94de2/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/7563f9c2b2726c4c0d84dc5d4ba603df8e1e88d8/ws.zip
           7z x ws.zip
 
       - name: Build RoomFinder
@@ -95,7 +95,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/69d8617a0eeb247eb43f802f20d00fac0fb94de2/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/7563f9c2b2726c4c0d84dc5d4ba603df8e1e88d8/ws.zip
           7z x ws.zip
 
       - name: Build SkipIntro
@@ -122,7 +122,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/69d8617a0eeb247eb43f802f20d00fac0fb94de2/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/7563f9c2b2726c4c0d84dc5d4ba603df8e1e88d8/ws.zip
           7z x ws.zip
 
       - name: Build RoomCode
@@ -149,7 +149,7 @@ jobs:
 
       - name: Prepare
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/69d8617a0eeb247eb43f802f20d00fac0fb94de2/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/7563f9c2b2726c4c0d84dc5d4ba603df8e1e88d8/ws.zip
           7z x ws.zip 
 
       - name: Build AdvancedStats

--- a/Common/UI/Environments.cs
+++ b/Common/UI/Environments.cs
@@ -32,7 +32,7 @@
 
         public static bool IsPcEdition()
         {
-            return MotherbrainGlobalVars.IsRunningOnDesktop;
+            return MotherbrainGlobalVars.IsRunningOnNonVRPlatform;
         }
 
         public static bool IsInHangouts()

--- a/HouseRules_Core/LifecycleDirector.cs
+++ b/HouseRules_Core/LifecycleDirector.cs
@@ -70,12 +70,22 @@
 
         private static bool HandSettingsPageController_SetupGameButtons_Prefix()
         {
+            if (HR.SelectedRuleset == Ruleset.None)
+            {
+                return true;
+            }
+
             // Don't allow PCVR privacy settings to change from Private to Public
             return false;
         }
 
         private static bool NonVrGameSettingsPageController_ToggleGamePrivacy_Prefix()
         {
+            if (HR.SelectedRuleset == Ruleset.None)
+            {
+                return true;
+            }
+
             // Don't allow PC-Edition privacy settings to change from Private to Public
             return false;
         }

--- a/HouseRules_Core/LifecycleDirector.cs
+++ b/HouseRules_Core/LifecycleDirector.cs
@@ -2,10 +2,10 @@
 {
     using System;
     using System.Linq;
-    using System.Reflection;
     using System.Text;
     using Boardgame;
     using Boardgame.Networking;
+    using Boardgame.NonVR.Ui.Settings;
     using HarmonyLib;
     using HouseRules.Types;
     using Photon.Realtime;
@@ -58,6 +58,26 @@
                 prefix: new HarmonyMethod(
                     typeof(LifecycleDirector),
                     nameof(SerializableEventQueue_DisconnectLocalPlayer_Prefix)));
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(NonVrGameSettingsPageController), "ToggleGamePrivacy"),
+                prefix: new HarmonyMethod(typeof(LifecycleDirector), nameof(NonVrGameSettingsPageController_ToggleGamePrivacy_Prefix)));
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(HandSettingsPageController), "<SetupGameButtons>g__ToggleGamePrivacy|16_4"),
+                prefix: new HarmonyMethod(typeof(LifecycleDirector), nameof(HandSettingsPageController_SetupGameButtons_Prefix)));
+        }
+
+        private static bool HandSettingsPageController_SetupGameButtons_Prefix()
+        {
+            // Don't allow PCVR privacy settings to change from Private to Public
+            return false;
+        }
+
+        private static bool NonVrGameSettingsPageController_ToggleGamePrivacy_Prefix()
+        {
+            // Don't allow PC-Edition privacy settings to change from Private to Public
+            return false;
         }
 
         private static void GameStartup_InitializeGame_Postfix(GameStartup __instance)

--- a/RoomCode/ModPatcher.cs
+++ b/RoomCode/ModPatcher.cs
@@ -11,15 +11,15 @@
         internal static void Patch(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(GameStateMachine), "GetRandomRoomCode"),
-                prefix: new HarmonyMethod(typeof(ModPatcher), nameof(GameStateMachine_GetRandomRoomCode_Prefix)));
+                original: AccessTools.Method(typeof(NetworkRoomUtils), "GetRandomRoomCode"),
+                prefix: new HarmonyMethod(typeof(ModPatcher), nameof(NetworkRoomUtils_GetRandomRoomCode_Prefix)));
 
             harmony.Patch(
                 original: AccessTools.Method(typeof(CreatingGameState), "OnJoinedRoom"),
                 prefix: new HarmonyMethod(typeof(ModPatcher), nameof(CreatingGameState_OnJoinedRoom_Prefix)));
         }
 
-        private static bool GameStateMachine_GetRandomRoomCode_Prefix(ref string __result)
+        private static bool NetworkRoomUtils_GetRandomRoomCode_Prefix(ref string __result)
         {
             if (!RoomCodeMod.Enabled)
             {

--- a/RoomFinder/RoomFinderMod.cs
+++ b/RoomFinder/RoomFinderMod.cs
@@ -23,7 +23,7 @@
 
         public override void OnSceneWasInitialized(int buildIndex, string sceneName)
         {
-            if (MotherbrainGlobalVars.IsRunningOnDesktop)
+            if (MotherbrainGlobalVars.IsRunningOnNonVRPlatform)
                 {
                     if (buildIndex != LobbySceneIndex)
                 {


### PR DESCRIPTION
Fixes House Rules
Fixes RoomFinder
Fixes RoomCode

They just renamed a variable and changed the location of a function...


Note: This isn't currently building because our binaries for the current Demeo build aren't on the server.

Example (D:\a\DemeoMods\DemeoMods\RoomFinder\RoomFinderMod.cs(26,39): error CS0117: 'MotherbrainGlobalVars' does not contain a definition for 'IsRunningOnNonVRPlatform')