### PR TITLE
Fix multiple, overlapping, instances HouseRules UI appearing.

### DIFF
--- a/Common.UI/Environments.cs
+++ b/Common.UI/Environments.cs
@@ -2,42 +2,20 @@
 {
     using UnityEngine.SceneManagement;
 
-    public enum Environment
-    {
-        Hangouts,
-        NonVr,
-        Vr,
-    }
-
     public static class Environments
     {
-        private const int SteamHangoutsSceneIndex = 45;
-        private const int OculusHangoutsSceneIndex = 43;
-
-        public static Environment CurrentEnvironment()
-        {
-            if (IsPcEdition())
-            {
-                return Environment.NonVr;
-            }
-
-            if (IsInHangouts())
-            {
-                return Environment.Hangouts;
-            }
-
-            return Environment.Vr;
-        }
-
-        public static bool IsPcEdition()
-        {
-            return MotherbrainGlobalVars.IsRunningOnNonVRPlatform;
-        }
+        private const int SteamVRHangoutsSceneIndex = 45;
+        private const int RiftHangoutsSceneIndex = 43;
 
         public static bool IsInHangouts()
         {
-            return SceneManager.GetActiveScene().buildIndex == SteamHangoutsSceneIndex
-                || SceneManager.GetActiveScene().buildIndex == OculusHangoutsSceneIndex;
+            if (!MotherbrainGlobalVars.IsRunningOnVRPlatform)
+            {
+                return false;
+            }
+
+            return SceneManager.GetActiveScene().buildIndex == SteamVRHangoutsSceneIndex
+                || SceneManager.GetActiveScene().buildIndex == RiftHangoutsSceneIndex;
         }
     }
 }

--- a/Common.UI/PageStackNavigation.cs
+++ b/Common.UI/PageStackNavigation.cs
@@ -34,7 +34,7 @@
             _nextButton = elementCreator.CreateButton(OnNextPageClick);
             _nextButtonText = elementCreator.CreateButtonText(">");
 
-            if (Environments.CurrentEnvironment() == Environment.NonVr)
+            if (MotherbrainGlobalVars.IsRunningOnNonVRPlatform)
             {
                 InitializeForNonVr();
             }

--- a/HouseRules.Configuration/HouseRulesConfigurationBase.cs
+++ b/HouseRules.Configuration/HouseRulesConfigurationBase.cs
@@ -15,8 +15,10 @@
         internal const string ModName = "HouseRules.Configuration";
         internal const string ModAuthor = "DemeoMods Team";
 
-        private const int NonVrSteamLobbySceneIndex = 2;
-        private const int NonVrCombinedSteamLobbySceneIndex = 3;
+        private const int NonVrSteamWindowsLobbySceneIndex = 2;
+        private const int NonVrOculusWindowsLobbySceneIndex = 2;
+        private const int SteamVRLobbySceneIndex = 1;
+        private const int RiftLobbySceneIndex = 1;
 
         private static Action<object>? _logInfo;
         private static Action<object>? _logDebug;
@@ -92,36 +94,62 @@
 
         internal static void OnSceneLoaded(int buildIndex, string sceneName)
         {
-            if (buildIndex == 0 || sceneName.Contains("Startup"))
+            if (MotherbrainGlobalVars.SelectedPlatform == MotherbrainPlatform.NonVrSteamWindows)
             {
+                if (buildIndex == NonVrSteamWindowsLobbySceneIndex)
+                {
+                    LogDebug("Recognized lobby in NonVrSteamWindows. Loading UI.");
+                    _ = new GameObject("HouseRulesUiNonVr", typeof(HouseRulesUiNonVr));
+                }
+
                 return;
             }
 
-            if (Environments.IsPcEdition())
+            if (MotherbrainGlobalVars.SelectedPlatform == MotherbrainPlatform.NonVrOculusWindows)
             {
-                if (buildIndex == NonVrSteamLobbySceneIndex || buildIndex == NonVrCombinedSteamLobbySceneIndex)
+                if (buildIndex == NonVrOculusWindowsLobbySceneIndex)
                 {
-                    LogDebug("Recognized lobby in PC. Loading UI.");
+                    LogDebug("Recognized lobby in NonVrOculusWindows. Loading UI.");
                     _ = new GameObject("HouseRulesUiNonVr", typeof(HouseRulesUiNonVr));
                 }
+
+                return;
             }
-            else if (Environments.IsInHangouts() || sceneName.Contains("HobbyShop"))
+
+            if (Environments.IsInHangouts())
             {
                 LogDebug("Recognized lobby in Hangouts. Loading UI.");
                 _ = new GameObject("HouseRulesUiHangouts", typeof(HouseRulesUiHangouts));
+                return;
             }
-            else if (sceneName.Contains("Lobby"))
+
+            if (MotherbrainGlobalVars.SelectedPlatform == MotherbrainPlatform.SteamVR)
             {
-                LogDebug("Recognized lobby in VR. Loading UI.");
-                _ = new GameObject("HouseRulesUiVr", typeof(HouseRulesUiVr));
-            }
-            else
-            {
-                if (HR.SelectedRuleset != Ruleset.None)
+                if (buildIndex == SteamVRLobbySceneIndex)
                 {
-                    LogDebug("Recognized modded game in VR. Loading UI.");
-                    _ = new GameObject("HouseRulesUiGameVr", typeof(HouseRulesUiGameVr));
+                    LogDebug("Recognized lobby in SteamVR. Loading UI.");
+                    _ = new GameObject("HouseRulesUiVr", typeof(HouseRulesUiVr));
                 }
+
+                return;
+            }
+
+            if (MotherbrainGlobalVars.SelectedPlatform == MotherbrainPlatform.Rift)
+            {
+                if (buildIndex == RiftLobbySceneIndex)
+                {
+                    LogDebug("Recognized lobby in Rift. Loading UI.");
+                    _ = new GameObject("HouseRulesUiVr", typeof(HouseRulesUiVr));
+                }
+
+                return;
+            }
+
+            // If a scene is loaded while a ruleset is selected, we must have loaded a game level.
+            if (MotherbrainGlobalVars.IsRunningOnVRPlatform && HR.SelectedRuleset != Ruleset.None)
+            {
+                LogDebug("Recognized modded game in VR. Loading UI.");
+                _ = new GameObject("HouseRulesUiGameVr", typeof(HouseRulesUiGameVr));
             }
         }
 


### PR DESCRIPTION
Issue: When changing pages in the HR UI, multiple pages are overlapping onto one another.

Root cause: The process that determines whether or not to load UIs (our `OnSceneLoaded()` hook function) is triggering the HR UI be loaded multiple times.

Solution: Our `OnSceneLoaded()` is re-written to be more explicit about how to determine when to load in the UI. It follows the same approach as https://github.com/orendain/DemeoMods/pull/549: to be very explicit about which scenes, and on which platforms, constitute being in the "lobby" where we want to UI rendered.

---

Additional background: Some time back, RG added helpers as part of their `MotherbrainGlobalVars` class, capturing the exact platform the game is being run on. This didn't exist before, and so at the time we introduced a helper (`Common.UI/Environments`) to help us determine that ourselves. Our method has become a bit flaky as the game as been ported to different platforms and seen changes in scene numbers. It is now uneeded as RG has captured that info on their end, which we can piggyback on to determine the platform and scene more precisely.

Hence the removal of some of the code in `Common.UI/Environments`.