### PR TITLE
Fixes Oculus HouseRules menu issues

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -54,6 +54,9 @@
     <Reference Include="Assembly-CSharp">
       <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
+    <Reference Include="Oculus.Interaction">
+      <HintPath>..\..\..\..\..\Oculus\Software\resolution-games-demeo\DemeoVR\Demeo_Data\Managed\Oculus.Interaction.dll</HintPath>
+    </Reference>
     <Reference Include="Unity.TextMeshPro">
       <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Unity.TextMeshPro.dll</HintPath>
     </Reference>

--- a/HouseRules_Configuration/HouseRules_Configuration.csproj
+++ b/HouseRules_Configuration/HouseRules_Configuration.csproj
@@ -53,6 +53,9 @@
     <Reference Include="MelonLoader">
       <HintPath>$(DemeoVrDir)\MelonLoader\MelonLoader.dll</HintPath>
     </Reference>
+    <Reference Include="Oculus.Interaction">
+      <HintPath>..\..\..\..\..\Oculus\Software\resolution-games-demeo\DemeoVR\Demeo_Data\Managed\Oculus.Interaction.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
     <Reference Include="Unity.TextMeshPro">

--- a/RoomFinder/RoomFinder.csproj
+++ b/RoomFinder/RoomFinder.csproj
@@ -53,6 +53,9 @@
     <Reference Include="MelonLoader">
       <HintPath>$(DemeoVrDir)\MelonLoader\MelonLoader.dll</HintPath>
     </Reference>
+    <Reference Include="Oculus.Interaction">
+      <HintPath>..\..\..\..\..\Oculus\Software\resolution-games-demeo\DemeoVR\Demeo_Data\Managed\Oculus.Interaction.dll</HintPath>
+    </Reference>
     <Reference Include="Photon3Unity3D">
       <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Photon3Unity3D.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Fix not being able to interact with Oculus main menu
Fix Oculus menu not appearing inside Heroes Hangout

Note: Because of the recent patch there are now different data files per platform. This means we're now having to look in a Steam game location for everything else and an Oculus game location for this one file. Also, for this to work you would need to have installed Demeo in the default directory given by the Oculus Windows app.