### PR TITLE
Update RoomFinder to be compatible with Demeo 1.39 (VR and NonVR Quest/Steam versions).

### DIFF
--- a/RoomFinder/RoomFinderBase.cs
+++ b/RoomFinder/RoomFinderBase.cs
@@ -13,8 +13,9 @@
         internal const string ModAuthor = "DemeoMods Team";
 
         private const int NonVrSteamWindowsLobbySceneIndex = 2;
-        private const int VrSteamLobbySceneIndex = 1;
-        private const int VrQuestLobbySceneIndex = 1;
+        private const int NonVrOculusWindowsLobbySceneIndex = 2;
+        private const int SteamVRLobbySceneIndex = 1;
+        private const int RiftLobbySceneIndex = 1;
 
         private static Action<object>? _logInfo;
         private static Action<object>? _logDebug;
@@ -84,11 +85,33 @@
                 return;
             }
 
-            if (MotherbrainGlobalVars.IsRunningOnVRPlatform)
+            if (MotherbrainGlobalVars.SelectedPlatform == MotherbrainPlatform.NonVrOculusWindows)
             {
-                if (buildIndex == VrSteamLobbySceneIndex || buildIndex == VrQuestLobbySceneIndex)
+                if (buildIndex == NonVrOculusWindowsLobbySceneIndex)
                 {
-                    LogDebug("Recognized lobby in VR. Loading UI.");
+                    LogDebug("Recognized lobby in NonVrOculusWindows. Loading UI.");
+                    _ = new GameObject("RoomFinderUiNonVr", typeof(RoomFinderUiNonVr));
+                }
+
+                return;
+            }
+
+            if (MotherbrainGlobalVars.SelectedPlatform == MotherbrainPlatform.SteamVR)
+            {
+                if (buildIndex == SteamVRLobbySceneIndex)
+                {
+                    LogDebug("Recognized lobby in SteamVR. Loading UI.");
+                    _ = new GameObject("RoomFinderUiVr", typeof(RoomFinderUiVr));
+                }
+
+                return;
+            }
+
+            if (MotherbrainGlobalVars.SelectedPlatform == MotherbrainPlatform.Rift)
+            {
+                if (buildIndex == RiftLobbySceneIndex)
+                {
+                    LogDebug("Recognized lobby in Rift. Loading UI.");
                     _ = new GameObject("RoomFinderUiVr", typeof(RoomFinderUiVr));
                 }
             }


### PR DESCRIPTION
Updates RoomFinder to be compatible with Demeo 1.39 (VR and NonVR Quest/Steam versions).

The previous RoomFinder commit removed the shared check and scene index variable used between NonVR Steam and NonVR Quest, and started by adding in an explicit check and variable used only by NonVR Steam.

This commit adds the equivalent check and variable for NonVR Quest. Additionally, it separates the checks for VR platforms (SteamVR and "Rift"). Making these checks more explicit should make it easier for us to make fixes should any one platform change.

@orendain tested RoomFinder on all 4 different platforms: NonVR Steam, Steam VR, NonVR Quest, Rift.