### PR TITLE
Prevent error when compiling since today's update.

### DIFF
--- a/HouseRules.Essentials/Rules/GrappleUnhookedRule.cs
+++ b/HouseRules.Essentials/Rules/GrappleUnhookedRule.cs
@@ -55,7 +55,8 @@
                 return;
             }
 
-            Piece source = _gameContext.pieceAndTurnController.GetPiece(pieceId);
+            var playerId = _gameContext.pieceAndTurnController.GetCurrentPlayer();
+            Piece source = _gameContext.pieceAndTurnController.GetActivePieceForPlayer(playerId);
             if (source != null && source.IsPlayer() && source.boardPieceId == BoardPieceId.HeroBarbarian)
             {
                 if (source.HasEffectState(EffectStateType.HasExplodingLamp))


### PR DESCRIPTION
The Demeo update today removed GetPiece from PieceAndTurnController. Found another method to get same result.