### PR TITLE
Unify HouseRules versioning.

### DIFF
--- a/HouseRules.Configuration/BepInExPlugin.cs
+++ b/HouseRules.Configuration/BepInExPlugin.cs
@@ -8,10 +8,7 @@ namespace HouseRules.Configuration
     using HouseRules.Core;
     using UnityEngine.SceneManagement;
 
-    [BepInPlugin(
-        HouseRulesConfigurationBase.ModId,
-        HouseRulesConfigurationBase.ModName,
-        HouseRulesConfigurationBase.ModVersion)]
+    [BepInPlugin(HouseRulesConfigurationBase.ModId, HouseRulesConfigurationBase.ModName, BuildVersion.Version)]
     [BepInDependency("com.orendain.demeomods.houserules.core")]
     internal class BepInExPlugin : BaseUnityPlugin
     {

--- a/HouseRules.Configuration/HouseRulesConfigurationBase.cs
+++ b/HouseRules.Configuration/HouseRulesConfigurationBase.cs
@@ -12,7 +12,6 @@
     {
         internal const string ModId = "com.orendain.demeomods.houserules.configuration";
         internal const string ModName = "HouseRules.Configuration";
-        internal const string ModVersion = "1.8.0";
         internal const string ModAuthor = "DemeoMods Team";
 
         private const int PC1LobbySceneIndex = 1;

--- a/HouseRules.Configuration/MelonLoaderMod.cs
+++ b/HouseRules.Configuration/MelonLoaderMod.cs
@@ -5,7 +5,7 @@ using MelonLoader;
 [assembly: MelonInfo(
     typeof(MelonLoaderMod),
     HouseRulesConfigurationBase.ModName,
-    HouseRulesConfigurationBase.ModVersion,
+    HouseRules.Core.BuildVersion.Version,
     HouseRulesConfigurationBase.ModAuthor,
     "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]

--- a/HouseRules.Configuration/VersionChecker.cs
+++ b/HouseRules.Configuration/VersionChecker.cs
@@ -72,13 +72,13 @@
         /// </summary>
         private static bool TryParseVersion(string tag, out string version)
         {
-            if (!tag.EndsWith("-houserules"))
+            if (!tag.StartsWith("houserules-"))
             {
                 version = string.Empty;
                 return false;
             }
 
-            version = tag.Substring(1).Replace("-houserules", string.Empty);
+            version = tag.Replace("houserules-v", string.Empty);
             return true;
         }
 

--- a/HouseRules.Core/BepInExPlugin.cs
+++ b/HouseRules.Core/BepInExPlugin.cs
@@ -5,7 +5,7 @@ namespace HouseRules.Core
     using BepInEx.Logging;
     using HarmonyLib;
 
-    [BepInPlugin(HouseRulesCoreBase.ModId, HouseRulesCoreBase.ModName, HouseRulesCoreBase.ModVersion)]
+    [BepInPlugin(HouseRulesCoreBase.ModId, HouseRulesCoreBase.ModName, BuildVersion.Version)]
     internal class BepInExPlugin : BaseUnityPlugin
     {
         internal ManualLogSource? Log { get; private set; }

--- a/HouseRules.Core/BuildVersion.cs
+++ b/HouseRules.Core/BuildVersion.cs
@@ -2,7 +2,6 @@
 {
     public static class BuildVersion
     {
-        public const string Version = "1.7.0";
-        public const string MajorMinorVersion = "1.7";
+        public const string Version = "1.8.0";
     }
 }

--- a/HouseRules.Core/HouseRulesCoreBase.cs
+++ b/HouseRules.Core/HouseRulesCoreBase.cs
@@ -9,7 +9,6 @@
     {
         internal const string ModId = "com.orendain.demeomods.houserules.core";
         internal const string ModName = "HouseRules.Core";
-        internal const string ModVersion = "1.8.0";
         internal const string ModAuthor = "DemeoMods Team";
 
         private static Action<object>? _logInfo;

--- a/HouseRules.Core/MelonLoaderMod.cs
+++ b/HouseRules.Core/MelonLoaderMod.cs
@@ -5,7 +5,7 @@ using MelonLoader;
 [assembly: MelonInfo(
     typeof(MelonLoaderMod),
     HouseRulesCoreBase.ModName,
-    HouseRulesCoreBase.ModVersion,
+    BuildVersion.Version,
     HouseRulesCoreBase.ModAuthor,
     "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]

--- a/HouseRules.Essentials/BepInExPlugin.cs
+++ b/HouseRules.Essentials/BepInExPlugin.cs
@@ -4,7 +4,7 @@ namespace HouseRules.Essentials
     using BepInEx;
     using BepInEx.Logging;
 
-    [BepInPlugin(HouseRulesEssentialsBase.ModId, HouseRulesEssentialsBase.ModName, HouseRulesEssentialsBase.ModVersion)]
+    [BepInPlugin(HouseRulesEssentialsBase.ModId, HouseRulesEssentialsBase.ModName, Core.BuildVersion.Version)]
     [BepInDependency("com.orendain.demeomods.houserules.core")]
     public class BepInExPlugin : BaseUnityPlugin
     {

--- a/HouseRules.Essentials/HouseRulesEssentialsBase.cs
+++ b/HouseRules.Essentials/HouseRulesEssentialsBase.cs
@@ -9,7 +9,6 @@
     {
         internal const string ModId = "com.orendain.demeomods.houserules.essentials";
         internal const string ModName = "HouseRules.Essentials";
-        internal const string ModVersion = "1.8.0";
         internal const string ModAuthor = "DemeoMods Team";
 
         private static Action<object>? _logDebug;

--- a/HouseRules.Essentials/MelonLoaderMod.cs
+++ b/HouseRules.Essentials/MelonLoaderMod.cs
@@ -5,7 +5,7 @@ using MelonLoader;
 [assembly: MelonInfo(
     typeof(MelonLoaderMod),
     HouseRulesEssentialsBase.ModName,
-    HouseRulesEssentialsBase.ModVersion,
+    HouseRules.Core.BuildVersion.Version,
     HouseRulesEssentialsBase.ModAuthor,
     "https://github.com/orendain/DemeoMods")]
 [assembly: MelonGame("Resolution Games", "Demeo")]


### PR DESCRIPTION
Unify HouseRules versioning so that all HR components use the same build version.

Also realigns update-checking logig with updated HouseRules version naming, as described in https://github.com/orendain/DemeoMods/pull/524.