### PR TITLE
New rule PieceMagicStatAdded

### DIFF
--- a/HouseRules.Essentials/HouseRulesEssentialsBase.cs
+++ b/HouseRules.Essentials/HouseRulesEssentialsBase.cs
@@ -91,6 +91,7 @@
             HR.Rulebook.Register(typeof(PieceAbilityListOverriddenRule));
             HR.Rulebook.Register(typeof(PieceBehavioursListOverriddenRule));
             HR.Rulebook.Register(typeof(PieceDownedCountAdjustedRule));
+            HR.Rulebook.Register(typeof(PieceMagicStatAddedRule));
             HR.Rulebook.Register(typeof(PiecePieceTypeListOverriddenRule));
             HR.Rulebook.Register(typeof(PieceUseWhenKilledOverriddenRule));
             HR.Rulebook.Register(typeof(PotionAdditionOverriddenRule));

--- a/HouseRules.Essentials/PieceMagicStatAddedRule.cs
+++ b/HouseRules.Essentials/PieceMagicStatAddedRule.cs
@@ -1,0 +1,69 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System.Collections.Generic;
+    using Boardgame.BoardEntities;
+    using DataKeys;
+    using HarmonyLib;
+    using HouseRules.Core;
+    using HouseRules.Core.Types;
+
+    public sealed class PieceMagicStatAddedRule : Rule, IConfigWritable<Dictionary<BoardPieceId, int>>, IPatchable, IMultiplayerSafe
+    {
+        public override string Description => "Some Heroes start with a magic bonus.";
+
+        protected override SyncableTrigger ModifiedSyncables => SyncableTrigger.NewPieceModified;
+
+        private static Dictionary<BoardPieceId, int> _globalAdjustments;
+        private static bool _isActivated;
+
+        public PieceMagicStatAddedRule(Dictionary<BoardPieceId, int> adjustments)
+        {
+            _adjustments = adjustments;
+        }
+
+        private readonly Dictionary<BoardPieceId, int> _adjustments;
+
+        public Dictionary<BoardPieceId, int> GetConfigObject() => _adjustments;
+
+        protected override void OnActivate(Context context)
+        {
+            _globalAdjustments = _adjustments;
+            _isActivated = true;
+        }
+
+        protected override void OnDeactivate(Context context) => _isActivated = false;
+
+        private static void Patch(Harmony harmony)
+        {
+            harmony.Patch(
+                original: AccessTools.Method(typeof(Piece), "CreatePiece"),
+                postfix: new HarmonyMethod(
+                    typeof(PieceMagicStatAddedRule),
+                    nameof(CreatePiece_Effects_Postfix)));
+        }
+
+        private static void CreatePiece_Effects_Postfix(ref Piece __result)
+        {
+            if (!_isActivated)
+            {
+                return;
+            }
+
+            if (!_globalAdjustments.ContainsKey(__result.boardPieceId))
+            {
+                return;
+            }
+
+            foreach (var replacement in _globalAdjustments)
+            {
+                if (replacement.Key == __result.boardPieceId)
+                {
+                    __result.effectSink.TryGetStatMax(Stats.Type.MagicBonus, out int myMaxMagic);
+                    __result.effectSink.TrySetStatMaxValue(Stats.Type.MagicBonus, myMaxMagic + 1);
+                    __result.effectSink.TrySetStatBaseValue(Stats.Type.MagicBonus, replacement.Value);
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/HouseRules.Essentials/PieceMagicStatAddedRule.cs
+++ b/HouseRules.Essentials/PieceMagicStatAddedRule.cs
@@ -59,7 +59,7 @@
                 if (replacement.Key == __result.boardPieceId)
                 {
                     __result.effectSink.TryGetStatMax(Stats.Type.MagicBonus, out int myMaxMagic);
-                    __result.effectSink.TrySetStatMaxValue(Stats.Type.MagicBonus, myMaxMagic + 1);
+                    __result.effectSink.TrySetStatMaxValue(Stats.Type.MagicBonus, myMaxMagic + replacement.Value);
                     __result.effectSink.TrySetStatBaseValue(Stats.Type.MagicBonus, replacement.Value);
                     return;
                 }

--- a/HouseRules.Essentials/README.md
+++ b/HouseRules.Essentials/README.md
@@ -768,6 +768,23 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
   },
   ```
 
+  #### __PieceMagicStatAdded__: Add magic bonus and max allowed magic to player ♟️BoardPiece
+  - Allows configuration of starting Magic stat and adjust max magic stat on a per-hero basis.
+  - To configure:
+    - Specify a Dictionary of [BoardPieceIds](../docs/SettingsReference.md#boardpieceids) and a number.
+
+  ###### _Example JSON config for PieceMagicStatAdded_
+
+  ```json
+  {
+    "Rule": "PieceMagicStatAdded",
+    "Config": {
+      "HeroSorcerer": "2",
+      "HeroWarlock": "1"
+    }
+  },
+```
+
 #### __PiecePieceTypeListOverridden__: Allows the list of PieceTypes for a ♟️BoardPiece to be overridden.
   - Board pieces have PieceTypes such as IgnoreWhenCharmed, Brittle, Enemy, Prop, Interactable which dictate certain behaviours.
   - With the right combination of rules, you can turn 🕷️spiderlings into thieves who steal your gold, cards, etc.


### PR DESCRIPTION
Adds points to magic stat to defined heroes and increases their max allowed magic stat by the same amount. This can't be accomplished in PieceConfigAdjusted as far as I can tell.
Example:
    {
      "Rule": "PieceMagicStatAdded",
      "Config": {
        "HeroSorcerer": 1
      }
    }