### PR TITLE
Two new rules added to specify Energy cards gained and/or Chest cards gained

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -26,7 +26,9 @@
             HR.Rulebook.Register(typeof(BackstabConfigOverriddenRule));
             HR.Rulebook.Register(typeof(CourageShantyAddsHpRule));
             HR.Rulebook.Register(typeof(CardAdditionOverriddenRule));
+            HR.Rulebook.Register(typeof(CardChestAdditionOverriddenRule));
             HR.Rulebook.Register(typeof(CardClassRestrictionOverriddenRule));
+            HR.Rulebook.Register(typeof(CardEnergyAdditionOverriddenRule));
             HR.Rulebook.Register(typeof(CardEnergyFromAttackMultipliedRule));
             HR.Rulebook.Register(typeof(CardEnergyFromRecyclingMultipliedRule));
             HR.Rulebook.Register(typeof(CardLimitModifiedRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -56,7 +56,9 @@
     <Compile Include="Rules\AbilityDamageOverriddenRule.cs" />
     <Compile Include="Rules\AbilityStealthDamageOverriddenRule.cs" />
     <Compile Include="Rules\AbilityHealOverriddenRule.cs" />
+    <Compile Include="Rules\CardChestAdditionOverriddenRule.cs" />
     <Compile Include="Rules\CardClassRestrictionOverriddenRule.cs" />
+    <Compile Include="Rules\CardEnergyAdditionOverriddenRule.cs" />
     <Compile Include="Rules\EnemyCooldownOverriddenRule.cs" />
     <Compile Include="Rules\PartyElectricityDamageOverriddenRule.cs" />
     <Compile Include="Rules\FreeAbilityOnCritRule.cs" />

--- a/HouseRules_Essentials/README.md
+++ b/HouseRules_Essentials/README.md
@@ -203,7 +203,8 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
     },
   ```
 
-#### __CardAdditionOverridden__: Overrides the lists of cards which players receive from chests & card energy.
+#### __CardAdditionOverridden__: Overrides the lists of cards which players receive from chest AND card energy (mana).
+  - 🚧 NOTE: You should not use this rule if you plan to use the following two rules! 🚧
   - The default card allocation mechanism is intercepted and changed to use a user-defined list of cards.
   - To configure:
     - Specify the [BoardPieceId](../docs/SettingsReference.md#boardpieceids) that should have its card pool overridden.
@@ -214,6 +215,41 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
   ```json
   {
     "Rule": "CardAdditionOverridden",
+    "Config": {
+      "HeroSorcerer": ["StrengthPotion", "SwiftnessPotion", "Bone", "Fireball", "Freeze", "BottleOfLye", "Teleportation", "HeavensFury", "RevealPath"],
+      "HeroGuardian": ["WhirlwindAttack", "Charge", "CallCompanion", "HealingPotion"]
+    }
+  },
+  ```
+#### __CardChestAdditionOverridden__: Overrides the lists of cards which players receive from chests.
+  - The default card allocation mechanism is intercepted and changed to use a user-defined list of cards.
+  - To configure:
+    - Specify the [BoardPieceId](../docs/SettingsReference.md#boardpieceids) that should have its card pool overridden.
+    - Specify a list of [AbilityKeys](../docs/SettingsReference.md#abilitykeys) for the cards that should make up the card pool.
+
+  ###### _Example JSON config for CardChestAdditionOverridden_
+
+  ```json
+  {
+    "Rule": "CardChestAdditionOverridden",
+    "Config": {
+      "HeroSorcerer": ["StrengthPotion", "SwiftnessPotion", "Bone", "Fireball", "Freeze", "BottleOfLye", "Teleportation", "HeavensFury", "RevealPath"],
+      "HeroGuardian": ["WhirlwindAttack", "Charge", "CallCompanion", "HealingPotion"]
+    }
+  },
+  ```
+
+#### __CardEnergyAdditionOverridden__: Overrides the lists of cards which players receive from card energy (mana).
+  - The default card allocation mechanism is intercepted and changed to use a user-defined list of cards.
+  - To configure:
+    - Specify the [BoardPieceId](../docs/SettingsReference.md#boardpieceids) that should have its card pool overridden.
+    - Specify a list of [AbilityKeys](../docs/SettingsReference.md#abilitykeys) for the cards that should make up the card pool.
+
+  ###### _Example JSON config for CardEnergyAdditionOverridden_
+
+  ```json
+  {
+    "Rule": "CardEnergyAdditionOverridden",
     "Config": {
       "HeroSorcerer": ["StrengthPotion", "SwiftnessPotion", "Bone", "Fireball", "Freeze", "BottleOfLye", "Teleportation", "HeavensFury", "RevealPath"],
       "HeroGuardian": ["WhirlwindAttack", "Charge", "CallCompanion", "HealingPotion"]

--- a/HouseRules_Essentials/Rules/CardEnergyAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardEnergyAdditionOverriddenRule.cs
@@ -4,35 +4,32 @@
     using System.Collections.Generic;
     using System.Threading;
     using Boardgame;
-    using Boardgame.Data;
     using Boardgame.SerializableEvents;
     using DataKeys;
     using HarmonyLib;
     using HouseRules.Types;
 
 
-    public sealed class CardAdditionOverriddenRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<AbilityKey>>>,
+    public sealed class CardEnergyAdditionOverriddenRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<AbilityKey>>>,
         IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Card additions from chests AND energy (mana) are overridden";
+        public override string Description => "Card additions from energy (mana) are overridden";
 
-        private static Dictionary<BoardPieceId, List<AbilityKey>> _globalHeroCards;
+        private static Dictionary<BoardPieceId, List<AbilityKey>> _globalEnergyCards;
         private static bool _isActivated;
-        private static bool _isSkipped;
-        private static int _numPlayers;
 
-        private readonly Dictionary<BoardPieceId, List<AbilityKey>> _heroCards;
+        private readonly Dictionary<BoardPieceId, List<AbilityKey>> _energyCards;
 
-        public CardAdditionOverriddenRule(Dictionary<BoardPieceId, List<AbilityKey>> heroCards)
+        public CardEnergyAdditionOverriddenRule(Dictionary<BoardPieceId, List<AbilityKey>> energyCards)
         {
-            _heroCards = heroCards;
+            _energyCards= energyCards;
         }
 
-        public Dictionary<BoardPieceId, List<AbilityKey>> GetConfigObject() => _heroCards;
+        public Dictionary<BoardPieceId, List<AbilityKey>> GetConfigObject() => _energyCards;
 
         protected override void OnActivate(GameContext gameContext)
         {
-            _globalHeroCards = _heroCards;
+            _globalEnergyCards= _energyCards;
             _isActivated = true;
         }
 
@@ -41,15 +38,9 @@
         private static void Patch(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(Interactable), "OnInteraction", new Type[] { typeof(int), typeof(IntPoint2D), typeof(GameContext), typeof(int) }),
-                prefix: new HarmonyMethod(
-                    typeof(CardAdditionOverriddenRule),
-                    nameof(Interactable_OnInteraction_Prefix)));
-
-            harmony.Patch(
                 original: AccessTools.Method(typeof(SerializableEventQueue), "RespondToRequest"),
                 prefix: new HarmonyMethod(
-                    typeof(CardAdditionOverriddenRule),
+                    typeof(CardEnergyAdditionOverriddenRule),
                     nameof(SerializableEventQueue_RespondToRequest_Prefix)));
         }
 
@@ -63,28 +54,6 @@
             public static Random GetThreadRandom()
             {
                 return randomWrapper.Value;
-            }
-        }
-
-        private static void Interactable_OnInteraction_Prefix(
-            GameContext gameContext,
-            IntPoint2D targetTile)
-        {
-            if (!_isActivated)
-            {
-                return;
-            }
-
-            if (!gameContext.pieceAndTurnController.GetInteractableAtPosition(targetTile))
-            {
-                return;
-            }
-
-            Interactable whatIsit = gameContext.pieceAndTurnController.GetInteractableAtPosition(targetTile);
-            if (whatIsit.type == Interactable.Type.PotionStand || whatIsit.type == Interactable.Type.WaterBottleChest || whatIsit.type == Interactable.Type.VortexDustChest)
-            {
-                _numPlayers = gameContext.pieceAndTurnController.GetNumberOfPlayerPieces();
-                _isSkipped = true;
             }
         }
 
@@ -102,26 +71,12 @@
                 return;
             }
 
-            if (_isSkipped)
-            {
-                if (_numPlayers > 1)
-                {
-                    _numPlayers--;
-                }
-                else
-                {
-                    _isSkipped = false;
-                }
-
-                return;
-            }
-
             var addCardToPieceEvent = (SerializableEventAddCardToPiece)request;
             var gameContext = Traverse.Create(__instance).Property<GameContext>("gameContext").Value;
             var pieceId = Traverse.Create(addCardToPieceEvent).Field<int>("pieceId").Value;
             var cardSource = Traverse.Create(addCardToPieceEvent).Field<int>("cardSource").Value;
 
-            if (cardSource != (int)MotherTracker.Context.Energy && cardSource != (int)MotherTracker.Context.Chest)
+            if (cardSource != (int)MotherTracker.Context.Energy)
             {
                 return;
             }
@@ -136,7 +91,7 @@
                 return;
             }
 
-            if (!_globalHeroCards.TryGetValue(piece.boardPieceId, out var replacementAbilityKeys))
+            if (!_globalEnergyCards.TryGetValue(piece.boardPieceId, out var replacementAbilityKeys))
             {
                 return;
             }

--- a/HouseRules_Essentials/Rules/PotionAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PotionAdditionOverriddenRule.cs
@@ -144,12 +144,9 @@
                 return;
             }
 
-            int rand;
-            AbilityKey replacementAbilityKey;
-
-            rand = RandomProvider.GetThreadRandom().Next(2, replacementAbilityKeys.Count);
-            AbilityKey replacementAbilityKey2 = replacementAbilityKeys[rand];
-            Traverse.Create(addCardToPieceEvent).Field<AbilityKey>("card").Value = replacementAbilityKey2;
+            int rand = RandomProvider.GetThreadRandom().Next(0, replacementAbilityKeys.Count);
+            AbilityKey replacementAbilityKey = replacementAbilityKeys[rand];
+            Traverse.Create(addCardToPieceEvent).Field<AbilityKey>("card").Value = replacementAbilityKey;
 
             return;
         }

--- a/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
@@ -142,7 +142,6 @@
         private static Inventory CreateInventory(BoardPieceId boardPieceId)
         {
             var inventory = new Inventory();
-            EssentialsMod.Logger.Warning($"StartCardsModified - > {boardPieceId}");
             foreach (var card in _globalHeroStartCards[boardPieceId])
             {
                 // flag bits


### PR DESCRIPTION
CardAddition will still work so no need to update existing rulesets
Standardized how randomness is computed between all loot sources
Fixed bug in PotionAddition and CardAddition that ignored the first two loot items
Removed leftover log from StartCardsModified
Updated README to reflect changes/additions