### PR TITLE
Fix mis-spelled rule

### DIFF
--- a/HouseRules_Essentials/EssentialsMod.cs
+++ b/HouseRules_Essentials/EssentialsMod.cs
@@ -61,7 +61,7 @@
             HR.Rulebook.Register(typeof(RoundCountLimitedRule));
             HR.Rulebook.Register(typeof(SpawnCategoryOverriddenRule));
             HR.Rulebook.Register(typeof(StartCardsModifiedRule));
-            HR.Rulebook.Register(typeof(StatModifiersOverridenRule));
+            HR.Rulebook.Register(typeof(StatModifiersOverriddenRule));
             HR.Rulebook.Register(typeof(StatusEffectConfigRule));
             HR.Rulebook.Register(typeof(TileEffectDurationOverriddenRule));
             HR.Rulebook.Register(typeof(TurnOrderOverriddenRule));

--- a/HouseRules_Essentials/HouseRules_Essentials.csproj
+++ b/HouseRules_Essentials/HouseRules_Essentials.csproj
@@ -78,7 +78,7 @@
     <Compile Include="Rules\PieceAbilityListOverriddenRule.cs" />
     <Compile Include="Rules\PieceDownedCountAdjustedRule.cs" />
     <Compile Include="Rules\RegainAbilityIfMaxxedOutOverriddenRule.cs" />
-    <Compile Include="Rules\StatModifiersOverridenRule.cs" />
+    <Compile Include="Rules\StatModifiersOverriddenRule.cs" />
     <Compile Include="Rules\AbilityRandomPieceListRule.cs" />
     <Compile Include="Rules\CardAdditionOverriddenRule.cs" />
     <Compile Include="Rules\CardEnergyFromAttackMultipliedRule.cs" />

--- a/HouseRules_Essentials/Rules/StatModifiersOverriddenRule.cs
+++ b/HouseRules_Essentials/Rules/StatModifiersOverriddenRule.cs
@@ -8,7 +8,7 @@
     using HarmonyLib;
     using HouseRules.Types;
 
-    public sealed class StatModifiersOverridenRule : Rule, IConfigWritable<Dictionary<AbilityKey, int>>,
+    public sealed class StatModifiersOverriddenRule : Rule, IConfigWritable<Dictionary<AbilityKey, int>>,
         IMultiplayerSafe
     {
         public override string Description => "Stat modifier abilities are adjusted";
@@ -17,11 +17,11 @@
         private Dictionary<AbilityKey, int> _originals;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="StatModifiersOverridenRule"/> class.
+        /// Initializes a new instance of the <see cref="StatModifiersOverriddenRule"/> class.
         /// </summary>
         /// <param name="adjustments">Key-value pairs mapping the name of a StatModifier and the new additiveBonus setting.
         /// Overwrites existing settings. Some StatModifiers require negative values.</param>
-        public StatModifiersOverridenRule(Dictionary<AbilityKey, int> adjustments)
+        public StatModifiersOverriddenRule(Dictionary<AbilityKey, int> adjustments)
         {
             _adjustments = adjustments;
             _originals = new Dictionary<AbilityKey, int>();


### PR DESCRIPTION
StatModifiersOverridden was spelled wrong as StatModifiersOverriden
Thanks to @BobtheBunny from our Discord channel for bringing this to light.