### PR TITLE
Update RoomFinder to be compatible with Demeo 1.39 (NonVR Steam).

### DIFF
--- a/RoomFinder/RoomFinderBase.cs
+++ b/RoomFinder/RoomFinderBase.cs
@@ -12,8 +12,7 @@
         internal const string ModVersion = "1.9.0";
         internal const string ModAuthor = "DemeoMods Team";
 
-        private const int NonVrSteamLobbySceneIndex = 1;
-        private const int NonVrCombinedSteamLobbySceneIndex = 3;
+        private const int NonVrSteamWindowsLobbySceneIndex = 2;
         private const int VrSteamLobbySceneIndex = 1;
         private const int VrQuestLobbySceneIndex = 1;
 
@@ -74,11 +73,11 @@
 
         internal static void OnSceneLoaded(int buildIndex)
         {
-            if (MotherbrainGlobalVars.IsRunningOnNonVRPlatform)
+            if (MotherbrainGlobalVars.SelectedPlatform == MotherbrainPlatform.NonVrSteamWindows)
             {
-                if (buildIndex == NonVrSteamLobbySceneIndex || buildIndex == NonVrCombinedSteamLobbySceneIndex)
+                if (buildIndex == NonVrSteamWindowsLobbySceneIndex)
                 {
-                    LogDebug("Recognized lobby in PC. Loading UI.");
+                    LogDebug("Recognized lobby in NonVrSteamWindows. Loading UI.");
                     _ = new GameObject("RoomFinderUiNonVr", typeof(RoomFinderUiNonVr));
                 }
 

--- a/RoomFinder/RoomManager.cs
+++ b/RoomFinder/RoomManager.cs
@@ -23,6 +23,7 @@
         /// </summary>
         internal static void RefreshRoomList()
         {
+            _lobby = _gameContext.gameStateMachine.lobby as Lobby;
             if (_lobby == null)
             {
                 RoomFinderBase.LogWarning("Lobby is uninitialized. Skipping room refresh.");
@@ -86,7 +87,6 @@
         private static void GameStartup_InitializeGame_Postfix(GameStartup __instance)
         {
             _gameContext = Traverse.Create(__instance).Field<GameContext>("gameContext").Value;
-            _lobby = Traverse.Create(__instance).Field<Lobby>("lobby").Value;
         }
 
         private static void MatchmakingControllerFactory_Create_Postfix(MatchmakingController __result)


### PR DESCRIPTION
Updates RoomFinder to be compatible with Demeo 1.39. This PR is focused on NonVR Steam (A.K.A. PC Edition). Checking the necessary updates required for other platforms will come after (would need to boot up other machines to test it).

Changes:
- ca72dad Add non-VR Steam specific check for scene indexes.
- 2e807da Get lobby reference at refresh time, not initialization time. Since lobby may not yet be initialized at game init.

> [!NOTE]
> @orendain tested this on PC Edition, but has not yet tested it on Steam VR or Quest VR. If needed, he can test that platform after a few other changes are merged in.