### PR TITLE
Update the `author` field to correctly reflect the team behind the develpment effort.

### DIFF
--- a/HouseRules_Configuration/Properties/AssemblyInfo.cs
+++ b/HouseRules_Configuration/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using MelonLoader;
 [assembly: AssemblyFileVersion(HouseRules.BuildVersion.Version)]
 
 // Melon Loader.
-[assembly: MelonInfo(typeof(ConfigurationMod), "HouseRules: Configuration", HouseRules.BuildVersion.Version, "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonInfo(typeof(ConfigurationMod), "HouseRules: Configuration", HouseRules.BuildVersion.Version, "DemeoMods Team", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("574512")]

--- a/HouseRules_Core/Properties/AssemblyInfo.cs
+++ b/HouseRules_Core/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using MelonLoader;
 [assembly: AssemblyFileVersion(BuildVersion.Version)]
 
 // Melon Loader.
-[assembly: MelonInfo(typeof(CoreMod), "HouseRules: Core", BuildVersion.Version, "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonInfo(typeof(CoreMod), "HouseRules: Core", BuildVersion.Version, "DemeoMods Team", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("574512")]

--- a/HouseRules_Essentials/Properties/AssemblyInfo.cs
+++ b/HouseRules_Essentials/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using MelonLoader;
 [assembly: AssemblyFileVersion(HouseRules.BuildVersion.Version)]
 
 // Melon Loader.
-[assembly: MelonInfo(typeof(EssentialsMod), "HouseRules: Essentials", HouseRules.BuildVersion.Version, "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonInfo(typeof(EssentialsMod), "HouseRules: Essentials", HouseRules.BuildVersion.Version, "DemeoMods Team", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("574512")]

--- a/RoomCode/Properties/AssemblyInfo.cs
+++ b/RoomCode/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using RoomCode;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 // Melon Loader.
-[assembly: MelonInfo(typeof(RoomCodeMod), "RoomCode", "1.2.0", "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonInfo(typeof(RoomCodeMod), "RoomCode", "1.2.0", "DemeoMods Team", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("581308")]

--- a/RoomFinder/Properties/AssemblyInfo.cs
+++ b/RoomFinder/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using RoomFinder;
 [assembly: AssemblyFileVersion(BuildVersion.Version)]
 
 // Melon Loader.
-[assembly: MelonInfo(typeof(RoomFinderMod), "RoomFinder", BuildVersion.Version, "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonInfo(typeof(RoomFinderMod), "RoomFinder", BuildVersion.Version, "DemeoMods Team", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("566788")]

--- a/SkipIntro/Properties/AssemblyInfo.cs
+++ b/SkipIntro/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using SkipIntro;
 [assembly: AssemblyFileVersion("1.0.0.0")]
 
 // Melon Loader.
-[assembly: MelonInfo(typeof(SkipIntroMod), "SkipIntro", "1.4.0", "Orendain", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonInfo(typeof(SkipIntroMod), "SkipIntro", "1.4.0", "DemeoMods Team", "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("566782")]


### PR DESCRIPTION
Originally, the `author` field was set so as to attribute the mods to their corresponding GitHub repository.  However, in practice, that field is used more for display purposes.  Thus, this PR updates the `author` field so that it correctly reflects the folks behind the effort.

Should pass all build checks once https://github.com/orendain/DemeoMods/pull/491 is merged.