### PR TITLE
Bump minimum required version of MelonLoader to `0.5.7`.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,6 +23,9 @@ dotnet_diagnostic.SA1204.severity = None
 # SA1309FieldNamesMustNotBeginWithUnderscore.
 dotnet_diagnostic.SA1309.severity = None
 
+# SA1313ParameterNamesMustBeginWithLowerCaseLetter.
+dotnet_diagnostic.SA1313.severity = None
+
 # SA1600ElementsMustBeDocumented.
 dotnet_diagnostic.SA1600.severity = None
 

--- a/Highlighter/MelonLoaderMod.cs
+++ b/Highlighter/MelonLoaderMod.cs
@@ -5,7 +5,7 @@ using MelonLoader;
 [assembly: MelonInfo(typeof(MelonLoaderMod), HighlighterBase.ModName, HighlighterBase.ModVersion, HighlighterBase.ModAuthor, "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
-[assembly: VerifyLoaderVersion("0.5.3", true)]
+[assembly: VerifyLoaderVersion("0.5.7", true)]
 
 namespace Highlighter
 {

--- a/HouseRules.Configuration/MelonLoaderMod.cs
+++ b/HouseRules.Configuration/MelonLoaderMod.cs
@@ -6,7 +6,7 @@ using MelonLoader;
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("574512")]
-[assembly: VerifyLoaderVersion("0.5.3", true)]
+[assembly: VerifyLoaderVersion("0.5.7", true)]
 
 namespace HouseRules.Configuration
 {

--- a/HouseRules.Core/MelonLoaderMod.cs
+++ b/HouseRules.Core/MelonLoaderMod.cs
@@ -6,7 +6,7 @@ using MelonLoader;
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("574512")]
-[assembly: VerifyLoaderVersion("0.5.3", true)]
+[assembly: VerifyLoaderVersion("0.5.7", true)]
 
 namespace HouseRules.Core
 {

--- a/HouseRules.Essentials/MelonLoaderMod.cs
+++ b/HouseRules.Essentials/MelonLoaderMod.cs
@@ -6,7 +6,7 @@ using MelonLoader;
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("574512")]
-[assembly: VerifyLoaderVersion("0.5.3", true)]
+[assembly: VerifyLoaderVersion("0.5.7", true)]
 
 namespace HouseRules.Essentials
 {

--- a/RoomCode/MelonLoaderMod.cs
+++ b/RoomCode/MelonLoaderMod.cs
@@ -7,7 +7,7 @@ using RoomCode;
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("581308")]
-[assembly: VerifyLoaderVersion("0.5.3", true)]
+[assembly: VerifyLoaderVersion("0.5.7", true)]
 
 namespace RoomCode
 {

--- a/RoomFinder/MelonLoaderMod.cs
+++ b/RoomFinder/MelonLoaderMod.cs
@@ -6,7 +6,7 @@ using RoomFinder;
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("566788")]
-[assembly: VerifyLoaderVersion("0.5.3", true)]
+[assembly: VerifyLoaderVersion("0.5.7", true)]
 
 namespace RoomFinder
 {

--- a/SkipIntro/MelonLoaderMod.cs
+++ b/SkipIntro/MelonLoaderMod.cs
@@ -6,7 +6,7 @@ using SkipIntro;
 [assembly: MelonGame("Resolution Games", "Demeo")]
 [assembly: MelonGame("Resolution Games", "Demeo PC Edition")]
 [assembly: MelonID("566782")]
-[assembly: VerifyLoaderVersion("0.5.3", true)]
+[assembly: VerifyLoaderVersion("0.5.7", true)]
 
 namespace SkipIntro
 {


### PR DESCRIPTION
Also reduces the severity of [SA1313](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md) (so that we don't get warnings about Harmony parameters starting with double underscore.
