### PR TITLE
Fix `LevelExitLockedUntilAllEnemiesDefeatedRule` not correctly unlocking door when all enemies were defeated.

### DIFF
--- a/HouseRules_Essentials/Rules/LevelExitLockedUntilAllEnemiesDefeatedRule.cs
+++ b/HouseRules_Essentials/Rules/LevelExitLockedUntilAllEnemiesDefeatedRule.cs
@@ -37,7 +37,10 @@
             harmony.Patch(
                 original: AccessTools.Constructor(
                     typeof(BoardgameActionPieceDied),
-                    new[] { typeof(GameContext), typeof(int[]), typeof(bool), typeof(bool), typeof(int) }),
+                    new[]
+                    {
+                        typeof(GameContext), typeof(int[]), typeof(bool), typeof(bool), typeof(bool), typeof(int),
+                    }),
                 postfix: new HarmonyMethod(
                     typeof(LevelExitLockedUntilAllEnemiesDefeatedRule),
                     nameof(BoardgameActionPieceDied_Constructor_Postfix)));


### PR DESCRIPTION
Resolves #465.

Issue was that Demeo's `BoardgameActionPieceDied.cs` has changed its contructor's signature, and our `LevelExitLockedUntilAllEnemiesDefeatedRule` rule had an outdated reference.