### PR TITLE
Add new rule, `LevelExitLockedUntilOneHeroRemainsRule`, which prohibts players from exiting levels unless they are the last hero remaining.

### DIFF
--- a/HouseRules.Essentials/EssentialsMod.cs
+++ b/HouseRules.Essentials/EssentialsMod.cs
@@ -44,6 +44,7 @@
             HR.Rulebook.Register(typeof(GoldPickedUpMultipliedRule));
             HR.Rulebook.Register(typeof(LampTypesOverriddenRule));
             HR.Rulebook.Register(typeof(LevelExitLockedUntilAllEnemiesDefeatedRule));
+            HR.Rulebook.Register(typeof(LevelExitLockedUntilOneHeroRemainsRule));
             HR.Rulebook.Register(typeof(LevelPropertiesModifiedRule));
             HR.Rulebook.Register(typeof(LevelSequenceOverriddenRule));
             HR.Rulebook.Register(typeof(MonsterDeckOverriddenRule));

--- a/HouseRules.Essentials/HouseRules.Essentials.csproj
+++ b/HouseRules.Essentials/HouseRules.Essentials.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Rules\CardClassRestrictionOverriddenRule.cs" />
     <Compile Include="Rules\CardEnergyAdditionOverriddenRule.cs" />
     <Compile Include="Rules\EnemyCooldownOverriddenRule.cs" />
+    <Compile Include="Rules\LevelExitLockedUntilOneHeroRemainsRule.cs" />
     <Compile Include="Rules\PartyElectricityDamageOverriddenRule.cs" />
     <Compile Include="Rules\FreeAbilityOnCritRule.cs" />
     <Compile Include="Rules\CourageShantyAddsHPRule.cs" />

--- a/HouseRules.Essentials/Rules/LevelExitLockedUntilOneHeroRemainsRule.cs
+++ b/HouseRules.Essentials/Rules/LevelExitLockedUntilOneHeroRemainsRule.cs
@@ -1,0 +1,92 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System.IO;
+    using Boardgame;
+    using Boardgame.SerializableEvents;
+    using HarmonyLib;
+    using HouseRules.Core.Types;
+
+    public sealed class LevelExitLockedUntilOneHeroRemainsRule :
+        Rule, IConfigWritable<bool>, IPatchable, IMultiplayerSafe
+    {
+        public override string Description => "Level exit is locked until only one hero remains";
+
+        private static bool _isActivated;
+        private static GameContext _gameContext;
+
+        public LevelExitLockedUntilOneHeroRemainsRule(bool enabled)
+        {
+        }
+
+        public bool GetConfigObject() => true;
+
+        protected override void OnActivate(GameContext gameContext)
+        {
+            _gameContext = gameContext;
+            _isActivated = true;
+        }
+
+        protected override void OnDeactivate(GameContext gameContext) => _isActivated = false;
+
+        private static void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(SerializableEventQueue), "ValidateSerializableEvent"),
+                postfix: new HarmonyMethod(
+                    typeof(LevelExitLockedUntilOneHeroRemainsRule),
+                    nameof(SerializableEventQueue_ValidateSerializableEvent_Postfix)));
+        }
+
+        private static void SerializableEventQueue_ValidateSerializableEvent_Postfix(
+            byte[] serializableEventData,
+            ref SerializableEvent __result)
+        {
+            if (!_isActivated)
+            {
+                return;
+            }
+
+            // Demeo has already determined the event was invalid.
+            if (__result == null)
+            {
+                return;
+            }
+
+            // Do not apply to the starting floor.
+            if (MotherTracker.motherTrackerData.floorIndex == 0)
+            {
+                return;
+            }
+
+            var serializableEvent = SerializableEvent.Deserialize(
+                new BinaryReader(new MemoryStream(serializableEventData)));
+            var interactEvent = serializableEvent as SerializableEventInteract;
+            if (interactEvent == null)
+            {
+                return;
+            }
+
+            if (IsPieceLastHeroAlive(interactEvent.pieceId))
+            {
+                return;
+            }
+
+            // Hero is not the last one alive. Disallow them from exiting.
+            __result = null;
+            GameUI.ShowCameraMessage("Only the last hero alive may exit the level.", 5);
+            _gameContext.serializableEventQueue.SendEventRequest(
+                new SerializableEventSnapToTile(interactEvent.pieceId));
+        }
+
+        private static bool IsPieceLastHeroAlive(int pieceId)
+        {
+            if (_gameContext.pieceAndTurnController.GetNumberOfPlayerPieces() > 1)
+            {
+                return false;
+            }
+
+            var lastPlayerPiece = _gameContext.pieceAndTurnController.GetPlayerPieces()[0];
+            return pieceId == lastPlayerPiece.networkID;
+        }
+    }
+}


### PR DESCRIPTION
Adds a new rule, `LevelExitLockedUntilOneHeroRemainsRule`, which prohibts players from exiting levels unless they are the last hero remaining.

Credit to `Logik` in the Discord server for the idea and request.