### PR TITLE
Recognize GitHub pipeline changes when labelling PRs.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@
 - Common/**
 
 'area: houserules/configuration':
-- .github/worklows/houserules.yml
+- .github/workflows/houserules.yml
 - HouseRules_Configuration/**
 
 'area: houserules/core':
@@ -14,7 +14,7 @@
 - HouseRules_Core/**
 
 'area: houserules/essentials':
-- .github/workfows/houserules.yml
+- .github/workflows/houserules.yml
 - HouseRules_Essentials/**
 
 'area: roomcode':

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,23 +1,30 @@
 'area: advancedstats':
+- .github/workflows/advancedstats.yml
 - AdvancedStats/**
 
 'area: common':
 - Common/**
 
 'area: houserules/configuration':
+- .github/worklows/houserules.yml
 - HouseRules_Configuration/**
 
 'area: houserules/core':
+- .github/workflows/houserules.yml
 - HouseRules_Core/**
 
 'area: houserules/essentials':
+- .github/workfows/houserules.yml
 - HouseRules_Essentials/**
 
 'area: roomcode':
+- .github/workflows/roomcode.yml
 - RoomCode/**
 
 'area: roomfinder':
+- .github/workflows/roomfinder.yml
 - RoomFinder/**
 
 'area: skipintro':
+- .github/workflows/skipintro.yml
 - SkipIntro/**


### PR DESCRIPTION
The labeler was not attributing mod pipeline changes to a specific mod label.  This PR makes sure that changes to pipeline files are attributed.