### PR TITLE
Update RoomFinder to be compatible with Demeo 2023/09/07 update.

### DIFF
--- a/RoomFinder/UI/RoomFinderUiNonVr.cs
+++ b/RoomFinder/UI/RoomFinderUiNonVr.cs
@@ -122,8 +122,12 @@
         private static void RefreshRoomList()
         {
             RoomFinderMod.SharedState.IsRefreshingRoomList = true;
+            var lobbyMenuController = Traverse
+                .Create(RoomFinderMod.SharedState.GameContext.gameStateMachine.lobby)
+                .Field<LobbyMenuController>("lobbyMenuController")
+                .Value;
             var lobbyMenuContext = Traverse
-                .Create(RoomFinderMod.SharedState.GameContext.gameStateMachine.lobby.GetLobbyMenuController)
+                .Create(lobbyMenuController)
                 .Field<LobbyMenu.ILobbyMenuContext>("lobbyMenuContext")
                 .Value;
 

--- a/RoomFinder/UI/RoomFinderUiVr.cs
+++ b/RoomFinder/UI/RoomFinderUiVr.cs
@@ -97,8 +97,12 @@
         private static void RefreshRoomList()
         {
             RoomFinderMod.SharedState.IsRefreshingRoomList = true;
+            var lobbyMenuController = Traverse
+                .Create(RoomFinderMod.SharedState.GameContext.gameStateMachine.lobby)
+                .Field<LobbyMenuController>("lobbyMenuController")
+                .Value;
             var lobbyMenuContext = Traverse
-                .Create(RoomFinderMod.SharedState.GameContext.gameStateMachine.lobby.GetLobbyMenuController)
+                .Create(lobbyMenuController)
                 .Field<LobbyMenu.ILobbyMenuContext>("lobbyMenuContext")
                 .Value;
 

--- a/RoomFinder/UI/RoomListPanelNonVr.cs
+++ b/RoomFinder/UI/RoomListPanelNonVr.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using Boardgame;
+    using Boardgame.Ui.LobbyMenu;
     using Common.UI;
     using Common.UI.Element;
     using HarmonyLib;
@@ -243,7 +244,11 @@
             return () =>
             {
                 RoomFinderMod.Logger.Msg($"Joining room [{roomCode}].");
-                Traverse.Create(RoomFinderMod.SharedState.GameContext.gameStateMachine.lobby.GetLobbyMenuController)
+                var lobbyMenuController = Traverse
+                    .Create(RoomFinderMod.SharedState.GameContext.gameStateMachine.lobby)
+                    .Field<LobbyMenuController>("lobbyMenuController")
+                    .Value;
+                Traverse.Create(lobbyMenuController)
                     .Method("JoinGame", roomCode, true)
                     .GetValue();
             };

--- a/RoomFinder/UI/RoomListPanelVr.cs
+++ b/RoomFinder/UI/RoomListPanelVr.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using Boardgame;
+    using Boardgame.Ui.LobbyMenu;
     using Common.UI;
     using Common.UI.Element;
     using HarmonyLib;
@@ -250,7 +251,11 @@
             return () =>
             {
                 RoomFinderMod.Logger.Msg($"Joining room [{roomCode}].");
-                Traverse.Create(RoomFinderMod.SharedState.GameContext.gameStateMachine.lobby.GetLobbyMenuController)
+                var lobbyMenuController = Traverse
+                    .Create(RoomFinderMod.SharedState.GameContext.gameStateMachine.lobby)
+                    .Field<LobbyMenuController>("lobbyMenuController")
+                    .Value;
+                Traverse.Create(lobbyMenuController)
                     .Method("JoinGame", roomCode, true)
                     .GetValue();
             };


### PR DESCRIPTION
Demeo changed the `lobby` field type of `gameStateMachine` from `Lobby` to `ILobbyMenuPresenter`, so fields/methods that were previously available no longer are.  This PR fetches necessary fields through another path.