### PR TITLE
Time for the next published HR release - Moving on up!

### DIFF
--- a/HouseRules_Core/BuildVersion.cs
+++ b/HouseRules_Core/BuildVersion.cs
@@ -2,7 +2,7 @@
 {
     public static class BuildVersion
     {
-        public const string Version = "1.6.2";
-        public const string MajorMinorVersion = "1.6";
+        public const string Version = "1.7.0";
+        public const string MajorMinorVersion = "1.7";
     }
 }

--- a/HouseRules_Essentials/Rulesets/Arachnophobia.cs
+++ b/HouseRules_Essentials/Rulesets/Arachnophobia.cs
@@ -110,7 +110,6 @@
             {
                 { AbilityKey.StrengthPotion, false },
                 { AbilityKey.SwiftnessPotion, false },
-                { AbilityKey.VigorPotion, false },
                 { AbilityKey.DamageResistPotion, false },
             });
 


### PR DESCRIPTION
Increment build version.
Also remove VigorPotion from RegainAbilityIfMaxxedOutOverriddenRule in Arachnophobia because it doesn't have a stat that can be checked.