### PR TITLE
Fix `LevelExitLockedUntilOneHeroRemainsRule` triggering on _all_ interactables.

### DIFF
--- a/HouseRules.Essentials/Rules/LevelExitLockedUntilOneHeroRemainsRule.cs
+++ b/HouseRules.Essentials/Rules/LevelExitLockedUntilOneHeroRemainsRule.cs
@@ -66,6 +66,12 @@
                 return;
             }
 
+            var interactable = _gameContext.pieceAndTurnController.GetInteractableAtPosition(interactEvent.targetTile);
+            if (interactable.type != Interactable.Type.LevelExit)
+            {
+                return;
+            }
+
             if (IsPieceLastHeroAlive(interactEvent.pieceId))
             {
                 return;


### PR DESCRIPTION
Fix `LevelExitLockedUntilOneHeroRemainsRule` triggering on _all_ interactables.

The issue was that the rule would block all interactions, rather than just interactions with the exit.  This fixes that issue.