### PR TITLE
In game rules list UI

### DIFF
--- a/Common/UI/Element/HangoutsElementCreator.cs
+++ b/Common/UI/Element/HangoutsElementCreator.cs
@@ -1,6 +1,7 @@
 ﻿namespace Common.UI.Element
 {
     using System;
+    using System.Text;
     using Bowser.Interaction;
     using Bowser.Legacy;
     using UnityEngine;
@@ -44,6 +45,16 @@
             return VrElementCreator.IsReady();
         }
 
+        public GameObject CreateLeftText(string text)
+        {
+            return CreateListText(text);
+        }
+
+        public GameObject CreateNewText(string text)
+        {
+            return _elementCreator.CreateMyText(text);
+        }
+
         public GameObject CreateNormalText(string text)
         {
             return _elementCreator.CreateNormalText(text);
@@ -62,6 +73,16 @@
         public GameObject CreateText(string text, Color color, int fontSize)
         {
             return _elementCreator.CreateText(text, color, fontSize);
+        }
+
+        public GameObject CreateMyText(string text)
+        {
+            return _elementCreator.CreateMyText(text);
+        }
+
+        public GameObject CreateListText(string text)
+        {
+            return _elementCreator.CreateListText(text);
         }
 
         public GameObject CreateButton(Action callback)

--- a/Common/UI/Element/IElementCreator.cs
+++ b/Common/UI/Element/IElementCreator.cs
@@ -1,10 +1,21 @@
 ﻿namespace Common.UI.Element
 {
     using System;
+    using System.Text;
     using UnityEngine;
 
     public interface IElementCreator
     {
+        /// <summary>
+        /// Creates a details text element.
+        /// </summary>
+        GameObject CreateLeftText(string text);
+
+        /// <summary>
+        /// Creates a details text element.
+        /// </summary>
+        GameObject CreateNewText(string text);
+
         /// <summary>
         /// Creates a normal text element.
         /// </summary>
@@ -24,6 +35,16 @@
         /// Creates a generic text element.
         /// </summary>
         GameObject CreateText(string text, Color color, int fontSize);
+
+        /// <summary>
+        /// Creates a my stringbuilder element.
+        /// </summary>
+        GameObject CreateMyText(string text);
+
+        /// <summary>
+        /// Creates a my stringbuilder element.
+        /// </summary>
+        GameObject CreateListText(string text);
 
         /// <summary>
         /// Creates a button with the specified callback.

--- a/Common/UI/Element/NonVrElementCreator.cs
+++ b/Common/UI/Element/NonVrElementCreator.cs
@@ -1,6 +1,7 @@
 ﻿namespace Common.UI.Element
 {
     using System;
+    using System.Text;
     using Boardgame.NonVR.Ui;
     using TMPro;
     using UnityEngine;
@@ -49,6 +50,16 @@
             return NonVrResourceTable.IsReady();
         }
 
+        public GameObject CreateLeftText(string text)
+        {
+            return CreateListText(text);
+        }
+
+        public GameObject CreateNewText(string text)
+        {
+            return CreateMyText(text);
+        }
+
         public GameObject CreateNormalText(string text)
         {
             return CreateText(text, ColorBrown, fontSize: NormalFontSize);
@@ -75,6 +86,42 @@
             textComponent.fontSize = fontSize;
             textComponent.fontSizeMax = fontSize;
             textComponent.fontSizeMin = 1;
+            textComponent.text = text;
+
+            container.GetComponent<Graphic>().raycastTarget = false;
+
+            return container;
+        }
+
+        public GameObject CreateMyText(string text)
+        {
+            var container = new GameObject("Text");
+
+            var textComponent = container.AddComponent<TextMeshPro>();
+            textComponent.alignment = TextAlignmentOptions.Center;
+            textComponent.enableAutoSizing = true;
+            textComponent.fontSize = NormalFontSize;
+            textComponent.fontSizeMax = NormalFontSize;
+            textComponent.fontSizeMin = 1;
+            textComponent.fontStyle = FontStyles.Normal;
+            textComponent.text = text;
+
+            container.GetComponent<Graphic>().raycastTarget = false;
+
+            return container;
+        }
+
+        public GameObject CreateListText(string text)
+        {
+            var container = new GameObject("Text");
+
+            var textComponent = container.AddComponent<TextMeshPro>();
+            textComponent.alignment = TextAlignmentOptions.Left;
+            textComponent.enableAutoSizing = false;
+            textComponent.fontSize = 6;
+            textComponent.fontSizeMax = 6;
+            textComponent.fontSizeMin = 5;
+            textComponent.fontStyle = FontStyles.Normal;
             textComponent.text = text;
 
             container.GetComponent<Graphic>().raycastTarget = false;

--- a/Common/UI/Element/VrElementCreator.cs
+++ b/Common/UI/Element/VrElementCreator.cs
@@ -1,6 +1,7 @@
 ﻿namespace Common.UI.Element
 {
     using System;
+    using System.Text;
     using TMPro;
     using UnityEngine;
 
@@ -51,6 +52,16 @@
             return VrResourceTable.IsReady();
         }
 
+        public GameObject CreateLeftText(string text)
+        {
+            return CreateListText(text);
+        }
+
+        public GameObject CreateNewText(string text)
+        {
+            return CreateMyText(text);
+        }
+
         public GameObject CreateNormalText(string text)
         {
             return CreateText(text, ColorBrown, fontSize: NormalFontSize);
@@ -63,7 +74,7 @@
 
         public GameObject CreateMenuHeaderText(string text)
         {
-            return CreateText(text, ColorBeige, fontSize: HeaderFontSize);
+            return CreateText(text, Color.cyan, fontSize: HeaderFontSize);
         }
 
         /// <summary>
@@ -92,6 +103,44 @@
             textComponent.fontSize = fontSize;
             textComponent.fontSizeMax = fontSize;
             textComponent.fontSizeMin = 1;
+            textComponent.fontStyle = FontStyles.Normal;
+            textComponent.text = text;
+            textComponent.transform.localPosition = new Vector3(0, 0, TextZShift);
+
+            return container;
+        }
+
+        public GameObject CreateMyText(string text)
+        {
+            var container = new GameObject("Text");
+
+            var textComponent = container.AddComponent<TextMeshPro>();
+            textComponent.alignment = TextAlignmentOptions.Center;
+            textComponent.colorGradientPreset = _resourceTable.FontColorGradient;
+            textComponent.enableAutoSizing = true;
+            textComponent.font = _resourceTable.Font;
+            textComponent.fontSize = 6;
+            textComponent.fontSizeMax = 6;
+            textComponent.fontSizeMin = 5;
+            textComponent.fontStyle = FontStyles.Bold;
+            textComponent.text = text;
+            textComponent.transform.localPosition = new Vector3(0, 0, TextZShift);
+
+            return container;
+        }
+
+        public GameObject CreateListText(string text)
+        {
+            var container = new GameObject("Text");
+
+            var textComponent = container.AddComponent<TextMeshPro>();
+            textComponent.alignment = TextAlignmentOptions.Left;
+            textComponent.colorGradientPreset = _resourceTable.FontColorGradient;
+            textComponent.enableAutoSizing = false;
+            textComponent.font = _resourceTable.Font;
+            textComponent.fontSize = 6;
+            textComponent.fontSizeMax = 6;
+            textComponent.fontSizeMin = 5;
             textComponent.fontStyle = FontStyles.Normal;
             textComponent.text = text;
             textComponent.transform.localPosition = new Vector3(0, 0, TextZShift);

--- a/HouseRules_Configuration/HouseRules_Configuration.csproj
+++ b/HouseRules_Configuration/HouseRules_Configuration.csproj
@@ -76,6 +76,7 @@
     <Compile Include="..\Common\**\*.cs" Exclude="..\Common\Properties\AssemblyInfo.cs;..\Common\bin\**\*.*;..\Common\obj\**\*.*;..\Common\**\*.csproj;..\Common\**\*.user;..\Common\**\*.vstemplate">
       <Link>Common\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </Compile>
+    <Compile Include="UI\HouseRulesUiGameVr.cs" />
     <Compile Include="UI\HouseRulesUiHangouts.cs" />
     <Compile Include="UI\HouseRulesUiNonVr.cs" />
     <Compile Include="UI\HouseRulesUiVr.cs" />

--- a/HouseRules_Configuration/UI/HouseRulesUiGameVr.cs
+++ b/HouseRules_Configuration/UI/HouseRulesUiGameVr.cs
@@ -1,0 +1,176 @@
+﻿namespace HouseRules.Configuration.UI
+{
+    using System;
+    using System.Collections;
+    using System.Linq;
+    using System.Text;
+    using Common.UI;
+    using Common.UI.Element;
+    using UnityEngine;
+
+    internal class HouseRulesUiGameVr : MonoBehaviour
+    {
+        private VrResourceTable _resourceTable;
+        private IElementCreator _elementCreator;
+        private Transform _anchor;
+
+        private void Start()
+        {
+            StartCoroutine(WaitAndInitialize());
+        }
+
+        private IEnumerator WaitAndInitialize()
+        {
+            while (!VrElementCreator.IsReady()
+                   || Resources
+                       .FindObjectsOfTypeAll<GameObject>()
+                       .Count(x => x.name == "~LeanTween") < 1)
+            {
+                ConfigurationMod.Logger.Msg("UI dependencies not yet ready. Waiting...");
+                yield return new WaitForSecondsRealtime(1);
+            }
+
+            ConfigurationMod.Logger.Msg("UI dependencies ready. Proceeding with initialization.");
+
+            _resourceTable = VrResourceTable.Instance();
+            _elementCreator = VrElementCreator.Instance();
+            _anchor = Resources
+                .FindObjectsOfTypeAll<GameObject>()
+                .First(x => x.name == "~LeanTween").transform;
+
+            Initialize();
+            ConfigurationMod.Logger.Msg("Initialization complete.");
+        }
+
+        private void Initialize()
+        {
+            transform.SetParent(_anchor, worldPositionStays: true);
+            transform.position = new Vector3(35.6f, 36.4f, -32.2f);
+
+            gameObject.AddComponent<FaceLocalPlayer>();
+
+            var background = new GameObject("Background");
+            var numRules = HR.SelectedRuleset.Rules.Count;
+            var scale = 1.5f;
+            background.AddComponent<MeshFilter>().mesh = _resourceTable.MenuMesh;
+            background.AddComponent<MeshRenderer>().material = _resourceTable.MenuMaterial;
+            background.transform.SetParent(transform, worldPositionStays: false);
+            background.transform.localPosition = new Vector3(0, 0, 0);
+            background.transform.localRotation =
+                Quaternion.Euler(-90, 0, 0); // Un-flip card from it's default face-up position.
+            if (numRules > 11)
+            {
+                scale = 1.5f + (float)(0.09 * (numRules - 11));
+            }
+
+            background.transform.localScale = new Vector3(4.75f, 1, scale);
+
+            var header = 3.6f;
+            var headerText = _elementCreator.CreateMenuHeaderText("HouseRules");
+            headerText.transform.SetParent(transform, worldPositionStays: false);
+            if (numRules > 11)
+            {
+                header = 3.6f + (float)(0.21f * (numRules - 11));
+            }
+
+            headerText.transform.localPosition = new Vector3(0, header, VrElementCreator.TextZShift);
+            Color indigo = new Color(0.294f, 0f, 0.51f);
+            Color brown = new Color(0.0392f, 0.0157f, 0, 1);
+            var sb = new StringBuilder();
+            sb.Append(ColorizeString("You're playing ", brown));
+            sb.Append(ColorizeString($"<u>{HR.SelectedRuleset.Name}</u>", indigo));
+            sb.AppendLine(ColorizeString(" ruleset!", brown));
+            sb.AppendLine(ColorizeString($"<i>{HR.SelectedRuleset.Description}</i>", Color.blue));
+            sb.AppendLine();
+            var ruleset = 1.25f;
+            var drift = 1.25f;
+            var rulesetPanel = _elementCreator.CreateNewText(sb.ToString());
+            rulesetPanel.transform.SetParent(transform, worldPositionStays: false);
+            if (numRules > 40)
+            {
+                drift = 1.25f - (float)(0.035f * (numRules - 20));
+            }
+            else if (numRules > 20)
+            {
+                drift = 1.25f - (float)(0.045f * (numRules - 20));
+            }
+
+            if (numRules > 11)
+            {
+                ruleset = drift + (float)(0.2f * (numRules - 11));
+            }
+
+            rulesetPanel.transform.localPosition = new Vector3(0, ruleset, VrElementCreator.TextZShift);
+
+            sb.Clear();
+            int total = 0;
+            sb.AppendLine();
+            if (numRules > 1)
+            {
+                sb.AppendLine(ColorizeString($"<========== {numRules} Active Rules ==========>", Color.magenta));
+            }
+            else
+            {
+                sb.AppendLine(ColorizeString($"<========== 1 Active Rule ==========>", Color.magenta));
+            }
+
+            foreach (var rule in HR.SelectedRuleset.Rules)
+            {
+                try
+                {
+                    var description = HR.SelectedRuleset.Rules[total].Description;
+                    sb.AppendLine(ColorizeString($"- {description}", Color.black));
+                    total++;
+                }
+                catch (Exception e)
+                {
+                    // TODO(orendain): Consider rolling back or disable rule.
+                    ConfigurationMod.Logger.Warning($"Failed to successfully call on rule [{rule.GetType()}]: {e}");
+                }
+            }
+
+            var center = -2f + (float)(numRules * .05);
+            var details = center - (float)(0.245 * numRules);
+            var detailsPanel = _elementCreator.CreateLeftText(sb.ToString());
+            detailsPanel.transform.SetParent(transform, worldPositionStays: false);
+
+            detailsPanel.transform.localPosition = new Vector3(0, details, VrElementCreator.TextZShift);
+
+            sb.Clear();
+            sb.Append(ColorizeString($"v{BuildVersion.Version}", Color.yellow));
+            var version = -9.5f;
+            var versionText = _elementCreator.CreateNormalText(sb.ToString());
+            versionText.transform.SetParent(transform, worldPositionStays: false);
+            if (numRules > 11)
+            {
+                version = -9.5f - (float)(0.58 * (numRules - 11));
+            }
+
+            versionText.transform.localPosition = new Vector3(-7, version, VrElementCreator.TextZShift);
+
+            if (ConfigurationMod.IsUpdateAvailable)
+            {
+                sb.Clear();
+                sb.Append(ColorizeString("NEW UPDATE AVAILABLE", Color.green));
+                var updateText = _elementCreator.CreateNormalText(sb.ToString());
+                updateText.transform.SetParent(transform, worldPositionStays: false);
+                updateText.transform.localPosition = new Vector3(5.75f, version, VrElementCreator.TextZShift);
+            }
+
+            // TODO(orendain): Fix so that ray interacts with entire object.
+            gameObject.AddComponent<BoxCollider>();
+        }
+
+        private static string ColorizeString(string text, Color color)
+        {
+            return string.Concat(new string[]
+            {
+        "<color=#",
+        ColorUtility.ToHtmlStringRGB(color),
+        ">",
+        text,
+        "</color>",
+            });
+        }
+    }
+}

--- a/HouseRules_Configuration/UI/HouseRulesUiGameVr.cs
+++ b/HouseRules_Configuration/UI/HouseRulesUiGameVr.cs
@@ -107,11 +107,11 @@
             sb.AppendLine();
             if (numRules > 1)
             {
-                sb.AppendLine(ColorizeString($"<========== {numRules} Active Rules ==========>", Color.magenta));
+                sb.AppendLine(ColorizeString($"<========== {numRules} Active Rules ==========>", Color.white));
             }
             else
             {
-                sb.AppendLine(ColorizeString($"<========== 1 Active Rule ==========>", Color.magenta));
+                sb.AppendLine(ColorizeString($"<========== 1 Active Rule ==========>", Color.white));
             }
 
             foreach (var rule in HR.SelectedRuleset.Rules)

--- a/HouseRules_Core/LifecycleDirector.cs
+++ b/HouseRules_Core/LifecycleDirector.cs
@@ -9,10 +9,11 @@
     using HarmonyLib;
     using HouseRules.Types;
     using Photon.Realtime;
+    using UnityEngine;
 
     internal static class LifecycleDirector
     {
-        private const float WelcomeMessageDurationSeconds = 30f;
+        private const float WelcomeMessageDurationSeconds = 10f;
         private const string ModdedRoomPropertyKey = "modded";
 
         private static GameContext _gameContext;
@@ -359,7 +360,7 @@
 
             if (!IsRulesetActive)
             {
-                GameUI.ShowCameraMessage(NotSafeForMultiplayerMessage(), WelcomeMessageDurationSeconds);
+                GameUI.ShowCameraMessage(NotSafeForMultiplayerMessage(), 30);
                 return;
             }
 
@@ -368,29 +369,70 @@
 
         private static string NotSafeForMultiplayerMessage()
         {
+            Color orange = new Color(1f, 0.499f, 0f);
             return new StringBuilder()
-                .AppendLine("Attention:")
-                .AppendLine("The HouseRules ruleset you selected is not safe for multiplayer games, and was not activated.")
+                .Append(ColorizeString("*** ", orange))
+                .Append(ColorizeString("ATTENTION", Color.red))
+                .AppendLine(ColorizeString(" ***", orange))
+                .AppendLine()
+                .AppendLine(ColorizeString("The HouseRules ruleset you selected is", Color.yellow))
+                .Append(ColorizeString("not safe", Color.cyan))
+                .AppendLine(ColorizeString(" for multiplayer games!", Color.yellow))
+                .AppendLine()
+                .Append(ColorizeString("The ruleset was ", Color.yellow))
+                .Append(ColorizeString("NOT", Color.white))
+                .AppendLine(ColorizeString(" activated!", Color.yellow))
                 .ToString();
         }
 
         private static string RulesetActiveMessage()
         {
+            Color violet = new Color(0.8f, 0f, 0.8f);
+            Color lightblue = new Color(0f, 0.75f, 1f);
+            Color orange = new Color(1f, 0.499f, 0f);
             var sb = new StringBuilder();
-            sb.AppendLine("Welcome to a game using HouseRules!");
-            sb.AppendLine();
-            sb.AppendLine($"{HR.SelectedRuleset.Name}:");
-            sb.AppendLine(HR.SelectedRuleset.Description);
-            sb.AppendLine();
-            sb.AppendLine("Rules:");
+            sb.AppendLine(ColorizeString("Welcome to a game using", Color.cyan));
+            sb.Append(ColorizeString("H", violet));
+            sb.Append(ColorizeString("o", lightblue));
+            sb.Append(ColorizeString("u", Color.green));
+            sb.Append(ColorizeString("s", Color.yellow));
+            sb.Append(ColorizeString("e", orange));
+            sb.Append(ColorizeString("-", Color.red));
+            sb.Append(ColorizeString("R", orange));
+            sb.Append(ColorizeString("u", Color.yellow));
+            sb.Append(ColorizeString("l", Color.green));
+            sb.Append(ColorizeString("e", lightblue));
+            sb.AppendLine(ColorizeString("s", violet));
 
-            for (var i = 0; i < HR.SelectedRuleset.Rules.Count; i++)
-            {
-                var description = HR.SelectedRuleset.Rules[i].Description;
-                sb.AppendLine($"{i + 1}. {description}");
-            }
+            // Pad lines to raise text higher on PC-Edition screen
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine();
+            sb.AppendLine();
 
             return sb.ToString();
+        }
+
+        private static string ColorizeString(string text, Color color)
+        {
+            return string.Concat(new string[]
+            {
+        "<color=#",
+        ColorUtility.ToHtmlStringRGB(color),
+        ">",
+        text,
+        "</color>",
+            });
         }
     }
 }

--- a/HouseRules_Core/LifecycleDirector.cs
+++ b/HouseRules_Core/LifecycleDirector.cs
@@ -13,9 +13,9 @@
 
     internal static class LifecycleDirector
     {
-        private const float WelcomeMessageDurationSeconds = 10f;
         private const string ModdedRoomPropertyKey = "modded";
 
+        private static float welcomeMessageDurationSeconds = 20f;
         private static GameContext _gameContext;
         private static bool _isCreatingGame;
         private static bool _isLoadingGame;
@@ -364,7 +364,7 @@
                 return;
             }
 
-            GameUI.ShowCameraMessage(RulesetActiveMessage(), WelcomeMessageDurationSeconds);
+            GameUI.ShowCameraMessage(RulesetActiveMessage(), welcomeMessageDurationSeconds);
         }
 
         private static string NotSafeForMultiplayerMessage()
@@ -390,6 +390,7 @@
             Color violet = new Color(0.8f, 0f, 0.8f);
             Color lightblue = new Color(0f, 0.75f, 1f);
             Color orange = new Color(1f, 0.499f, 0f);
+            Color gold = new Color(1f, 1f, 0.6f);
             var sb = new StringBuilder();
             sb.AppendLine(ColorizeString("Welcome to a game using", Color.cyan));
             sb.Append(ColorizeString("H", violet));
@@ -403,6 +404,24 @@
             sb.Append(ColorizeString("l", Color.green));
             sb.Append(ColorizeString("e", lightblue));
             sb.AppendLine(ColorizeString("s", violet));
+
+            if (MotherbrainGlobalVars.IsRunningOnNonVRPlatform)
+            {
+                sb.AppendLine();
+                sb.AppendLine(ColorizeString($"{HR.SelectedRuleset.Name}:", Color.yellow));
+                sb.AppendLine(ColorizeString(HR.SelectedRuleset.Description, Color.white));
+                sb.AppendLine();
+
+                for (var i = 0; i < HR.SelectedRuleset.Rules.Count; i++)
+                {
+                    var description = HR.SelectedRuleset.Rules[i].Description;
+                    sb.AppendLine(ColorizeString($"{i + 1}. {description}", gold));
+                }
+            }
+            else
+            {
+                welcomeMessageDurationSeconds = 10f;
+            }
 
             // Pad lines to raise text higher on PC-Edition screen
             sb.AppendLine();

--- a/HouseRules_Essentials/Rules/AbilityActionCostAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityActionCostAdjustedRule.cs
@@ -10,7 +10,7 @@
     public sealed class AbilityActionCostAdjustedRule : Rule, IConfigWritable<Dictionary<AbilityKey, bool>>,
         IMultiplayerSafe
     {
-        public override string Description => "Ability AP costs are adjusted";
+        public override string Description => "Hero ability Action Point costs are adjusted";
 
         private readonly Dictionary<AbilityKey, bool> _adjustments;
         private Dictionary<AbilityKey, bool> _originals;

--- a/HouseRules_Essentials/Rules/AbilityBackstabAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityBackstabAdjustedRule.cs
@@ -10,7 +10,7 @@
     public sealed class AbilityBackstabAdjustedRule : Rule, IConfigWritable<Dictionary<AbilityKey, bool>>,
         IMultiplayerSafe
     {
-        public override string Description => "Ability backstab enablement is adjusted";
+        public override string Description => "Hero ability backstab bonus damage is adjusted";
 
         private readonly Dictionary<AbilityKey, bool> _adjustments;
         private Dictionary<AbilityKey, bool> _originals;

--- a/HouseRules_Essentials/Rules/AbilityDamageOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityDamageOverriddenRule.cs
@@ -9,7 +9,7 @@
 
     public sealed class AbilityDamageOverriddenRule : Rule, IConfigWritable<Dictionary<AbilityKey, List<int>>>, IMultiplayerSafe
     {
-        public override string Description => "Ability damage values are overridden";
+        public override string Description => "Ability damage is adjusted";
 
         private readonly Dictionary<AbilityKey, List<int>> _adjustments;
         private Dictionary<AbilityKey, List<int>> _originals;

--- a/HouseRules_Essentials/Rules/AbilityHealOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityHealOverriddenRule.cs
@@ -10,7 +10,7 @@
 
     public sealed class AbilityHealOverriddenRule : Rule, IConfigWritable<Dictionary<AbilityKey, int>>, IMultiplayerSafe
     {
-        public override string Description => "Ability Heal settings are adjusted";
+        public override string Description => "Ability Heal amounts are adjusted";
 
         private readonly Dictionary<AbilityKey, int> _adjustments;
         private Dictionary<AbilityKey, int> _originals;

--- a/HouseRules_Essentials/Rules/AbilityRandomPieceListRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityRandomPieceListRule.cs
@@ -10,7 +10,7 @@
 
     public sealed class AbilityRandomPieceListRule : Rule, IConfigWritable<Dictionary<AbilityKey, List<BoardPieceId>>>
     {
-        public override string Description => "Ability randomPieceLists are replaced";
+        public override string Description => "Ability random summons are replaced (Skirmish Only)";
 
         private readonly Dictionary<AbilityKey, List<BoardPieceId>> _adjustments;
         private Dictionary<AbilityKey, List<BoardPieceId>> _originals;

--- a/HouseRules_Essentials/Rules/AbilityStealthDamageOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/AbilityStealthDamageOverriddenRule.cs
@@ -9,7 +9,7 @@
 
     public sealed class AbilityStealthDamageOverriddenRule : Rule, IConfigWritable<Dictionary<AbilityKey, int>>, IMultiplayerSafe
     {
-        public override string Description => "Ability stealth bonus damage values are overridden";
+        public override string Description => "Ability stealth bonus damage values are adjusted";
 
         private readonly Dictionary<AbilityKey, int> _adjustments;
         private Dictionary<AbilityKey, int> _originals;

--- a/HouseRules_Essentials/Rules/BackstabConfigOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/BackstabConfigOverriddenRule.cs
@@ -10,7 +10,7 @@
     public sealed class BackstabConfigOverriddenRule : Rule, IConfigWritable<List<BoardPieceId>>, IPatchable,
         IMultiplayerSafe
     {
-        public override string Description => "Backstab is allocated to new BoardPieceIDs";
+        public override string Description => "Hero ability to backstab is adjusted";
 
         private static List<BoardPieceId> _globalAdjustments;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardAdditionOverriddenRule.cs
@@ -13,7 +13,7 @@
     public sealed class CardAdditionOverriddenRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<AbilityKey>>>,
         IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Card additions from chests AND energy (mana) are overridden";
+        public override string Description => "Card additions from chests AND energy (mana) are adjusted";
 
         private static Dictionary<BoardPieceId, List<AbilityKey>> _globalHeroCards;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/CardChestAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardChestAdditionOverriddenRule.cs
@@ -13,7 +13,7 @@
     public sealed class CardChestAdditionOverriddenRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<AbilityKey>>>,
         IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Card additions from chests are overridden";
+        public override string Description => "Card additions from chests are adjusted";
 
         private static Dictionary<BoardPieceId, List<AbilityKey>> _globalChestCards;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/CardClassRestrictionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardClassRestrictionOverriddenRule.cs
@@ -11,7 +11,7 @@
     public sealed class CardClassRestrictionOverriddenRule : Rule,
         IConfigWritable<Dictionary<AbilityKey, BoardPieceId>>, IMultiplayerSafe
     {
-        public override string Description => "Card class restrictions are overridden";
+        public override string Description => "Card class restrictions are adjusted";
 
         private readonly Dictionary<AbilityKey, BoardPieceId> _adjustments;
         private Dictionary<AbilityKey, BoardPieceId> _originals;

--- a/HouseRules_Essentials/Rules/CardEnergyAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/CardEnergyAdditionOverriddenRule.cs
@@ -12,7 +12,7 @@
     public sealed class CardEnergyAdditionOverriddenRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<AbilityKey>>>,
         IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Card additions from energy (mana) are overridden";
+        public override string Description => "Card additions from energy (mana) are adjusted";
 
         private static Dictionary<BoardPieceId, List<AbilityKey>> _globalEnergyCards;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/CardEnergyFromAttackMultipliedRule.cs
+++ b/HouseRules_Essentials/Rules/CardEnergyFromAttackMultipliedRule.cs
@@ -7,7 +7,7 @@
 
     public sealed class CardEnergyFromAttackMultipliedRule : Rule, IConfigWritable<float>, IMultiplayerSafe
     {
-        public override string Description => "CardConfig energy from attack is multiplied";
+        public override string Description => "Card energy (mana) given from attacks is adjusted";
 
         private readonly float _multiplier;
         private readonly float _originalValue;

--- a/HouseRules_Essentials/Rules/CardEnergyFromRecyclingMultipliedRule.cs
+++ b/HouseRules_Essentials/Rules/CardEnergyFromRecyclingMultipliedRule.cs
@@ -7,7 +7,7 @@
     public sealed class CardEnergyFromRecyclingMultipliedRule : Rule, IConfigWritable<float>, IPatchable,
         IMultiplayerSafe
     {
-        public override string Description => "CardConfig energy from recycling is multiplied";
+        public override string Description => "Card energy (mana) from recycling is adjusted";
 
         private static float _globalMultiplier;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/CardLimitModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/CardLimitModifiedRule.cs
@@ -7,7 +7,7 @@
 
     public sealed class CardLimitModifiedRule : Rule, IConfigWritable<int>, IPatchable
     {
-        public override string Description => "Card limit is modified";
+        public override string Description => "Hero starting card limit is adjusted (Skirmish Only)";
 
         private static int _globalLimit;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/CardSellValueMultipliedRule.cs
+++ b/HouseRules_Essentials/Rules/CardSellValueMultipliedRule.cs
@@ -7,7 +7,7 @@
 
     public sealed class CardSellValueMultipliedRule : Rule, IConfigWritable<float>, IPatchable
     {
-        public override string Description => "CardConfig sell values are multiplied";
+        public override string Description => "Card sell values are adjusted (Skirmish Only)";
 
         private static float _globalMultiplier;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/CourageShantyAddsHPRule.cs
+++ b/HouseRules_Essentials/Rules/CourageShantyAddsHPRule.cs
@@ -7,7 +7,7 @@
 
     public sealed class CourageShantyAddsHpRule : Rule, IConfigWritable<int>, IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Courage Shanty also adds HP.";
+        public override string Description => "Courage Shanty also gives a heal";
 
         private static int _globalAdjustments;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/EnemyAttackScaledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyAttackScaledRule.cs
@@ -8,7 +8,7 @@
 
     public sealed class EnemyAttackScaledRule : Rule, IConfigWritable<float>, IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Enemy attack damage is scaled";
+        public override string Description => "Enemy attack damage is adjusted";
 
         private static float _globalMultiplier;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/EnemyCooldownOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyCooldownOverriddenRule.cs
@@ -9,7 +9,7 @@
 
     public sealed class EnemyCooldownOverriddenRule : Rule, IConfigWritable<Dictionary<AbilityKey, int>>, IMultiplayerSafe
     {
-        public override string Description => "Enemy ability cooldown values are overridden";
+        public override string Description => "Enemy ability cooldown turns are adjusted";
 
         private readonly Dictionary<AbilityKey, int> _adjustments;
         private Dictionary<AbilityKey, int> _originals;

--- a/HouseRules_Essentials/Rules/EnemyHealthScaledRule.cs
+++ b/HouseRules_Essentials/Rules/EnemyHealthScaledRule.cs
@@ -8,7 +8,7 @@
 
     public sealed class EnemyHealthScaledRule : Rule, IConfigWritable<float>, IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Enemy health is scaled";
+        public override string Description => "Enemy health is adjusted";
 
         protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.NewPieceModified;
 

--- a/HouseRules_Essentials/Rules/FreeAbilityOnCritRule.cs
+++ b/HouseRules_Essentials/Rules/FreeAbilityOnCritRule.cs
@@ -11,7 +11,7 @@
     public sealed class FreeAbilityOnCritRule : Rule, IConfigWritable<Dictionary<BoardPieceId, AbilityKey>>, IPatchable,
         IMultiplayerSafe
     {
-        public override string Description => "Critical Hit gives free card.";
+        public override string Description => "Hero critical hits gives a free card";
 
         private static Dictionary<BoardPieceId, AbilityKey> _globalAdjustments;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/GoldPickedUpMultipliedRule.cs
+++ b/HouseRules_Essentials/Rules/GoldPickedUpMultipliedRule.cs
@@ -8,7 +8,7 @@
 
     public sealed class GoldPickedUpMultipliedRule : Rule, IConfigWritable<float>, IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Gold picked up is multiplied";
+        public override string Description => "Gold found per pile is adjusted";
 
         private static float _globalMultiplier;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/LampTypesOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/LampTypesOverriddenRule.cs
@@ -10,7 +10,7 @@
     public sealed class LampTypesOverriddenRule : Rule, IConfigWritable<Dictionary<int, List<BoardPieceId>>>,
         IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Lamp types are overridden.";
+        public override string Description => "Lamp spawn types and variety are adjusted";
 
         private static Dictionary<int, List<BoardPieceId>> _globalAdjustments;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/LevelExitLockedUntilAllEnemiesDefeatedRule.cs
+++ b/HouseRules_Essentials/Rules/LevelExitLockedUntilAllEnemiesDefeatedRule.cs
@@ -12,7 +12,7 @@
     public sealed class LevelExitLockedUntilAllEnemiesDefeatedRule : Rule, IConfigWritable<bool>, IPatchable,
         IMultiplayerSafe
     {
-        public override string Description => "Level exit stays locked until all enemies are defeated.";
+        public override string Description => "Level exit stays locked until all enemies are defeated";
 
         private static bool _isActivated;
 

--- a/HouseRules_Essentials/Rules/LevelPropertiesModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/LevelPropertiesModifiedRule.cs
@@ -9,7 +9,7 @@
 
     public sealed class LevelPropertiesModifiedRule : Rule, IConfigWritable<Dictionary<string, int>>, IMultiplayerSafe
     {
-        public override string Description => "Level properties are modified";
+        public override string Description => "Each floor's POI's and maximum gold are adjusted";
 
         private const int DefaultDreadLevel = 1;
         private readonly Dictionary<string, int> _levelProperties;

--- a/HouseRules_Essentials/Rules/LevelSequenceOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/LevelSequenceOverriddenRule.cs
@@ -10,7 +10,7 @@
 
     public sealed class LevelSequenceOverriddenRule : Rule, IConfigWritable<List<string>>, IPatchable, IMultiplayerSafe
     {
-        public override string Description => "LevelSequence is overridden";
+        public override string Description => "The adventure's map order is adjusted";
 
         private static List<string> _globalAdjustments;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/MonsterDeckOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/MonsterDeckOverriddenRule.cs
@@ -14,7 +14,7 @@
 
     public sealed class MonsterDeckOverriddenRule : Rule, IConfigWritable<MonsterDeckOverriddenRule.DeckConfig>, IPatchable, IMultiplayerSafe
     {
-        public override string Description => "MonsterDeck creation is overriden";
+        public override string Description => "Enemy spawn randomness is adjusted";
 
         private static DeckConfig _globalAdjustments;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/PartyElectricityDamageOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PartyElectricityDamageOverriddenRule.cs
@@ -11,7 +11,7 @@
     public sealed class PartyElectricityDamageOverriddenRule : Rule, IConfigWritable<bool>, IPatchable,
         IMultiplayerSafe
     {
-        public override string Description => "Player on player electricity damage is zero.";
+        public override string Description => "Heroes can't hurt or stun each other with electricity damage";
 
         private static bool _isActivated;
 

--- a/HouseRules_Essentials/Rules/PetsFocusHunterMarkRule.cs
+++ b/HouseRules_Essentials/Rules/PetsFocusHunterMarkRule.cs
@@ -10,7 +10,7 @@
 
     public sealed class PetsFocusHunterMarkRule : Rule, IConfigWritable<bool>, IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Pets focus on hunter marked enemies";
+        public override string Description => "Pets focus on Hunter's marked enemies";
 
         private static bool _isActivated;
 

--- a/HouseRules_Essentials/Rules/PieceDownedCountAdjustedRule.cs
+++ b/HouseRules_Essentials/Rules/PieceDownedCountAdjustedRule.cs
@@ -10,7 +10,7 @@
 
     public sealed class PieceDownedCountAdjustedRule : Rule, IConfigWritable<Dictionary<BoardPieceId, int>>, IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Player piece maximum knockdown count modified on creation";
+        public override string Description => "Hero maximum knockdown count adjusted";
 
         protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.NewPieceModified;
 
@@ -64,31 +64,25 @@
             foreach (var replacement in _globalAdjustments)
             {
                 int countReplacement;
-                int timerReplacement;
                 switch (replacement.Value)
                 {
                     case 0:
                         countReplacement = 3;
-                        timerReplacement = 0;
                         break;
                     case 1:
                         countReplacement = 2;
-                        timerReplacement = 1;
                         break;
                     case 2:
                         countReplacement = 1;
-                        timerReplacement = 2;
                         break;
                     default:
                         countReplacement = 0;
-                        timerReplacement = 3;
                         break;
                 }
 
                 if (replacement.Key == __result.boardPieceId)
                 {
                     __result.effectSink.TrySetStatBaseValue(Stats.Type.DownedCounter, countReplacement);
-                    __result.effectSink.TrySetStatBaseValue(Stats.Type.DownedTimer, timerReplacement);
                 }
             }
         }

--- a/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PiecePieceTypeListOverriddenRule.cs
@@ -11,7 +11,7 @@
     public sealed class PiecePieceTypeListOverriddenRule : Rule,
         IConfigWritable<Dictionary<BoardPieceId, List<PieceType>>>, IMultiplayerSafe
     {
-        public override string Description => "Piece piece types are adjusted";
+        public override string Description => "Piece types are adjusted";
 
         protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.NewPieceModified;
 

--- a/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PieceUseWhenKilledOverriddenRule.cs
@@ -10,7 +10,7 @@
     public sealed class PieceUseWhenKilledOverriddenRule : Rule,
         IConfigWritable<Dictionary<BoardPieceId, List<AbilityKey>>>, IMultiplayerSafe
     {
-        public override string Description => "Piece UseWhenKilled lists are overridden";
+        public override string Description => "Piece 'use when killed' abilities are adjusted";
 
         protected override SyncableTrigger ModifiedSyncables =>
             SyncableTrigger.NewPieceModified | SyncableTrigger.StatusEffectDataModified;

--- a/HouseRules_Essentials/Rules/PotionAdditionOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/PotionAdditionOverriddenRule.cs
@@ -13,7 +13,7 @@
     public sealed class PotionAdditionOverriddenRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<AbilityKey>>>,
         IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Potion additions are overridden";
+        public override string Description => "Potion Rack loot is adjusted";
 
         private static Dictionary<BoardPieceId, List<AbilityKey>> _globalPotionCards;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/RatNestsSpawnGoldRule.cs
+++ b/HouseRules_Essentials/Rules/RatNestsSpawnGoldRule.cs
@@ -8,7 +8,7 @@
 
     public sealed class RatNestsSpawnGoldRule : Rule, IConfigWritable<int>
     {
-        public override string Description => "Rat nests spawn gold";
+        public override string Description => "Rat nests spawn gold (Skirmish Only)";
 
         private readonly int _pileCount;
         private int _originalSpawnAmount;

--- a/HouseRules_Essentials/Rules/RegainAbilityIfMaxxedOutOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/RegainAbilityIfMaxxedOutOverriddenRule.cs
@@ -11,7 +11,7 @@
     public sealed class RegainAbilityIfMaxxedOutOverriddenRule : Rule, IConfigWritable<Dictionary<AbilityKey, bool>>,
         IMultiplayerSafe
     {
-        public override string Description => "RegainAbilityIfMaxxedOut settings are overridden";
+        public override string Description => "Regain ability card if stat maxxed out setting adjusted";
 
         private readonly Dictionary<AbilityKey, bool> _adjustments;
         private Dictionary<AbilityKey, bool> _originals;

--- a/HouseRules_Essentials/Rules/RoundCountLimitedRule.cs
+++ b/HouseRules_Essentials/Rules/RoundCountLimitedRule.cs
@@ -7,7 +7,7 @@
 
     public sealed class RoundCountLimitedRule : Rule, IConfigWritable<int>, IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Round count is limited";
+        public override string Description => "This adventure's total round count is limited";
 
         private const float RoundsLeftMessageDurationSeconds = 5f;
         private static int _globalRoundLimit;

--- a/HouseRules_Essentials/Rules/SpawnCategoryOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/SpawnCategoryOverriddenRule.cs
@@ -8,7 +8,7 @@
 
     public sealed class SpawnCategoryOverriddenRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<int>>>, IMultiplayerSafe
     {
-        public override string Description => "Spawn Category definitions are Overridden";
+        public override string Description => "Enemy spawn randomness is adjusted";
 
         private readonly Dictionary<BoardPieceId, List<int>> _adjustments;
         private Dictionary<BoardPieceId, List<int>> _originals;

--- a/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
+++ b/HouseRules_Essentials/Rules/StartCardsModifiedRule.cs
@@ -11,7 +11,7 @@
 
     public sealed class StartCardsModifiedRule : Rule, IConfigWritable<Dictionary<BoardPieceId, List<StartCardsModifiedRule.CardConfig>>>, IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Hero start cards are modified";
+        public override string Description => "Hero start cards are adjusted";
 
         private static Dictionary<BoardPieceId, List<CardConfig>> _globalHeroStartCards;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/StatModifiersOverridenRule.cs
+++ b/HouseRules_Essentials/Rules/StatModifiersOverridenRule.cs
@@ -11,7 +11,7 @@
     public sealed class StatModifiersOverridenRule : Rule, IConfigWritable<Dictionary<AbilityKey, int>>,
         IMultiplayerSafe
     {
-        public override string Description => "StatModifiersOverridenRule are overridden";
+        public override string Description => "Stat modifier abilities are adjusted";
 
         private readonly Dictionary<AbilityKey, int> _adjustments;
         private Dictionary<AbilityKey, int> _originals;

--- a/HouseRules_Essentials/Rules/StatusEffectConfigRule.cs
+++ b/HouseRules_Essentials/Rules/StatusEffectConfigRule.cs
@@ -8,7 +8,7 @@
 
     public sealed class StatusEffectConfigRule : Rule, IConfigWritable<List<StatusEffectData>>, IMultiplayerSafe
     {
-        public override string Description => "StatusEffects config is Overridden";
+        public override string Description => "Some buffs/debuffs have their duration & effects adjusted";
 
         protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.StatusEffectDataModified;
 

--- a/HouseRules_Essentials/Rules/TileEffectDurationOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/TileEffectDurationOverriddenRule.cs
@@ -9,7 +9,7 @@
     public sealed class TileEffectDurationOverriddenRule : Rule, IConfigWritable<Dictionary<TileEffect, int>>,
         IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Tile Effect durations are overridden.";
+        public override string Description => "Tile effect durations are adjusted";
 
         private static Dictionary<TileEffect, int> _globalAdjustments;
         private static bool _isActivated;

--- a/HouseRules_Essentials/Rules/TurnOrderOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/TurnOrderOverriddenRule.cs
@@ -12,7 +12,7 @@
 
     public sealed class TurnOrderOverriddenRule : Rule, IConfigWritable<TurnOrderOverriddenRule.Scores>, IPatchable, IMultiplayerSafe
     {
-        public override string Description => "Turn order is overridden.";
+        public override string Description => "Hero turn order is adjusted";
 
         private static Scores _globalConfig;
         private static bool _isActivated;


### PR DESCRIPTION
![VirtualDesktop Android-20230705-113604](https://github.com/orendain/DemeoMods/assets/103865052/e64ed6f1-5ac3-4a80-ad64-5520c9cf8fb8)
![VirtualDesktop Android-20230705-113633](https://github.com/orendain/DemeoMods/assets/103865052/00e11851-c8d3-4b4a-98ff-51072e509219)
![VirtualDesktop Android-20230705-113703](https://github.com/orendain/DemeoMods/assets/103865052/9068d6ee-c895-456a-a7f9-c56dc5e8f4bc)

(VR only) Creates a persistent panel next to the gaming table (only while playing) displaying the ruleset, description, and the rules used.

Changed lots of rule descriptions to be easier for non-programmers to understand. Also colorizes, shortens, and lowers the timer on the ShowCameraMessage. While I was there I removed some unnecessary code in the PieceDownedCount rule.
 
This would be **EASILY** modified to display user-configured rules descriptions if someone could create a way for me to get those... I am totally lost in how to do that.