### PR TITLE
Fix RoomFinder not updating room list when returning from Heroes Hangouts.

### DIFF
--- a/RoomFinder/RoomFinderBase.cs
+++ b/RoomFinder/RoomFinderBase.cs
@@ -12,8 +12,10 @@
         internal const string ModVersion = "1.9.0";
         internal const string ModAuthor = "DemeoMods Team";
 
-        private const int PC1LobbySceneIndex = 1;
-        private const int PC2LobbySceneIndex = 3;
+        private const int NonVrSteamLobbySceneIndex = 1;
+        private const int NonVrCombinedSteamLobbySceneIndex = 3;
+        private const int VrSteamLobbySceneIndex = 1;
+        private const int VrQuestLobbySceneIndex = 1;
 
         private static Action<object>? _logInfo;
         private static Action<object>? _logDebug;
@@ -74,24 +76,23 @@
         {
             if (MotherbrainGlobalVars.IsRunningOnNonVRPlatform)
             {
-                if (buildIndex != PC1LobbySceneIndex && buildIndex != PC2LobbySceneIndex)
+                if (buildIndex == NonVrSteamLobbySceneIndex || buildIndex == NonVrCombinedSteamLobbySceneIndex)
                 {
-                    LogInfo($"{buildIndex} scene failed to load PC lobby");
-                    return;
+                    LogDebug("Recognized lobby in PC. Loading UI.");
+                    _ = new GameObject("RoomFinderUiNonVr", typeof(RoomFinderUiNonVr));
                 }
 
-                LogDebug("Recognized lobby in PC. Loading UI.");
-                _ = new GameObject("RoomFinderUiNonVr", typeof(RoomFinderUiNonVr));
                 return;
             }
 
-            if (buildIndex != PC1LobbySceneIndex && buildIndex != PC2LobbySceneIndex)
+            if (MotherbrainGlobalVars.IsRunningOnVRPlatform)
             {
-                return;
+                if (buildIndex == VrSteamLobbySceneIndex || buildIndex == VrQuestLobbySceneIndex)
+                {
+                    LogDebug("Recognized lobby in VR. Loading UI.");
+                    _ = new GameObject("RoomFinderUiVr", typeof(RoomFinderUiVr));
+                }
             }
-
-            LogDebug("Recognized lobby in VR. Loading UI.");
-            _ = new GameObject("RoomFinderUiVr", typeof(RoomFinderUiVr));
         }
     }
 }

--- a/RoomFinder/RoomFinderBase.cs
+++ b/RoomFinder/RoomFinderBase.cs
@@ -72,7 +72,6 @@
 
         internal static void OnSceneLoaded(int buildIndex)
         {
-            LogDebug("OnSceneLoaded");
             if (MotherbrainGlobalVars.IsRunningOnNonVRPlatform)
             {
                 if (buildIndex != PC1LobbySceneIndex && buildIndex != PC2LobbySceneIndex)

--- a/RoomFinder/UI/RoomFinderUiVr.cs
+++ b/RoomFinder/UI/RoomFinderUiVr.cs
@@ -20,6 +20,11 @@
             RoomManager.RoomListUpdated += OnRoomListUpdated;
         }
 
+        private void OnDestroy()
+        {
+            RoomManager.RoomListUpdated -= OnRoomListUpdated;
+        }
+
         private IEnumerator WaitAndInitialize()
         {
             while (!VrElementCreator.IsReady()


### PR DESCRIPTION
Fixes RoomFinder not updating room list when returning from Heroes Hangouts.

Thanks to `MexicanS.C.` from the Demeo Modding Discord server for reporting the issue.

Also renames some constants to make RoomFinder UI loading logic a bit more readable by looking at the code.