### PR TITLE
Update GitHub builds to reference latest Demeo assemblies.

### DIFF
--- a/.github/workflows/advancedstats.yaml
+++ b/.github/workflows/advancedstats.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Add Dependencies
         run: |
-          wget -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/6b23af71840c8574354a84639c7097888acb3c19/2025-06-08.zip
+          wget -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/63c8d96e6eb642d540c096f5bb9fb8dbcbe937a7/2025-06-08.zip
           7z x deps.zip -o./libs
 
       - name: Build BepInEx Plugin

--- a/.github/workflows/freecamera.yaml
+++ b/.github/workflows/freecamera.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Add Dependencies
         run: |
-          wget -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/6b23af71840c8574354a84639c7097888acb3c19/2025-06-08.zip
+          wget -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/63c8d96e6eb642d540c096f5bb9fb8dbcbe937a7/2025-06-08.zip
           7z x deps.zip -o./libs
 
       - name: Build BepInEx Plugin

--- a/.github/workflows/highlighter.yaml
+++ b/.github/workflows/highlighter.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Add Dependencies
         run: |
-          wget -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/6b23af71840c8574354a84639c7097888acb3c19/2025-06-08.zip
+          wget -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/63c8d96e6eb642d540c096f5bb9fb8dbcbe937a7/2025-06-08.zip
           7z x deps.zip -o./libs
 
       - name: Build BepInEx Plugin

--- a/.github/workflows/houserules.yaml
+++ b/.github/workflows/houserules.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Add Dependencies
         run: |
-          wget -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/6b23af71840c8574354a84639c7097888acb3c19/2025-06-08.zip
+          wget -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/63c8d96e6eb642d540c096f5bb9fb8dbcbe937a7/2025-06-08.zip
           7z x deps.zip -o./libs
 
       - name: Build HouseRules.Core BepInEx Plugin

--- a/.github/workflows/roomcode.yaml
+++ b/.github/workflows/roomcode.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Add Dependencies
         run: |
-          wget -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/6b23af71840c8574354a84639c7097888acb3c19/2025-06-08.zip
+          wget -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/63c8d96e6eb642d540c096f5bb9fb8dbcbe937a7/2025-06-08.zip
           7z x deps.zip -o./libs
 
       - name: Build BepInEx Plugin

--- a/.github/workflows/roomfinder.yaml
+++ b/.github/workflows/roomfinder.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Add Dependencies
         run: |
-          wget -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/6b23af71840c8574354a84639c7097888acb3c19/2025-06-08.zip
+          wget -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/63c8d96e6eb642d540c096f5bb9fb8dbcbe937a7/2025-06-08.zip
           7z x deps.zip -o./libs
 
       - name: Build BepInEx Plugin

--- a/.github/workflows/skipintro.yaml
+++ b/.github/workflows/skipintro.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Add Dependencies
         run: |
-          wget -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/6b23af71840c8574354a84639c7097888acb3c19/2025-06-08.zip
+          wget -O deps.zip https://gist.github.com/orendain/9053d92b9f3571c619618619665c8cbc/raw/63c8d96e6eb642d540c096f5bb9fb8dbcbe937a7/2025-06-08.zip
           7z x deps.zip -o./libs
 
       - name: Build BepInEx Plugin


### PR DESCRIPTION
Resolves #540.

Updates GitHub builds to reference latest Demeo assemblies as of 2025-06-08.

HouseRules still fails checks, but for other reasons which will be addressed separately.