### PR TITLE
New rule AbilityTargetEffectsOverridden

### DIFF
--- a/HouseRules.Essentials/AbilityTargetEffectsOverriddenRule.cs
+++ b/HouseRules.Essentials/AbilityTargetEffectsOverriddenRule.cs
@@ -5,7 +5,7 @@
     using DataKeys;
     using HouseRules.Core.Types;
 
-    public sealed class AbilityTargetEffectsRule : Rule, IConfigWritable<Dictionary<AbilityKey, List<EffectStateType>>>, IMultiplayerSafe
+    public sealed class AbilityTargetEffectsOverriddenRule : Rule, IConfigWritable<Dictionary<AbilityKey, List<EffectStateType>>>, IMultiplayerSafe
     {
         public override string Description => "Some abilities have added secondary effects.";
 
@@ -13,10 +13,10 @@
         private Dictionary<AbilityKey, List<EffectStateType>> _originals;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AbilityTargetEffectsRule"/> class.
+        /// Initializes a new instance of the <see cref="AbilityTargetEffectsOverriddenRule"/> class.
         /// </summary>
         /// <param name="adjustments">Key-value pairs of abilityKey and List<EffectStateType>.</param>
-        public AbilityTargetEffectsRule(Dictionary<AbilityKey, List<EffectStateType>> adjustments)
+        public AbilityTargetEffectsOverriddenRule(Dictionary<AbilityKey, List<EffectStateType>> adjustments)
         {
             _adjustments = adjustments;
             _originals = new Dictionary<AbilityKey, List<EffectStateType>>();

--- a/HouseRules.Essentials/AbilityTargetEffectsRule.cs
+++ b/HouseRules.Essentials/AbilityTargetEffectsRule.cs
@@ -1,0 +1,56 @@
+﻿namespace HouseRules.Essentials.Rules
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using DataKeys;
+    using HouseRules.Core.Types;
+
+    public sealed class AbilityTargetEffectsRule : Rule, IConfigWritable<Dictionary<AbilityKey, List<EffectStateType>>>, IMultiplayerSafe
+    {
+        public override string Description => "Some abilities have added secondary effects.";
+
+        private readonly Dictionary<AbilityKey, List<EffectStateType>> _adjustments;
+        private Dictionary<AbilityKey, List<EffectStateType>> _originals;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AbilityTargetEffectsRule"/> class.
+        /// </summary>
+        /// <param name="adjustments">Key-value pairs of abilityKey and List<EffectStateType>.</param>
+        public AbilityTargetEffectsRule(Dictionary<AbilityKey, List<EffectStateType>> adjustments)
+        {
+            _adjustments = adjustments;
+            _originals = new Dictionary<AbilityKey, List<EffectStateType>>();
+        }
+
+        public Dictionary<AbilityKey, List<EffectStateType>> GetConfigObject() => _adjustments;
+
+        protected override void OnPreGameCreated(Context context)
+        {
+            _originals = ReplaceAbilities(context, _adjustments);
+        }
+
+        protected override void OnDeactivate(Context context)
+        {
+            ReplaceAbilities(context, _originals);
+        }
+
+        private static Dictionary<AbilityKey, List<EffectStateType>> ReplaceAbilities(Context context, Dictionary<AbilityKey, List<EffectStateType>> replacements)
+        {
+            var originals = new Dictionary<AbilityKey, List<EffectStateType>>();
+            foreach (var replacement in replacements)
+            {
+                var abilityPromise = context.AbilityFactory.LoadAbility(replacement.Key);
+                abilityPromise.OnLoaded(ability =>
+                {
+                    originals[replacement.Key] = ability.targetEffects.ToList();
+                    ability.targetEffects = replacement.Value.ToArray();
+                });
+            }
+
+            // Theoretically, there can be a race condition as there's no guarantee the promise above is fulfilled by
+            // the return value is used. Realistically, there's no concern since the value isn't used until after the
+            // promise has long been fulfilled.
+            return originals;
+        }
+    }
+}

--- a/HouseRules.Essentials/HouseRulesEssentialsBase.cs
+++ b/HouseRules.Essentials/HouseRulesEssentialsBase.cs
@@ -60,6 +60,7 @@
             HR.Rulebook.Register(typeof(AbilityActionCostAdjustedRule));
             HR.Rulebook.Register(typeof(AbilityRandomPieceListRule));
             HR.Rulebook.Register(typeof(AbilityStealthDamageOverriddenRule));
+            HR.Rulebook.Register(typeof(AbilityTargetEffectsRule));
             HR.Rulebook.Register(typeof(ApplyEffectOnHitAdjustedRule));
             HR.Rulebook.Register(typeof(BackstabConfigOverriddenRule));
             HR.Rulebook.Register(typeof(CourageShantyAddsHpRule));

--- a/HouseRules.Essentials/HouseRulesEssentialsBase.cs
+++ b/HouseRules.Essentials/HouseRulesEssentialsBase.cs
@@ -60,7 +60,7 @@
             HR.Rulebook.Register(typeof(AbilityActionCostAdjustedRule));
             HR.Rulebook.Register(typeof(AbilityRandomPieceListRule));
             HR.Rulebook.Register(typeof(AbilityStealthDamageOverriddenRule));
-            HR.Rulebook.Register(typeof(AbilityTargetEffectsRule));
+            HR.Rulebook.Register(typeof(AbilityTargetEffectsOverriddenRule));
             HR.Rulebook.Register(typeof(ApplyEffectOnHitAdjustedRule));
             HR.Rulebook.Register(typeof(BackstabConfigOverriddenRule));
             HR.Rulebook.Register(typeof(CourageShantyAddsHpRule));

--- a/HouseRules.Essentials/README.md
+++ b/HouseRules.Essentials/README.md
@@ -189,6 +189,23 @@ The [Settings Reference](../docs/SettingsReference.md) contains lists of all dif
   },
   ```
 
+  #### __AbilityTargetEffectsAdjusted__: Replaces the list of addition effects to the selected abilities
+  - REPLACES the list of addition effects for the selected abilities. You may manually include the original effect if desired.
+  - To configure:
+    - Specify the [AbilityKey](../docs/SettingsReference.md#abilitykeys) of the ability to modify.
+    - Specify the list of [EffectStates](../docs/SettingsReference.md#effectstatetypes) that the ability should apply.
+
+  ###### _Example JSON config for AbilityTargetEffectsAdjusted_
+
+  ```json
+  {
+    "Rule": "AbilityTargetEffectsAdjusted",
+    "Config": {
+      "Javelin": [ "Weaken1Turn" ],
+      "WarCry": [ "Panic", "Blinded" ]
+  }
+  ```
+
 #### __ApplyEffectOnHitAdjusted__: Adjusts the effect that a ♟️BoardPiece has on attackers.
   - For example, you can make Barricades inspire Panic on enemies that hit it.
   - To be useful the effect has to last at least 2 rounds.


### PR DESCRIPTION
Replaces the list of addition effects to the selected abilities. If the ability already has an effect it should be included in the list unless you don't want the original effect on the ability.

Example:
    {
      "Rule": "AbilityTargetEffectsOverridden",
        "Config": {
          "Javelin": [ "Weaken1Turn" ],
          "ExplodingGasLamp": [ "Diseased", "Stunned" ]
    }