### PR TITLE
Add automatic release drafting when tagging mods for release.

### DIFF
--- a/.github/release-drafter-advancedstats.yaml
+++ b/.github/release-drafter-advancedstats.yaml
@@ -1,0 +1,5 @@
+_extends: demeomods:.github/release-drafter.yaml
+name-template: 'AdvancedStats v$RESOLVED_VERSION'
+tag-template: 'advancedstats-v$RESOLVED_VERSION'
+tag-prefix: 'advancedstats-v'
+include-labels: ['area: advancedstats']

--- a/.github/release-drafter-highlighter.yaml
+++ b/.github/release-drafter-highlighter.yaml
@@ -1,0 +1,5 @@
+_extends: demeomods:.github/release-drafter.yaml
+name-template: 'Highlighter v$RESOLVED_VERSION'
+tag-template: 'highlighter-v$RESOLVED_VERSION'
+tag-prefix: 'highlighter-v'
+include-labels: ['area: highlighter']

--- a/.github/release-drafter-houserules.yaml
+++ b/.github/release-drafter-houserules.yaml
@@ -1,0 +1,8 @@
+_extends: demeomods:.github/release-drafter.yaml
+name-template: 'HouseRules v$RESOLVED_VERSION'
+tag-template: 'houserules-v$RESOLVED_VERSION'
+tag-prefix: 'houserules-v'
+include-labels:
+  - 'area: houserules/configuration'
+  - 'area: houserules/core'
+  - 'area: houserules/essentials'

--- a/.github/release-drafter-roomcode.yaml
+++ b/.github/release-drafter-roomcode.yaml
@@ -1,0 +1,5 @@
+_extends: demeomods:.github/release-drafter.yaml
+name-template: 'RoomCode v$RESOLVED_VERSION'
+tag-template: 'roomcode-v$RESOLVED_VERSION'
+tag-prefix: 'roomcode-v'
+include-labels: ['area: roomcode']

--- a/.github/release-drafter-roomfinder.yaml
+++ b/.github/release-drafter-roomfinder.yaml
@@ -1,0 +1,5 @@
+_extends: demeomods:.github/release-drafter.yaml
+name-template: 'RoomFinder v$RESOLVED_VERSION'
+tag-template: 'roomfinder-v$RESOLVED_VERSION'
+tag-prefix: 'roomfinder-v'
+include-labels: ['area: roomfinder']

--- a/.github/release-drafter-skipintro.yaml
+++ b/.github/release-drafter-skipintro.yaml
@@ -1,0 +1,5 @@
+_extends: demeomods:.github/release-drafter.yaml
+name-template: 'SkipIntro v$RESOLVED_VERSION'
+tag-template: 'skipintro-v$RESOLVED_VERSION'
+tag-prefix: 'skipintro-v'
+include-labels: ['area: skipintro']

--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -1,0 +1,11 @@
+categories:
+  - title: '✨ Features/Enhancements'
+    labels: ['type: feature']
+  - title: '🐛 Fixes'
+    labels: ['type: bug']
+  - title: '🧰 Maintenance'
+    labels: ['type: chore', 'type: documentation']
+category-template: '### $TITLE'
+change-template: '- $TITLE (#$NUMBER)'
+exclude-labels: ['type: amendment']
+template: '$CHANGES'

--- a/.github/workflows/advancedstats-tag.yaml
+++ b/.github/workflows/advancedstats-tag.yaml
@@ -1,0 +1,35 @@
+name: AdvancedStats Tag
+
+on:
+  push:
+    tags:
+      - 'advancedstats-v*'
+
+jobs:
+  capture_version:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.capture_version.outputs.tag }}
+      version: ${{ steps.capture_version.outputs.version }}
+    steps:
+      - name: Capture Version
+        id: capture_version
+        run: |
+          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "version=${GITHUB_REF#refs/tags/advancedstats-v}" >> $GITHUB_OUTPUT
+
+  draft:
+    name: Draft Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    needs: capture_version
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-advancedstats.yaml
+          tag: ${{ needs.capture_version.outputs.tag }}
+          version: ${{ needs.capture_version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/highlighter-tag.yaml
+++ b/.github/workflows/highlighter-tag.yaml
@@ -1,0 +1,35 @@
+name: Highlighter Tag
+
+on:
+  push:
+    tags:
+      - 'highlighter-v*'
+
+jobs:
+  capture_version:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.capture_version.outputs.tag }}
+      version: ${{ steps.capture_version.outputs.version }}
+    steps:
+      - name: Capture Version
+        id: capture_version
+        run: |
+          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "version=${GITHUB_REF#refs/tags/highlighter-v}" >> $GITHUB_OUTPUT
+
+  draft:
+    name: Draft Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    needs: capture_version
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-highlighter.yaml
+          tag: ${{ needs.capture_version.outputs.tag }}
+          version: ${{ needs.capture_version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/houserules-tag.yaml
+++ b/.github/workflows/houserules-tag.yaml
@@ -1,0 +1,35 @@
+name: HouseRules Tag
+
+on:
+  push:
+    tags:
+      - 'houserules-v*'
+
+jobs:
+  capture_version:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.capture_version.outputs.tag }}
+      version: ${{ steps.capture_version.outputs.version }}
+    steps:
+      - name: Capture Version
+        id: capture_version
+        run: |
+          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "version=${GITHUB_REF#refs/tags/houserules-v}" >> $GITHUB_OUTPUT
+
+  draft:
+    name: Draft Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    needs: capture_version
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-houserules.yaml
+          tag: ${{ needs.capture_version.outputs.tag }}
+          version: ${{ needs.capture_version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/roomcode-tag.yaml
+++ b/.github/workflows/roomcode-tag.yaml
@@ -1,0 +1,35 @@
+name: RoomCode Tag
+
+on:
+  push:
+    tags:
+      - 'roomcode-v*'
+
+jobs:
+  capture_version:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.capture_version.outputs.tag }}
+      version: ${{ steps.capture_version.outputs.version }}
+    steps:
+      - name: Capture Version
+        id: capture_version
+        run: |
+          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "version=${GITHUB_REF#refs/tags/roomcode-v}" >> $GITHUB_OUTPUT
+
+  draft:
+    name: Draft Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    needs: capture_version
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-roomcode.yaml
+          tag: ${{ needs.capture_version.outputs.tag }}
+          version: ${{ needs.capture_version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/roomfinder-tag.yaml
+++ b/.github/workflows/roomfinder-tag.yaml
@@ -1,0 +1,35 @@
+name: RoomFinder Tag
+
+on:
+  push:
+    tags:
+      - 'roomfinder-v*'
+
+jobs:
+  capture_version:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.capture_version.outputs.tag }}
+      version: ${{ steps.capture_version.outputs.version }}
+    steps:
+      - name: Capture Version
+        id: capture_version
+        run: |
+          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "version=${GITHUB_REF#refs/tags/roomfinder-v}" >> $GITHUB_OUTPUT
+
+  draft:
+    name: Draft Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    needs: capture_version
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-roomfinder.yaml
+          tag: ${{ needs.capture_version.outputs.tag }}
+          version: ${{ needs.capture_version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/skipintro-tag.yaml
+++ b/.github/workflows/skipintro-tag.yaml
@@ -1,0 +1,35 @@
+name: SkipIntro Tag
+
+on:
+  push:
+    tags:
+      - 'skipintro-v*'
+
+jobs:
+  capture_version:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.capture_version.outputs.tag }}
+      version: ${{ steps.capture_version.outputs.version }}
+    steps:
+      - name: Capture Version
+        id: capture_version
+        run: |
+          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "version=${GITHUB_REF#refs/tags/skipintro-v}" >> $GITHUB_OUTPUT
+
+  draft:
+    name: Draft Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    needs: capture_version
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-skipintro.yaml
+          tag: ${{ needs.capture_version.outputs.tag }}
+          version: ${{ needs.capture_version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/DemeoMods.sln
+++ b/DemeoMods.sln
@@ -21,6 +21,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoomFinder", "RoomFinder\Ro
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SkipIntro", "SkipIntro\SkipIntro.csproj", "{E986568C-684F-4DD3-980C-8D8443982EC6}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{30D29CFD-6317-4630-B618-9590E90E6CAE}"
+	ProjectSection(SolutionItems) = preProject
+		.github\labeler.yml = .github\labeler.yml
+		.github\release-drafter.yaml = .github\release-drafter.yaml
+		.github\release-drafter-advancedstats.yaml = .github\release-drafter-advancedstats.yaml
+		.github\release-drafter-highlighter.yaml = .github\release-drafter-highlighter.yaml
+		.github\release-drafter-houserules.yaml = .github\release-drafter-houserules.yaml
+		.github\release-drafter-roomcode.yaml = .github\release-drafter-roomcode.yaml
+		.github\release-drafter-roomfinder.yaml = .github\release-drafter-roomfinder.yaml
+		.github\release-drafter-skipintro.yaml = .github\release-drafter-skipintro.yaml
+	EndProjectSection
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".workflows", ".workflows", "{704400AE-213D-4015-A6A6-2F5659641B56}"
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\highlighter.yml = .github\workflows\highlighter.yml
@@ -31,6 +43,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".workflows", ".workflows", 
 		.github\workflows\curseforge.yml = .github\workflows\curseforge.yml
 		.github\workflows\houserules.yml = .github\workflows\houserules.yml
 		.github\workflows\roomfinder.yml = .github\workflows\roomfinder.yml
+		.github\workflows\advancedstats-tag.yaml = .github\workflows\advancedstats-tag.yaml
+		.github\workflows\highlighter-tag.yaml = .github\workflows\highlighter-tag.yaml
+		.github\workflows\houserules-tag.yaml = .github\workflows\houserules-tag.yaml
+		.github\workflows\roomcode-tag.yaml = .github\workflows\roomcode-tag.yaml
+		.github\workflows\roomfinder-tag.yaml = .github\workflows\roomfinder-tag.yaml
+		.github\workflows\skipintro-tag.yaml = .github\workflows\skipintro-tag.yaml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{8C7F69F7-5EF5-4AED-8B59-43EB164F7EC5}"
@@ -124,5 +142,8 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B0B15766-A7B9-4CB1-A9A0-EE502996942A}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{704400AE-213D-4015-A6A6-2F5659641B56} = {30D29CFD-6317-4630-B618-9590E90E6CAE}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Adds automatic release drafting when tagging mods for release.  When a tag is created for a mod, a release is automatically drafted with the changelog automatically filled it.

In order to improve tagging, this PR assumes a slight change how to releases are tagged.


Instead of `<version>-<mod-name>` (e.g., `v1.0.0-roomfinder`), the files in this PR look for `<mod-name>-<version>` (e.g., `roomfinder-v1.0.0`).

This way, tags are organized first by the mod they represent before anything else.