### PR TITLE
Update build dependencies for 2023-09-08.

### DIFF
--- a/.github/workflows/houserules.yml
+++ b/.github/workflows/houserules.yml
@@ -21,12 +21,12 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set Up MSBuild
-        uses: microsoft/setup-msbuild@v1.3.1
+        uses: microsoft/setup-msbuild@v1
 
       - name: Add Build Dependencies
         run: |
-          C:\msys64\usr\bin\wget.exe https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/eab432f1b7df70451905531f1e77bb05102747ec/ws.zip
-          7z x ws.zip
+          C:\msys64\usr\bin\wget.exe -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/180eb5a6465eda285066704d89cef8d5b9109ee6/2023-09-07.zip
+          7z x deps.zip
 
       - name: Build HouseRules_Core
         run: msbuild -m -v:d -p:Configuration=Release -p:DemeoVrDir="%GITHUB_WORKSPACE%" HouseRules_Core\HouseRules_Core.csproj
@@ -54,7 +54,7 @@ jobs:
           xcopy docs\rulesets\* Bundle\UserData\HouseRules\ExampleRulesets
 
       - name: Upload Bundle
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v3
         with:
           name: HouseRules
           path: Bundle\*


### PR DESCRIPTION
This is the HouseRules-equivalent of https://github.com/orendain/DemeoMods/pull/489.