### PR TITLE
Update SkipIntro to work with Demeo 1.39.

### DIFF
--- a/SkipIntro/ModPatcher.cs
+++ b/SkipIntro/ModPatcher.cs
@@ -26,8 +26,8 @@
         private static bool MotherbrainSceneUtil_LoadIntro_Prefix(ref AsyncOperation __result)
         {
             SkipIntroBase.LogDebug("Skipping the intro scene.");
-            (AsyncOperation, AsyncOperation) tuple = MotherbrainSceneUtil.LoadLobby();
-            __result = tuple.Item1;
+            var (loadLobby, _) = MotherbrainSceneUtil.LoadLobby();
+            __result = loadLobby;
             return false;
         }
 

--- a/SkipIntro/ModPatcher.cs
+++ b/SkipIntro/ModPatcher.cs
@@ -26,7 +26,8 @@
         private static bool MotherbrainSceneUtil_LoadIntro_Prefix(ref AsyncOperation __result)
         {
             SkipIntroBase.LogDebug("Skipping the intro scene.");
-            __result = MotherbrainSceneUtil.LoadLobby();
+            (AsyncOperation, AsyncOperation) tuple = MotherbrainSceneUtil.LoadLobby();
+            __result = tuple.Item1;
             return false;
         }
 


### PR DESCRIPTION
Updates SkipIntro to work with Demeo 1.39.

Interestingly, the existing SkipIntro DLL works when I tested it. However, the existing _code_ won't compile, it's just the current DLL that works. This change will ensure SkipIntro will build fine.

> [!NOTE]
> @orendain tested this on PC Edition, but has not yet tested it on Steam VR or Quest VR. If needed, he can test that platform after a few other changes are merged in.