### PR TITLE
Longdesc wasn't working as intended

### DIFF
--- a/HouseRules.Configuration/UI/HouseRulesUiGameVr.cs
+++ b/HouseRules.Configuration/UI/HouseRulesUiGameVr.cs
@@ -53,7 +53,7 @@
             int numRules = 13;
             int textLength = 0;
             int returnCount = 0;
-            if (string.IsNullOrEmpty(HR.SelectedRuleset.Longdesc))
+            if (!string.IsNullOrEmpty(HR.SelectedRuleset.Longdesc))
             {
                 textLength = HR.SelectedRuleset.Longdesc.Length;
                 returnCount = HR.SelectedRuleset.Longdesc.Count(f => f == '\n');

--- a/HouseRules.Core/LifecycleDirector.cs
+++ b/HouseRules.Core/LifecycleDirector.cs
@@ -418,7 +418,7 @@
                 sb.AppendLine(ColorizeString(HR.SelectedRuleset.Description, Color.white));
                 sb.AppendLine();
 
-                if (string.IsNullOrEmpty(HR.SelectedRuleset.Longdesc))
+                if (!string.IsNullOrEmpty(HR.SelectedRuleset.Longdesc))
                 {
                     sb.AppendLine(ColorizeString($"<========== Ruleset Creator's Description ==========>", orange));
                     sb.AppendLine(ColorizeString($"{HR.SelectedRuleset.Longdesc}", gold));


### PR DESCRIPTION
Now the list of rules should show when no longdesc exists and the creator's description should show when there is one.