### PR TITLE
Gracefully handle the case when the HouseRules ruleset directory is missing.

### DIFF
--- a/HouseRules.Configuration/HouseRulesConfigurationBase.cs
+++ b/HouseRules.Configuration/HouseRulesConfigurationBase.cs
@@ -1,9 +1,8 @@
-﻿using System.IO;
-
-namespace HouseRules.Configuration
+﻿namespace HouseRules.Configuration
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using Common.UI;
     using HouseRules.Configuration.UI;
     using HouseRules.Core;

--- a/HouseRules.Configuration/HouseRulesConfigurationBase.cs
+++ b/HouseRules.Configuration/HouseRulesConfigurationBase.cs
@@ -1,4 +1,6 @@
-﻿namespace HouseRules.Configuration
+﻿using System.IO;
+
+namespace HouseRules.Configuration
 {
     using System;
     using System.Collections.Generic;
@@ -134,6 +136,12 @@
         /// <param name="directory">Path of the directory from which to load rulesets.</param>
         internal static void LoadRulesetsFromDirectory(string directory)
         {
+            if (!Directory.Exists(directory))
+            {
+                LogWarning($"Directory [{directory}] does not exist. Skipping ruleset loading.");
+                return;
+            }
+
             var rulesetFiles = RulesetImporter.ListRulesets(directory);
             LogInfo($"Found [{rulesetFiles.Count}] custom ruleset files to load.");
 

--- a/HouseRules.Configuration/HouseRulesConfigurationBase.cs
+++ b/HouseRules.Configuration/HouseRulesConfigurationBase.cs
@@ -138,8 +138,7 @@ namespace HouseRules.Configuration
         {
             if (!Directory.Exists(directory))
             {
-                LogWarning($"Directory [{directory}] does not exist. Skipping ruleset loading.");
-                return;
+                Directory.CreateDirectory(directory);
             }
 
             var rulesetFiles = RulesetImporter.ListRulesets(directory);


### PR DESCRIPTION
Creates the HR ruleset directory if it's missing, avoiding an error being logged.