### PR TITLE
Update `RoomFinder` mod for compatibility with 2023-05-16 Demeo update.

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -39,6 +39,12 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(DemeoVrDir)\demeo_Data\Managed\BowserCore.dll</HintPath>
     </Reference>
+    <Reference Include="BowserCoreDataTypesRuntime">
+      <HintPath>$(DemeoVrDir)\demeo_Data\Managed\BowserCoreDataTypesRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="BowserLegacyRuntime">
+      <HintPath>$(DemeoVrDir)\demeo_Data\Managed\BowserLegacyRuntime.dll</HintPath>
+    </Reference>
     <Reference Include="MelonLoader">
       <HintPath>$(DemeoVrDir)\MelonLoader\MelonLoader.dll</HintPath>
     </Reference>

--- a/Common/CommonModule.cs
+++ b/Common/CommonModule.cs
@@ -1,6 +1,6 @@
 ﻿namespace Common
 {
-    using Bowser.Core;
+    using Bowser.Legacy;
     using MelonLoader;
 
     internal static class CommonModule

--- a/Common/Patcher.cs
+++ b/Common/Patcher.cs
@@ -1,7 +1,7 @@
 ﻿namespace Common
 {
-    using Bowser.Core;
     using Bowser.GameIntegration;
+    using Bowser.Legacy;
     using HarmonyLib;
 
     internal static class Patcher

--- a/Common/UI/Element/HangoutsElementCreator.cs
+++ b/Common/UI/Element/HangoutsElementCreator.cs
@@ -1,7 +1,7 @@
 ﻿namespace Common.UI.Element
 {
     using System;
-    using Bowser.Core;
+    using Bowser.Legacy;
     using UnityEngine;
 
     internal class HangoutsElementCreator : IElementCreator

--- a/RoomFinder/RoomFinder.csproj
+++ b/RoomFinder/RoomFinder.csproj
@@ -41,6 +41,12 @@
     <Reference Include="BowserCore">
       <HintPath>$(DemeoVrDir)\demeo_Data\Managed\BowserCore.dll</HintPath>
     </Reference>
+    <Reference Include="BowserCoreDataTypesRuntime">
+      <HintPath>$(DemeoVrDir)\demeo_Data\Managed\BowserCoreDataTypesRuntime.dll</HintPath>
+    </Reference>
+    <Reference Include="BowserLegacyRuntime">
+      <HintPath>$(DemeoVrDir)\demeo_Data\Managed\BowserLegacyRuntime.dll</HintPath>
+    </Reference>
     <Reference Include="MelonLoader">
       <HintPath>$(DemeoVrDir)\MelonLoader\MelonLoader.dll</HintPath>
     </Reference>

--- a/RoomFinder/SharedState.cs
+++ b/RoomFinder/SharedState.cs
@@ -6,6 +6,8 @@
     {
         internal GameContext GameContext { get; set; }
 
+        internal LobbyMatchmakingController LobbyMatchmakingController { get; set; }
+
         internal bool IsRefreshingRoomList { get; set; }
 
         internal bool HasRoomListUpdated { get; set; }

--- a/RoomFinder/UI/RoomFinderUiNonVr.cs
+++ b/RoomFinder/UI/RoomFinderUiNonVr.cs
@@ -136,14 +136,21 @@
 
         private void PopulateRoomList()
         {
-            var cachedRooms =
-                Traverse.Create(RoomFinderMod.SharedState.GameContext.gameStateMachine)
-                    .Field<Dictionary<string, RoomInfo>>("cachedRoomList").Value;
+            var unfilteredRooms =
+                Traverse.Create(RoomFinderMod.SharedState.LobbyMatchmakingController)
+                    .Field<List<RoomInfo>>("roomList").Value;
 
-            RoomFinderMod.Logger.Msg($"Captured {cachedRooms.Count} rooms.");
+            var isRoomValidMethod = Traverse.Create(RoomFinderMod.SharedState.LobbyMatchmakingController).Method(
+                "IsRoomValidWithCurrentConfiguration",
+                new[] { typeof(RoomInfo) });
 
-            var rooms = cachedRooms.Values.ToList().Select(Room.Parse).ToList();
-            _roomListPanel.UpdateRooms(rooms);
+            var filteredRooms = unfilteredRooms
+                .Where(info => isRoomValidMethod.GetValue<bool>(info)).ToList().Select(Room.Parse).ToList();
+
+            RoomFinderMod.Logger.Msg($"Found {unfilteredRooms.Count} total rooms.");
+            RoomFinderMod.Logger.Msg($"Listing {filteredRooms.Count} available rooms.");
+
+            _roomListPanel.UpdateRooms(filteredRooms);
         }
     }
 }


### PR DESCRIPTION
There were numerous changes to Demeo's game-joining flow that `RoomFinder` needed to compensate for.  Those are encapsulated in this PR.

- Demeo has moved the location at which cached rooms were available (previously `cachedRoomList` in `GameStateMachine`, now `roomList` in `LobbyMatchmakingController`).
- As a consequence of the above, we must also now capture a reference to `LobbyMatchmakingController` as part of the patching sequence.
- Some resources that were once in `BowserCore.dll` have been moved to `BowserLegacyRuntime.dll` and `BowserCoreDataTypesRuntime.dll`, meaning those are now new dependencies.


> **Warning**
>
> This has only been tested on the Non-VR PC edition, hence changes to `RoomFinder/UI/RoomFinderUiNonVr.cs` and not `RoomFinder/UI/RoomFinderUiVr.cs`.
>
> The author will attempt to make the VR-equivalent changes within the next day.