### PR TITLE
Apply general maintenance.

### DIFF
--- a/.github/workflows/advancedstats.yml
+++ b/.github/workflows/advancedstats.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Add Build Dependencies
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/7563f9c2b2726c4c0d84dc5d4ba603df8e1e88d8/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/eab432f1b7df70451905531f1e77bb05102747ec/ws.zip
           7z x ws.zip
 
       - name: Build Project

--- a/.github/workflows/houserules.yml
+++ b/.github/workflows/houserules.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Add Build Dependencies
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/237277ac6fbc60feb5b83c0f87d5407513d51de1/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/eab432f1b7df70451905531f1e77bb05102747ec/ws.zip
           7z x ws.zip
 
       - name: Build HouseRules_Core

--- a/.github/workflows/roomcode.yml
+++ b/.github/workflows/roomcode.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Add Build Dependencies
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/7563f9c2b2726c4c0d84dc5d4ba603df8e1e88d8/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/eab432f1b7df70451905531f1e77bb05102747ec/ws.zip
           7z x ws.zip
 
       - name: Build Project

--- a/.github/workflows/roomfinder.yml
+++ b/.github/workflows/roomfinder.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Add Build Dependencies
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/237277ac6fbc60feb5b83c0f87d5407513d51de1/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/eab432f1b7df70451905531f1e77bb05102747ec/ws.zip
           7z x ws.zip
 
       - name: Build Project

--- a/.github/workflows/skipintro.yml
+++ b/.github/workflows/skipintro.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Add Build Dependencies
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/jimconner/f3c89c300d0b13e23c32fc9fb5d1b1df/raw/7563f9c2b2726c4c0d84dc5d4ba603df8e1e88d8/ws.zip
+          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/eab432f1b7df70451905531f1e77bb05102747ec/ws.zip
           7z x ws.zip
 
       - name: Build Project

--- a/AdvancedStats/AdvancedStatsMod.cs
+++ b/AdvancedStats/AdvancedStatsMod.cs
@@ -1,6 +1,5 @@
 ﻿namespace AdvancedStats
 {
-    using HarmonyLib;
     using MelonLoader;
 
     internal class AdvancedStatsMod : MelonMod
@@ -9,14 +8,13 @@
 
         public override void OnSceneWasInitialized(int buildIndex, string sceneName)
         {
-            var harmony = new Harmony("com.orendain.demeomods.advancedstats");
             if (sceneName == "StartupDesktop")
             {
-                NonVRAdvancedStatsView.Patch(harmony);
+                NonVRAdvancedStatsView.Patch(HarmonyInstance);
             }
             else if (sceneName.Contains("Startup"))
             {
-                VRAdvancedStatsView.Patch(harmony);
+                VRAdvancedStatsView.Patch(HarmonyInstance);
             }
         }
     }

--- a/AdvancedStats/Properties/AssemblyInfo.cs
+++ b/AdvancedStats/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
-using MelonLoader;
 using AdvancedStats;
+using MelonLoader;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information

--- a/Common/CommonModule.cs
+++ b/Common/CommonModule.cs
@@ -10,7 +10,7 @@
         internal static BowserButtonHandler HangoutsButtonHandler { get; set; }
 
         /// <summary>
-        /// Initialize the module. This should be called during the dependant module's OnApplicationStart().
+        /// Initialize the module. This should be called during the dependant module's OnInitializeMelon().
         /// </summary>
         public static void Initialize()
         {

--- a/Common/CommonModule.cs
+++ b/Common/CommonModule.cs
@@ -1,6 +1,7 @@
 ﻿namespace Common
 {
     using Bowser.Legacy;
+    using HarmonyLib;
     using MelonLoader;
 
     internal static class CommonModule
@@ -12,9 +13,8 @@
         /// <summary>
         /// Initialize the module. This should be called during the dependant module's OnInitializeMelon().
         /// </summary>
-        public static void Initialize()
+        public static void Initialize(Harmony harmony)
         {
-            var harmony = new HarmonyLib.Harmony("com.orendain.demeomods.common");
             Patcher.Patch(harmony);
         }
     }

--- a/Common/UI/Environments.cs
+++ b/Common/UI/Environments.cs
@@ -1,6 +1,5 @@
 ﻿namespace Common.UI
 {
-    using MelonLoader;
     using UnityEngine.SceneManagement;
 
     public enum Environment
@@ -12,7 +11,6 @@
 
     public static class Environments
     {
-        private const string DemeoPCEditionString = "Demeo PC Edition";
         private const int SteamHangoutsSceneIndex = 45;
         private const int OculusHangoutsSceneIndex = 43;
 

--- a/HouseRules_Configuration/ConfigManager.cs
+++ b/HouseRules_Configuration/ConfigManager.cs
@@ -14,7 +14,6 @@
     {
         internal static readonly string RulesetDirectory = Path.Combine(MelonUtils.UserDataDirectory, "HouseRules");
 
-        private readonly MelonPreferences_Category _configCategory;
         private readonly MelonPreferences_Entry<string> _defaultRulesetEntry;
         private readonly MelonPreferences_Entry<bool> _loadRulesetsFromConfigEntry;
 
@@ -25,9 +24,9 @@
 
         private ConfigManager()
         {
-            _configCategory = MelonPreferences.CreateCategory("HouseRules");
-            _defaultRulesetEntry = _configCategory.CreateEntry("defaultRuleset", string.Empty);
-            _loadRulesetsFromConfigEntry = _configCategory.CreateEntry("loadRulesetsFromConfig", true);
+            var configCategory = MelonPreferences.CreateCategory("HouseRules");
+            _defaultRulesetEntry = configCategory.CreateEntry("defaultRuleset", string.Empty);
+            _loadRulesetsFromConfigEntry = configCategory.CreateEntry("loadRulesetsFromConfig", true);
             Directory.CreateDirectory(RulesetDirectory);
             SetDefaultSerializationSettings();
         }

--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -20,7 +20,7 @@
 
         public override void OnInitializeMelon()
         {
-            CommonModule.Initialize();
+            CommonModule.Initialize(HarmonyInstance);
             DetermineIfUpdateAvailable();
         }
 

--- a/HouseRules_Configuration/ConfigurationMod.cs
+++ b/HouseRules_Configuration/ConfigurationMod.cs
@@ -18,13 +18,13 @@
 
         internal static bool IsUpdateAvailable { get; private set; }
 
-        public override void OnApplicationStart()
+        public override void OnInitializeMelon()
         {
             CommonModule.Initialize();
             DetermineIfUpdateAvailable();
         }
 
-        public override void OnApplicationLateStart()
+        public override void OnLateInitializeMelon()
         {
             ExampleRulesetExporter.ExportExampleRulesetsIfNeeded();
 

--- a/HouseRules_Configuration/UI/RulesetListPanelNonVr.cs
+++ b/HouseRules_Configuration/UI/RulesetListPanelNonVr.cs
@@ -125,7 +125,6 @@
             buttonTextTransform.sizeDelta = new Vector2(300, 50);
             buttonTextTransform.localPosition = new Vector2(-325f, 1);
 
-
             var description = _elementCreator.CreateNormalText(ruleset.Description);
             var rectTransform = (RectTransform)description.transform;
             rectTransform.SetParent(container.transform, worldPositionStays: false);

--- a/HouseRules_Core/CoreMod.cs
+++ b/HouseRules_Core/CoreMod.cs
@@ -9,13 +9,11 @@
     internal class CoreMod : MelonMod
     {
         internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("HouseRules:Core");
-        private static readonly Harmony RulesPatcher = new Harmony("com.orendain.demeomods.houserules.core.patcher");
 
         public override void OnInitializeMelon()
         {
-            var harmony = new Harmony("com.orendain.demeomods.houserules.core");
-            LifecycleDirector.Patch(harmony);
-            BoardSyncer.Patch(harmony);
+            LifecycleDirector.Patch(HarmonyInstance);
+            BoardSyncer.Patch(HarmonyInstance);
 
             HR.Rulebook.Register(Ruleset.None);
         }
@@ -25,7 +23,7 @@
             PatchRegisteredRules();
         }
 
-        private static void PatchRegisteredRules()
+        private void PatchRegisteredRules()
         {
             var patchableRules = HR.Rulebook.RuleTypes.Where(typ => typeof(IPatchable).IsAssignableFrom(typ)).ToList();
             Logger.Msg($"Found [{patchableRules.Count}] registered rules that require game patching.");
@@ -35,7 +33,7 @@
                 Logger.Msg($"Patching game with rule type: {ruleType}");
 
                 var traverse = Traverse.Create(ruleType)
-                    .Method("Patch", paramTypes: new[] { typeof(Harmony) }, arguments: new object[] { RulesPatcher });
+                    .Method("Patch", paramTypes: new[] { typeof(Harmony) }, arguments: new object[] { HarmonyInstance });
                 if (!traverse.MethodExists())
                 {
                     Logger.Warning($"Could not find expected Patch method for rule [{ruleType}]. Skipping patching for that rule.");

--- a/HouseRules_Core/CoreMod.cs
+++ b/HouseRules_Core/CoreMod.cs
@@ -11,7 +11,7 @@
         internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("HouseRules:Core");
         private static readonly Harmony RulesPatcher = new Harmony("com.orendain.demeomods.houserules.core.patcher");
 
-        public override void OnApplicationStart()
+        public override void OnInitializeMelon()
         {
             var harmony = new Harmony("com.orendain.demeomods.houserules.core");
             LifecycleDirector.Patch(harmony);
@@ -20,7 +20,7 @@
             HR.Rulebook.Register(Ruleset.None);
         }
 
-        public override void OnApplicationLateStart()
+        public override void OnLateInitializeMelon()
         {
             PatchRegisteredRules();
         }

--- a/HouseRules_Core/LifecycleDirector.cs
+++ b/HouseRules_Core/LifecycleDirector.cs
@@ -207,7 +207,6 @@
             DeactivateRuleset();
         }
 
-
         /// <summary>
         /// Add properties to the room to indicate its modded nature.
         /// </summary>

--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -8,7 +8,7 @@
     {
         internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("HouseRules:Essentials");
 
-        public override void OnApplicationStart()
+        public override void OnInitializeMelon()
         {
             RegisterRuleTypes();
             RegisterRulesets();

--- a/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
@@ -10,7 +10,6 @@
     using HarmonyLib;
     using HouseRules.Types;
 
-
     public sealed class CardAdditionOverriddenRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<AbilityKey>>>,
         IPatchable, IMultiplayerSafe
     {
@@ -80,8 +79,8 @@
                 return;
             }
 
-            Interactable whatIsit = gameContext.pieceAndTurnController.GetInteractableAtPosition(targetTile);
-            if (whatIsit.type == Interactable.Type.PotionStand || whatIsit.type == Interactable.Type.WaterBottleChest || whatIsit.type == Interactable.Type.VortexDustChest)
+            var interactable = gameContext.pieceAndTurnController.GetInteractableAtPosition(targetTile);
+            if (interactable.type == Interactable.Type.PotionStand || interactable.type == Interactable.Type.WaterBottleChest || interactable.type == Interactable.Type.VortexDustChest)
             {
                 _numPlayers = gameContext.pieceAndTurnController.GetNumberOfPlayerPieces();
                 _isSkipped = true;
@@ -141,8 +140,8 @@
                 return;
             }
 
-            int rand = RandomProvider.GetThreadRandom().Next(0, replacementAbilityKeys.Count);
-            AbilityKey replacementAbilityKey = replacementAbilityKeys[rand];
+            var rand = RandomProvider.GetThreadRandom().Next(0, replacementAbilityKeys.Count);
+            var replacementAbilityKey = replacementAbilityKeys[rand];
             Traverse.Create(addCardToPieceEvent).Field<AbilityKey>("card").Value = replacementAbilityKey;
         }
     }

--- a/HouseRules_Essentials/Rules/CardChestAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardChestAdditionOverriddenRule.cs
@@ -15,7 +15,7 @@
     {
         public override string Description => "Card additions from chests are overridden";
 
-        private static Dictionary<BoardPieceId, List<AbilityKey>> _globalchestCards;
+        private static Dictionary<BoardPieceId, List<AbilityKey>> _globalChestCards;
         private static bool _isActivated;
         private static bool _isChest;
         private static int _numPlayers;
@@ -31,7 +31,7 @@
 
         protected override void OnActivate(GameContext gameContext)
         {
-            _globalchestCards = _chestCards;
+            _globalChestCards = _chestCards;
             _isActivated = true;
         }
 
@@ -43,7 +43,7 @@
         private static void Patch(Harmony harmony)
         {
             harmony.Patch(
-                original: AccessTools.Method(typeof(Interactable), "OnInteraction", new Type[] { typeof(int), typeof(IntPoint2D), typeof(GameContext), typeof(int) }),
+                original: AccessTools.Method(typeof(Interactable), "OnInteraction", new[] { typeof(int), typeof(IntPoint2D), typeof(GameContext), typeof(int) }),
                 prefix: new HarmonyMethod(
                     typeof(CardChestAdditionOverriddenRule),
                     nameof(Interactable_OnInteraction_Prefix)));
@@ -134,16 +134,14 @@
                 return;
             }
 
-            if (!_globalchestCards.TryGetValue(piece.boardPieceId, out var replacementAbilityKeys))
+            if (!_globalChestCards.TryGetValue(piece.boardPieceId, out var replacementAbilityKeys))
             {
                 return;
             }
 
-            int rand = RandomProvider.GetThreadRandom().Next(0, replacementAbilityKeys.Count);
-            AbilityKey replacementAbilityKey = replacementAbilityKeys[rand];
+            var rand = RandomProvider.GetThreadRandom().Next(0, replacementAbilityKeys.Count);
+            var replacementAbilityKey = replacementAbilityKeys[rand];
             Traverse.Create(addCardToPieceEvent).Field<AbilityKey>("card").Value = replacementAbilityKey;
-
-            return;
         }
     }
 }

--- a/HouseRules_Essentials/Rules/CardEnergyAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardEnergyAdditionOverriddenRule.cs
@@ -9,7 +9,6 @@
     using HarmonyLib;
     using HouseRules.Types;
 
-
     public sealed class CardEnergyAdditionOverriddenRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<AbilityKey>>>,
         IPatchable, IMultiplayerSafe
     {
@@ -22,14 +21,14 @@
 
         public CardEnergyAdditionOverriddenRule(Dictionary<BoardPieceId, List<AbilityKey>> energyCards)
         {
-            _energyCards= energyCards;
+            _energyCards = energyCards;
         }
 
         public Dictionary<BoardPieceId, List<AbilityKey>> GetConfigObject() => _energyCards;
 
         protected override void OnActivate(GameContext gameContext)
         {
-            _globalEnergyCards= _energyCards;
+            _globalEnergyCards = _energyCards;
             _isActivated = true;
         }
 
@@ -96,8 +95,8 @@
                 return;
             }
 
-            int rand = RandomProvider.GetThreadRandom().Next(0, replacementAbilityKeys.Count);
-            AbilityKey replacementAbilityKey = replacementAbilityKeys[rand];
+            var rand = RandomProvider.GetThreadRandom().Next(0, replacementAbilityKeys.Count);
+            var replacementAbilityKey = replacementAbilityKeys[rand];
             Traverse.Create(addCardToPieceEvent).Field<AbilityKey>("card").Value = replacementAbilityKey;
         }
     }

--- a/HouseRules_Essentials/Rules/EnemyRespawnDisabledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyRespawnDisabledRule.cs
@@ -32,12 +32,7 @@
 
         private static bool AIDirectorController2_DynamicSpawning_Prefix()
         {
-            if (!_isActivated)
-            {
-                return true;
-            }
-
-            return false;
+            return !_isActivated;
         }
     }
 }

--- a/HouseRules_Essentials/Rules/GoldPickedUpMultipliedRule.cs
+++ b/HouseRules_Essentials/Rules/GoldPickedUpMultipliedRule.cs
@@ -35,7 +35,7 @@
             harmony.Patch(
                 original: AccessTools.Constructor(
                     typeof(SerializableEventPickup),
-                    new[] {typeof(int), typeof(IntPoint2D), typeof(bool)}),
+                    new[] { typeof(int), typeof(IntPoint2D), typeof(bool) }),
                 postfix: new HarmonyMethod(
                     typeof(GoldPickedUpMultipliedRule),
                     nameof(SerializableEventPickup_Constructor_Postfix)));
@@ -48,7 +48,7 @@
                 return;
             }
 
-            __instance.goldAmount = (int) (__instance.goldAmount * _globalMultiplier);
+            __instance.goldAmount = (int)(__instance.goldAmount * _globalMultiplier);
         }
     }
 }

--- a/HouseRules_Essentials/Rules/MonsterDeckOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/MonsterDeckOverriddenRule.cs
@@ -79,7 +79,7 @@
                 }
 
                 mySubDeck.Add(deckItem);
-                for (int i = 0; i < deckItemConfig.Value - 1; i++)
+                for (var i = 0; i < deckItemConfig.Value - 1; i++)
                 {
                     mySubDeck.Add(deckItem);
                 }
@@ -137,7 +137,7 @@
             SpawnZone spawnZone2 = null;
             List<SpawnZone> list;
             list = context.spawnZoneModel.GetZonesWithTag(tag);
-            for (int i = list.Count - 1; i >= 0; i--)
+            for (var i = list.Count - 1; i >= 0; i--)
             {
                 SpawnZone spawnZone3 = list[i];
                 if (spawnZone3.GetAllFreeTiles(ref boardState).Count == 0)
@@ -150,8 +150,8 @@
             IntPoint2D intPoint2D = IntPoint2D.Invalid;
             IntPoint2D keyHolderPosition = IntPoint2D.Invalid;
 
-            int num = 0;
-            for (int j = 0; j < list.Count; j++)
+            var num = 0;
+            for (var j = 0; j < list.Count; j++)
             {
                 SpawnZone spawnZone4 = list[j];
                 if (spawnZone4.NumStepsToExit >= AIDirectorConfig.KeyHolderMinDistanceToExit && spawnZone4.NumStepsToExit <= AIDirectorConfig.KeyHolderMaxDistanceToExit && spawnZone4.numStepsToEntrance >= AIDirectorConfig.KeyHolderMinDistanceToEntrance)

--- a/HouseRules_Essentials/Rules/PartyElectricityDamageOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PartyElectricityDamageOverriddenRule.cs
@@ -13,7 +13,6 @@
     {
         public override string Description => "Player on player electricity damage is zero.";
 
-        private static bool _globalAdjustments;
         private static bool _isActivated;
 
         private readonly bool _adjustments;
@@ -27,7 +26,6 @@
 
         protected override void OnActivate(GameContext gameContext)
         {
-            _globalAdjustments = _adjustments;
             _isActivated = true;
         }
 
@@ -35,7 +33,6 @@
 
         private static void Patch(Harmony harmony)
         {
-
             harmony.Patch(
                 original: AccessTools.Method(typeof(ProjectileHitSequence), "OnStarted"),
                 prefix: new HarmonyMethod(

--- a/HouseRules_Essentials/Rules/PetsFocusHunterMarkRule.cs
+++ b/HouseRules_Essentials/Rules/PetsFocusHunterMarkRule.cs
@@ -54,9 +54,6 @@
                 return true;
             }
 
-            var attackTargetType = Traverse.Create(__instance)
-                .Method("GetAttackTargetType", __instance.piece)
-                .GetValue<PieceType>();
             if (!__instance.piece.HasPieceType(PieceType.Bot) && !__instance.piece.IsConfused())
             {
                 return true;

--- a/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
@@ -44,7 +44,7 @@
         private static Dictionary<BoardPieceId, List<PieceType>> ReplaceExistingProperties(
             Dictionary<BoardPieceId, List<PieceType>> pieceConfigChanges)
         {
-            var gameContext = Traverse.Create(typeof(GameHub)).Field<GameContext>("gameContext").Value; 
+            var gameContext = Traverse.Create(typeof(GameHub)).Field<GameContext>("gameContext").Value;
             var previousProperties = new Dictionary<BoardPieceId, List<PieceType>>();
 
             foreach (var item in pieceConfigChanges)

--- a/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
@@ -3,7 +3,6 @@
     using System.Collections.Generic;
     using System.Linq;
     using Boardgame;
-    using Data.GameData;
     using DataKeys;
     using HarmonyLib;
     using HouseRules.Types;

--- a/HouseRules_Essentials/Rules/RoundCountLimitedRule.cs
+++ b/HouseRules_Essentials/Rules/RoundCountLimitedRule.cs
@@ -45,7 +45,6 @@
                     nameof(SerializableEventQueue_RespondToRequest_Postfix)));
         }
 
-
         private static void GameStartup_InitializeGame_Postfix(GameStartup __instance)
         {
             var gameContext = Traverse.Create(__instance).Field<GameContext>("gameContext").Value;
@@ -77,10 +76,7 @@
 
                 EssentialsMod.Logger.Msg("EVERYONE DIES NOW!");
                 _gameContext.serializableEventQueue.SendResponseEvent(new SerializableEventEndGame());
-                return;
             }
-
-            return;
         }
 
         private static void ShowRoundsLeft()

--- a/HouseRules_Essentials/Rules/SpawnCategoryOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/SpawnCategoryOverriddenRule.cs
@@ -2,7 +2,6 @@
 {
     using System.Collections.Generic;
     using Boardgame;
-    using Data.GameData;
     using DataKeys;
     using HarmonyLib;
     using HouseRules.Types;
@@ -18,7 +17,7 @@
         /// Initializes a new instance of the <see cref="SpawnCategoryOverriddenRule"/> class.
         /// </summary>
         /// <param name="adjustments">Accepts a Dictionary of BoardPieceIDs and Int settings
-        /// for MaxPerDe</param>
+        /// for MaxPerDeck.</param>
         public SpawnCategoryOverriddenRule(Dictionary<BoardPieceId, List<int>> adjustments)
         {
             _adjustments = adjustments;

--- a/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
+++ b/HouseRules_Essentials/Rulesets/ItsATrapRuleset.cs
@@ -349,7 +349,7 @@
                 },
             });
 
-            var tileEffectDuration = new TileEffectDurationOverriddenRule(new Dictionary<Boardgame.Board.TileEffect, int>
+            var tileEffectDuration = new TileEffectDurationOverriddenRule(new Dictionary<TileEffect, int>
             {
                 { TileEffect.Gas, 10 },
                 { TileEffect.Acid, 1 },

--- a/RoomCode/README.md
+++ b/RoomCode/README.md
@@ -22,7 +22,7 @@ If none of the room codes are available, the mod will fall back to Demeo's
 random room code generation.
 
 **Example configuration:**
-```toml[ModPatcher.cs](ModPatcher.cs)
+```toml
 [RoomCode]
 enabled = true
 codes = ["8888", "7777", "1234"]

--- a/RoomCode/README.md
+++ b/RoomCode/README.md
@@ -22,7 +22,7 @@ If none of the room codes are available, the mod will fall back to Demeo's
 random room code generation.
 
 **Example configuration:**
-```toml
+```toml[ModPatcher.cs](ModPatcher.cs)
 [RoomCode]
 enabled = true
 codes = ["8888", "7777", "1234"]

--- a/RoomCode/RoomCodeMod.cs
+++ b/RoomCode/RoomCodeMod.cs
@@ -13,9 +13,7 @@
 
         public override void OnInitializeMelon()
         {
-            var harmony = new HarmonyLib.Harmony("com.orendain.demeomods.roomcode");
-            ModPatcher.Patch(harmony);
-
+            ModPatcher.Patch(HarmonyInstance);
             InitializeConfiguration();
         }
 

--- a/RoomCode/RoomCodeMod.cs
+++ b/RoomCode/RoomCodeMod.cs
@@ -11,7 +11,7 @@
 
         internal static List<string> RoomCodes { get; private set; }
 
-        public override void OnApplicationStart()
+        public override void OnInitializeMelon()
         {
             var harmony = new HarmonyLib.Harmony("com.orendain.demeomods.roomcode");
             ModPatcher.Patch(harmony);

--- a/RoomFinder/RoomFinderMod.cs
+++ b/RoomFinder/RoomFinderMod.cs
@@ -1,7 +1,6 @@
 ﻿namespace RoomFinder
 {
     using Common;
-    using HarmonyLib;
     using MelonLoader;
     using RoomFinder.UI;
     using UnityEngine;
@@ -16,9 +15,8 @@
 
         public override void OnInitializeMelon()
         {
-            var harmony = new Harmony("com.orendain.demeomods.roomfinder");
-            Patcher.Patch(harmony);
-            CommonModule.Initialize();
+            Patcher.Patch(HarmonyInstance);
+            CommonModule.Initialize(HarmonyInstance);
         }
 
         public override void OnSceneWasInitialized(int buildIndex, string sceneName)

--- a/RoomFinder/RoomFinderMod.cs
+++ b/RoomFinder/RoomFinderMod.cs
@@ -14,7 +14,7 @@
         internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("RoomFinder");
         internal static readonly SharedState SharedState = SharedState.NewInstance();
 
-        public override void OnApplicationStart()
+        public override void OnInitializeMelon()
         {
             var harmony = new Harmony("com.orendain.demeomods.roomfinder");
             Patcher.Patch(harmony);

--- a/RoomFinder/RoomFinderMod.cs
+++ b/RoomFinder/RoomFinderMod.cs
@@ -7,7 +7,6 @@
 
     internal class RoomFinderMod : MelonMod
     {
-        private const string DemeoPCEditionString = "Demeo PC Edition";
         private const int LobbySceneIndex = 1;
 
         internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("RoomFinder");
@@ -22,8 +21,8 @@
         public override void OnSceneWasInitialized(int buildIndex, string sceneName)
         {
             if (MotherbrainGlobalVars.IsRunningOnNonVRPlatform)
-                {
-                    if (buildIndex != LobbySceneIndex)
+            {
+                if (buildIndex != LobbySceneIndex)
                 {
                     return;
                 }

--- a/SkipIntro/SkipIntroMod.cs
+++ b/SkipIntro/SkipIntroMod.cs
@@ -6,7 +6,7 @@
     {
         internal static readonly MelonLogger.Instance Logger = new MelonLogger.Instance("SkipIntro");
 
-        public override void OnApplicationStart()
+        public override void OnInitializeMelon()
         {
             var harmony = new HarmonyLib.Harmony("com.orendain.demeomods.skipintro");
             ModPatcher.Patch(harmony);

--- a/SkipIntro/SkipIntroMod.cs
+++ b/SkipIntro/SkipIntroMod.cs
@@ -8,8 +8,7 @@
 
         public override void OnInitializeMelon()
         {
-            var harmony = new HarmonyLib.Harmony("com.orendain.demeomods.skipintro");
-            ModPatcher.Patch(harmony);
+            ModPatcher.Patch(HarmonyInstance);
         }
     }
 }


### PR DESCRIPTION
Hopefully the size of this PR is not too overwhelming to review.  Can split up the PR is it is.  There is no change in functionality in this PR, it is simply a maintenance and cleanup pass.

Changes:
- Replace deprecated/obsolete MelonLoader methods with preferred ones (e.g., `OnApplicationStart` -> `OnInitializeMelon`).
- Use MelonLoader-provided Harmony instance instead of creating new instacnes of them.
- Fix formatting.
- Remove unused imports.
- Use `var` style declaration instead of explicit types.
- Remove redundant code.
- Fixed some capitilization.
- Reduced nesting by restructuring some condition flows.  Specifically, by [using guard clauses](https://refactoring.guru/replace-nested-conditional-with-guard-clauses).
- Update MelonLoader dependencies in the GitHub workflows.