### PR TITLE
Introduce Highlighter Mod.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,6 +5,10 @@
 'area: common':
 - Common/**
 
+'area: highlighter':
+  - .github/workflows/highlighter.yml
+  - Highlighter/**
+
 'area: houserules/configuration':
 - .github/workflows/houserules.yml
 - HouseRules_Configuration/**

--- a/.github/workflows/highlighter.yml
+++ b/.github/workflows/highlighter.yml
@@ -1,0 +1,43 @@
+name: Highlighter
+
+on:
+  pull_request:
+    paths:
+      - 'Highlighter/**'
+      - '.github/workflows/highlighter.yml'
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: cmd
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Up MSBuild
+        uses: microsoft/setup-msbuild@v1
+
+      - name: Add Build Dependencies
+        run: |
+          C:\msys64\usr\bin\wget.exe -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/180eb5a6465eda285066704d89cef8d5b9109ee6/2023-09-07.zip
+          7z x deps.zip
+
+      - name: Build Project
+        run: msbuild -m -v:d -p:Configuration=Release -p:DemeoVrDir="%GITHUB_WORKSPACE%" Highlighter\Highlighter.csproj
+
+      - name: Assemble into Bundle
+        run: |
+          mkdir Bundle\Mods
+          xcopy Highlighter\bin\Release\Highlighter.dll Bundle\Mods
+
+      - name: Upload Bundle
+        uses: actions/upload-artifact@v3
+        with:
+          name: Highlighter
+          path: Bundle\*

--- a/DemeoMods.sln
+++ b/DemeoMods.sln
@@ -60,6 +60,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ExampleRulesets", "ExampleR
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdvancedStats", "AdvancedStats\AdvancedStats.csproj", "{A1850892-02BC-41F0-9131-E63CDD61E8DC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Highlighter", "Highlighter\Highlighter.csproj", "{E9D15E52-072A-4CC7-A7C3-21A4AA44FA79}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -98,6 +100,10 @@ Global
 		{A1850892-02BC-41F0-9131-E63CDD61E8DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1850892-02BC-41F0-9131-E63CDD61E8DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1850892-02BC-41F0-9131-E63CDD61E8DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9D15E52-072A-4CC7-A7C3-21A4AA44FA79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E9D15E52-072A-4CC7-A7C3-21A4AA44FA79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9D15E52-072A-4CC7-A7C3-21A4AA44FA79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E9D15E52-072A-4CC7-A7C3-21A4AA44FA79}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Highlighter/Highlighter.csproj
+++ b/Highlighter/Highlighter.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import
+            Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"
+            Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+    <PropertyGroup>
+        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+        <ProjectGuid>{E9D15E52-072A-4CC7-A7C3-21A4AA44FA79}</ProjectGuid>
+        <OutputType>Library</OutputType>
+        <AppDesignerFolder>Properties</AppDesignerFolder>
+        <RootNamespace>Highlighter</RootNamespace>
+        <AssemblyName>Highlighter</AssemblyName>
+        <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+        <FileAlignment>512</FileAlignment>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>full</DebugType>
+        <Optimize>false</Optimize>
+        <OutputPath>bin\Debug\</OutputPath>
+        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <DebugType>pdbonly</DebugType>
+        <Optimize>true</Optimize>
+        <OutputPath>bin\Release\</OutputPath>
+        <DefineConstants>TRACE</DefineConstants>
+        <ErrorReport>prompt</ErrorReport>
+        <WarningLevel>4</WarningLevel>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="0Harmony">
+            <HintPath>$(DemeoVrDir)\MelonLoader\0Harmony.dll</HintPath>
+        </Reference>
+        <Reference Include="Assembly-CSharp">
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\Assembly-CSharp.dll</HintPath>
+        </Reference>
+        <Reference Include="MelonLoader">
+            <HintPath>$(DemeoVrDir)\MelonLoader\MelonLoader.dll</HintPath>
+        </Reference>
+        <Reference Include="UnityEngine.CoreModule">
+            <HintPath>$(DemeoVrDir)\demeo_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+        </Reference>
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="MoveHighlighter.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs"/>
+        <Compile Include="HighlighterMod.cs" />
+    </ItemGroup>
+    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
+    <Target Name="CopyToModsDir" AfterTargets="Build">
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoVrDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoPcDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoOculusVrDir)\Mods" />
+        <Copy SourceFiles="$(OutputPath)\$(ProjectName).dll" DestinationFolder="$(DemeoOculusPcDir)\Mods" />
+    </Target>
+</Project>

--- a/Highlighter/HighlighterMod.cs
+++ b/Highlighter/HighlighterMod.cs
@@ -1,0 +1,12 @@
+﻿namespace Highlighter
+{
+    using MelonLoader;
+
+    internal class HighlighterMod : MelonMod
+    {
+        public override void OnInitializeMelon()
+        {
+            MoveHighlighter.Patch(HarmonyInstance);
+        }
+    }
+}

--- a/Highlighter/MoveHighlighter.cs
+++ b/Highlighter/MoveHighlighter.cs
@@ -1,0 +1,167 @@
+﻿namespace Highlighter
+{
+    using Boardgame;
+    using Boardgame.BoardEntities.Abilities;
+    using Boardgame.BoardPiece;
+    using Boardgame.Data;
+    using Boardgame.NonVR.BoardPiece;
+    using Boardgame.Ui;
+    using DataKeys;
+    using HarmonyLib;
+    using UnityEngine;
+
+    public static class MoveHighlighter
+    {
+        private static GameContext _gameContext;
+        private static IntPoint2D _lastHoveredTile;
+
+        internal static void Patch(Harmony harmony)
+        {
+            // To allow mid-game hooking.
+            _gameContext = Traverse.Create(typeof(GameHub)).Field<GameContext>("gameContext").Value;
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(GameStartup), "InitializeGame"),
+                postfix: new HarmonyMethod(typeof(MoveHighlighter), nameof(GameStartup_InitializeGame_Postfix)));
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(NonVrGrabbableMiniature), "OnGrabMoved"),
+                postfix: new HarmonyMethod(
+                    typeof(MoveHighlighter),
+                    nameof(NonVrGrabbableMiniature_OnGrabMoved_Postfix)));
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(GrabbableMiniature), "OnGrabMoved"),
+                postfix: new HarmonyMethod(
+                    typeof(MoveHighlighter),
+                    nameof(GrabbableMiniature_OnGrabMoved_Postfix)));
+
+            harmony.Patch(
+                original: AccessTools.Method(typeof(BaseGrabbableMiniature), "OnGrabStatusChanged"),
+                postfix: new HarmonyMethod(
+                    typeof(MoveHighlighter),
+                    nameof(BaseGrabbableMiniature_OnGrabStatusChanged_Postfix)));
+        }
+
+        private static void GameStartup_InitializeGame_Postfix(GameStartup __instance)
+        {
+            _gameContext = Traverse.Create(__instance).Field<GameContext>("gameContext").Value;
+        }
+
+        private static void NonVrGrabbableMiniature_OnGrabMoved_Postfix(
+            NonVrGrabbableMiniature __instance,
+            Vector3 position)
+        {
+            var actionSelect = Traverse.Create(__instance).Field<ActionSelect>("actionSelect").Value;
+            if (actionSelect == null)
+            {
+                return;
+            }
+
+            var hoveredTile = _gameContext.boardModel.GetTileHoverData(position).tile;
+            var isMoveInvalid = !actionSelect.MovesInRange.IsMove(hoveredTile);
+            if (isMoveInvalid)
+            {
+                // No redraw required.
+                if (_lastHoveredTile == IntPoint2D.Invalid)
+                {
+                    return;
+                }
+
+                _lastHoveredTile = IntPoint2D.Invalid;
+                ResetPlayerMoveOutline();
+                return;
+            }
+
+            // No redraw required.
+            if (_lastHoveredTile == hoveredTile)
+            {
+                return;
+            }
+
+            _lastHoveredTile = hoveredTile;
+            UpdatePlayerMoveOutline(hoveredTile);
+        }
+
+        private static void GrabbableMiniature_OnGrabMoved_Postfix(
+            GrabbableMiniature __instance,
+            Vector3 pos)
+        {
+            var actionSelect = Traverse.Create(__instance).Field<ActionSelect>("actionSelect").Value;
+            if (actionSelect == null)
+            {
+                return;
+            }
+
+            var hoveredTile = _gameContext.boardModel.GetTileHoverData(pos).tile;
+            var isMoveInvalid = !actionSelect.MovesInRange.IsMove(hoveredTile);
+            if (isMoveInvalid)
+            {
+                // No redraw required.
+                if (_lastHoveredTile == IntPoint2D.Invalid)
+                {
+                    return;
+                }
+
+                _lastHoveredTile = IntPoint2D.Invalid;
+                ResetPlayerMoveOutline();
+                return;
+            }
+
+            // No redraw required.
+            if (_lastHoveredTile == hoveredTile)
+            {
+                return;
+            }
+
+            _lastHoveredTile = hoveredTile;
+            UpdatePlayerMoveOutline(hoveredTile);
+        }
+
+        private static void BaseGrabbableMiniature_OnGrabStatusChanged_Postfix(bool status)
+        {
+            // Do not react when piece is first picked up.
+            if (status)
+            {
+                return;
+            }
+
+            var currentPiece = _gameContext.pieceAndTurnController.CurrentPiece;
+            _gameContext.tileHighlightController.UpdatePlayerMoveOutline(currentPiece);
+        }
+
+        private static void ResetPlayerMoveOutline()
+        {
+            var currentPiece = _gameContext.pieceAndTurnController.CurrentPiece;
+            var moveSet = _gameContext.boardModel.GetMovesInRange(
+                    currentPiece.gridPos,
+                    currentPiece.GetMoveRange(),
+                    currentPiece);
+            TileHighlightController.PlayerPieceTurnHighlight?.UpdateHighlights(
+                moveSet,
+                TileHighlight.HighlightType.Friendly,
+                null,
+                _gameContext.boardModel);
+            TileHighlightController.PlayerPieceTurnHighlight?.FadeIn();
+        }
+
+        private static void UpdatePlayerMoveOutline(IntPoint2D hoveredTile)
+        {
+            var currentPiece = _gameContext.pieceAndTurnController.CurrentPiece;
+            var originalGridPos = currentPiece.gridPos;
+
+            currentPiece.gridPos = originalGridPos.GetMoveTo(hoveredTile);
+            var moveSet = AbilityFactory
+                .GetAbility(AbilityKey.MagicMissile)
+                .CreateMoveSet(currentPiece, _gameContext.pieceAndTurnController, _gameContext.boardModel);
+            currentPiece.gridPos = originalGridPos;
+
+            TileHighlightController.PlayerPieceTurnHighlight?.UpdateHighlights(
+                moveSet,
+                TileHighlight.HighlightType.ElvenKingShockwave,
+                null,
+                _gameContext.boardModel);
+            TileHighlightController.PlayerPieceTurnHighlight?.FadeIn();
+        }
+    }
+}

--- a/Highlighter/MoveHighlighter.cs
+++ b/Highlighter/MoveHighlighter.cs
@@ -53,6 +53,31 @@
             Vector3 position)
         {
             var actionSelect = Traverse.Create(__instance).Field<ActionSelect>("actionSelect").Value;
+            OnMiniatureGrabMoved(actionSelect, position);
+        }
+
+        private static void GrabbableMiniature_OnGrabMoved_Postfix(
+            GrabbableMiniature __instance,
+            Vector3 pos)
+        {
+            var actionSelect = Traverse.Create(__instance).Field<ActionSelect>("actionSelect").Value;
+            OnMiniatureGrabMoved(actionSelect, pos);
+        }
+
+        private static void BaseGrabbableMiniature_OnGrabStatusChanged_Postfix(bool status)
+        {
+            // Do not react when piece is first picked up.
+            if (status)
+            {
+                return;
+            }
+
+            var currentPiece = _gameContext.pieceAndTurnController.CurrentPiece;
+            _gameContext.tileHighlightController.UpdatePlayerMoveOutline(currentPiece);
+        }
+
+        private static void OnMiniatureGrabMoved(ActionSelect actionSelect, Vector3 position)
+        {
             if (actionSelect == null)
             {
                 return;
@@ -81,53 +106,6 @@
 
             _lastHoveredTile = hoveredTile;
             UpdatePlayerMoveOutline(hoveredTile);
-        }
-
-        private static void GrabbableMiniature_OnGrabMoved_Postfix(
-            GrabbableMiniature __instance,
-            Vector3 pos)
-        {
-            var actionSelect = Traverse.Create(__instance).Field<ActionSelect>("actionSelect").Value;
-            if (actionSelect == null)
-            {
-                return;
-            }
-
-            var hoveredTile = _gameContext.boardModel.GetTileHoverData(pos).tile;
-            var isMoveInvalid = !actionSelect.MovesInRange.IsMove(hoveredTile);
-            if (isMoveInvalid)
-            {
-                // No redraw required.
-                if (_lastHoveredTile == IntPoint2D.Invalid)
-                {
-                    return;
-                }
-
-                _lastHoveredTile = IntPoint2D.Invalid;
-                ResetPlayerMoveOutline();
-                return;
-            }
-
-            // No redraw required.
-            if (_lastHoveredTile == hoveredTile)
-            {
-                return;
-            }
-
-            _lastHoveredTile = hoveredTile;
-            UpdatePlayerMoveOutline(hoveredTile);
-        }
-
-        private static void BaseGrabbableMiniature_OnGrabStatusChanged_Postfix(bool status)
-        {
-            // Do not react when piece is first picked up.
-            if (status)
-            {
-                return;
-            }
-
-            var currentPiece = _gameContext.pieceAndTurnController.CurrentPiece;
-            _gameContext.tileHighlightController.UpdatePlayerMoveOutline(currentPiece);
         }
 
         private static void ResetPlayerMoveOutline()

--- a/Highlighter/Properties/AssemblyInfo.cs
+++ b/Highlighter/Properties/AssemblyInfo.cs
@@ -1,0 +1,43 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+using Highlighter;
+using MelonLoader;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Highlighter")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("DemeoMod Team")]
+[assembly: AssemblyProduct("Highlighter")]
+[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("E9D15E52-072A-4CC7-A7C3-21A4AA44FA79")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+
+// Melon Loader.
+[assembly: MelonInfo(typeof(HighlighterMod), "Highlighter", "1.0.0", "DemeoMods Team", "https://github.com/orendain/DemeoMods")]
+[assembly: MelonGame("Resolution Games", "Demeo")]
+[assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
+[assembly: VerifyLoaderVersion("0.5.7", true)]


### PR DESCRIPTION
This new mod, Highlighter, provides in-game highlighting/coloring.  Currently, the only highlighting this mod makes available is for displaying a character's line-of-sight.

This was inspired by [a mod written by MuKen](https://steamcommunity.com/app/1484280/discussions/0/3091137796295708382/) which was once in the scene.

Features:
- When hovering the local player's character over a square, the board will be highlighted with all squares that would be in that character's line-of-sight if they were to move there.

Known Functional Concerns:
1. There is a limit to how far the line-of-sight highlighting reaches.  This is due to the built-in ability, `MagicMissle`, that the mod uses to compute which squares are reachable.  This can be improved if a better, further-reaching ability is discovered, or if we tweak how valid squares are computed.

[Screencast from 09-18-2023 02:28:54 AM.webm](https://github.com/orendain/DemeoMods/assets/1426304/0d7383e6-5e62-4a21-aae2-584487e28457)